### PR TITLE
Deepen the Schema walk into one fold behind a node-backend seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,6 +50,22 @@ _Avoid_: repeat, stay, hold.
 The declarative field→selector tree describing what to extract from a target page.
 _Avoid_: template, mapping, model.
 
+**Schema fold**:
+The single recursive interpretation of a Schema against a loaded document — container vs object-list vs leaf vs value-list, type coercion, the missing-node policy, the swallow-and-log scope. It has exactly one home (`SchemaContentParser<TNode>`); a backend never re-implements it.
+_Avoid_: walk, traversal, visitor, parser (the parser is the shell around the fold).
+
+**Node backend**:
+The per-document-shape seam the fold calls (`ISchemaBackend<TNode>`): parse a root, select-many, select-one, extract a leaf's **raw value**. HTML/CSS and JSON/JSONPath are two backends; the seam is the only place document-specific quirks live.
+_Avoid_: parser, loader, driver.
+
+**Raw value**:
+What a backend's `ExtractRaw` returns for a leaf *before* coercion — a `string` for text/markup backends, a native token for structured ones. An *untyped* leaf is this value verbatim; that single fact (not duplicated code) is the entire HTML-vs-JSON output difference.
+_Avoid_: text, content, the value.
+
+**Typed coercion**:
+The Schema→CLR conversion the fold applies when `SchemaElement.Type` is set (`Integer`→`int.Parse`, …). Shared grammar, backend-independent — never a per-backend concern.
+_Avoid_: parsing, casting, conversion (unqualified).
+
 **ParsedData**:
 The extracted record from one target page — its URL plus a JSON object.
 _Avoid_: result, item, row.
@@ -65,6 +81,7 @@ _Avoid_: output, writer, exporter.
 - A **Crawl step** maps one **Job** to one **Crawl outcome**.
 - A **Target page** outcome produces one **ParsedData**, emitted to every **Sink**.
 - A **Transit page** **advance**s the selector chain; a **Page with pagination** **retain**s it.
+- A **Schema fold** interprets a **Schema** by calling one **Node backend**; the backend yields **raw value**s, the fold applies **typed coercion**.
 
 ## Example dialogue
 
@@ -75,3 +92,5 @@ _Avoid_: output, writer, exporter.
 
 - **Selector-chain handling of pagination vs following was implicit.** In `Spider.CrawlAsync` one call site passed the dequeued chain and another the original chain, with nothing naming the difference. Resolved structurally: the **Crawl step** returns a **Crawl outcome** whose `Followed.Next` and `Paginated.Items` carry the **advance**d chain and whose `Paginated.NextPages` carries the **retain**ed chain — the two rules are now distinct named fields, not two look-alike call sites (see `docs/adr/0001-crawl-outcome-closed-sum.md`).
 - **"Page type" vs "page category".** Resolved: **page category** = Target / Transit / Pagination, derived from the selector chain. **PageType** is the load mode (Static vs Dynamic, i.e. HTTP vs Puppeteer). Distinct concepts — never conflate them.
+- **The HTML-vs-JSON untyped-leaf difference was accidental duplication; it is now a deliberate, pinned property.** An untyped leaf is the **raw value** verbatim: HTML yields a string, JSON keeps its native number/bool. This is intentional (JSON-endpoint users depend on native types) and is the *only* legitimate behavioural difference between backends — it rides on `ExtractRaw`'s return type, not copied code, and is pinned cross-backend in `SchemaFoldTests`. Do not "unify" it (see `docs/adr/0002-schema-fold-and-node-backend-seam.md`).
+- **Previously-divergent log/selector behaviour is now uniform — by design, not regression.** The missing-node and parsing-error log messages were textually different per backend, and the HTML single-value path tolerated a missing selector where the list paths did not. The fold makes all three uniform. Observable outcomes (field left empty/unset, parse not aborted) are unchanged; only the divergent log text and the single-value selector-miss mechanism were unified.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ For other ways to extend your functionality see the next section.
 | IVisitedLinkTracker | Tracker of visited links. A default implementation is an in-memory tracker. You can provide your own for Redis, MongoDB, etc. |
 | IStaticPageLoader   | Loads a page over HTTP and returns its HTML as a string                                                                       |
 | IBrowserPageLoader  | Loads a page in a headless browser (Puppeteer), runs any page actions, and returns the rendered HTML                           |
-| IContentParser      | Takes HTML and schema and returns JSON representation (JObject).                                                              |
+| IContentParser      | Takes a document + Schema and returns its JSON representation (JObject). The shipped HTML and JSON parsers are thin shells over one shared Schema fold. |
+| ISchemaBackend&lt;TNode&gt; | The per-document-shape seam the shared fold calls: parse a root, select many / one by selector, extract a leaf's raw value. A new backend (e.g. XPath, System.Text.Json) is an implementation of this, not a re-derivation of the walk. |
 | ILinkParser         | Takes HTML as a string and returns page links                                                                                 |
 | IScraperSink        | Represents a data store for writing the results of web scraping. Takes the JObject as parameter                               |
 | ICrawlStep          | The crawl-step decision: maps a Job + loaded page + Schema to a CrawlOutcome (parse the page, follow links, or paginate). Swap it to customize crawl-vs-parse behavior. |
@@ -303,6 +304,7 @@ For other ways to extend your functionality see the next section.
 * Job - a record that represents a job for the spider
 * LinkPathSelector - represents a selector for links to be crawled
 * CrawlOutcome - the closed result of a crawl step: a parsed target page, followed links, or paginated pages
+* Schema fold - the single recursive Schema interpreter (`SchemaContentParser<TNode>`); every backend reuses it instead of re-implementing the walk
 
 ## Repository structure
 

--- a/WebReaper.Tests/WebReaper.UnitTests/SchemaFoldTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/SchemaFoldTests.cs
@@ -1,0 +1,198 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json.Linq;
+using WebReaper.Core.Parser.Abstract;
+using WebReaper.Core.Parser.Concrete;
+using WebReaper.Domain.Parsing;
+
+namespace WebReaper.UnitTests;
+
+// The Schema fold, exercised directly through the seam. The legacy
+// per-backend behaviour is already pinned by ParserTests / ListParsingTests
+// / JsonParsingTests; these tests pin what the *deepening* added: one fold
+// serving every backend, the divergence/quirks being deliberate and
+// quarantined, and a brand-new backend being a tiny adapter — not a copy of
+// the walk.
+public class SchemaFoldTests
+{
+    private static AngleSharpContentParser Html() => new(NullLogger.Instance);
+    private static JsonContentParser Json() => new(NullLogger.Instance);
+
+    [Fact]
+    public async Task Same_schema_shape_folds_to_the_same_structure_on_html_and_json()
+    {
+        // Selectors are inherently backend-specific (CSS vs JSONPath); the
+        // grammar is what's shared. With typed leaves, coercion normalises
+        // both sides, so the assembled JObjects must be byte-identical.
+        const string html =
+            "<html><body><div class='post'>" +
+            "<h1 class='title'>Hello</h1><span class='views'>42</span>" +
+            "<ul><li class='tag'>a</li><li class='tag'>b</li></ul>" +
+            "</div></body></html>";
+        const string json =
+            @"{ ""post"": { ""title"": ""Hello"", ""views"": 42, ""tags"": [ ""a"", ""b"" ] } }";
+
+        var htmlResult = await Html().ParseAsync(html, new Schema
+        {
+            new Schema("post")
+            {
+                Children =
+                {
+                    new SchemaElement("title", ".title", DataType.String),
+                    new SchemaElement("views", ".views", DataType.Integer),
+                    new SchemaElement("tags", ".tag", DataType.String) { IsList = true }
+                }
+            }
+        });
+
+        var jsonResult = await Json().ParseAsync(json, new Schema
+        {
+            new Schema("post")
+            {
+                Children =
+                {
+                    new SchemaElement("title", "post.title", DataType.String),
+                    new SchemaElement("views", "post.views", DataType.Integer),
+                    new SchemaElement("tags", "post.tags[*]", DataType.String) { IsList = true }
+                }
+            }
+        });
+
+        Assert.True(JToken.DeepEquals(htmlResult, jsonResult),
+            $"html={htmlResult.ToString(Newtonsoft.Json.Formatting.None)} " +
+            $"json={jsonResult.ToString(Newtonsoft.Json.Formatting.None)}");
+    }
+
+    [Fact]
+    public async Task Untyped_leaf_divergence_is_deliberate_html_string_vs_json_native()
+    {
+        // DELIBERATE, see docs/adr/0002: an untyped leaf is the backend's
+        // raw value verbatim — HTML text is a string, a JSON number stays a
+        // number. Do not "unify" this; that would silently regress every
+        // JSON-endpoint user. This test fails loudly if someone tries.
+        var htmlList = await Html().ParseAsync(
+            "<i>1</i><i>2</i>",
+            new Schema { new SchemaElement("n", "i") { IsList = true } });
+        var jsonList = await Json().ParseAsync(
+            @"{ ""n"": [ 1, 2 ] }",
+            new Schema { new SchemaElement("n", "$.n[*]") { IsList = true } });
+
+        Assert.Equal(JTokenType.String, ((JArray)htmlList["n"]!)[0].Type);
+        Assert.Equal(JTokenType.Integer, ((JArray)jsonList["n"]!)[0].Type);
+    }
+
+    [Fact]
+    public async Task Src_to_title_rewrite_is_quarantined_in_the_html_backend()
+    {
+        var element = new SchemaElement("u", ".img", "src");
+
+        var result = await Html().ParseAsync(
+            "<img class='img' src='SRC' title='TITLE'>",
+            new Schema { element });
+
+        Assert.Equal("TITLE", result["u"]!.ToString()); // src was rewritten to title
+        Assert.Equal("title", element.Attr);            // the historical mutation, preserved
+    }
+
+    [Fact]
+    public async Task Json_backend_has_no_attr_notion_so_src_is_ignored_and_unmutated()
+    {
+        var element = new SchemaElement("u", "u", "src");
+
+        var result = await Json().ParseAsync(@"{ ""u"": ""V"" }", new Schema { element });
+
+        Assert.Equal("V", result["u"]!.ToString());
+        Assert.Equal("src", element.Attr); // quarantine boundary: no mutation on this side
+    }
+
+    [Fact]
+    public async Task Typed_coercion_is_backend_independent()
+    {
+        var html = await Html().ParseAsync(
+            "<i>7</i><b>true</b>",
+            new Schema
+            {
+                new SchemaElement("i", "i", DataType.Integer),
+                new SchemaElement("b", "b", DataType.Boolean)
+            });
+        var json = await Json().ParseAsync(
+            @"{ ""i"": 7, ""b"": true }",
+            new Schema
+            {
+                new SchemaElement("i", "$.i", DataType.Integer),
+                new SchemaElement("b", "$.b", DataType.Boolean)
+            });
+
+        Assert.True(JToken.DeepEquals(html, json));
+        Assert.Equal(7, html["i"]!.Value<int>());
+        Assert.True(html["b"]!.Value<bool>());
+    }
+
+    [Fact]
+    public async Task Missing_single_value_yields_empty_string_on_every_backend()
+    {
+        var schema = () => new Schema { new SchemaElement("x", "nope") };
+
+        var html = await Html().ParseAsync("<p>hi</p>",
+            new Schema { new SchemaElement("x", ".nope") });
+        var json = await Json().ParseAsync(@"{ ""y"": 1 }",
+            new Schema { new SchemaElement("x", "$.nope") });
+        var custom = await new SchemaContentParser<KeyValueNode>(new KeyValueBackend(), NullLogger.Instance)
+            .ParseAsync("y=1", schema());
+
+        Assert.Equal(string.Empty, html["x"]!.ToString());
+        Assert.Equal(string.Empty, json["x"]!.ToString());
+        Assert.Equal(string.Empty, custom["x"]!.ToString());
+    }
+
+    [Fact]
+    public async Task A_new_backend_is_a_tiny_adapter_reusing_the_fold()
+    {
+        // The deepening's deliverable: a document shape that is neither HTML
+        // nor JSON runs through the SAME fold (coercion, JObject assembly,
+        // missing-node policy) with a ~15-line ISchemaBackend and zero
+        // copied walk.
+        var parser = new SchemaContentParser<KeyValueNode>(new KeyValueBackend(), NullLogger.Instance);
+
+        var result = await parser.ParseAsync(
+            "title=Hello\nviews=42\ntag=a\ntag=b",
+            new Schema
+            {
+                new SchemaElement("title", "title", DataType.String),
+                new SchemaElement("views", "views", DataType.Integer),
+                new SchemaElement("tags", "tag", DataType.String) { IsList = true }
+            });
+
+        Assert.Equal("Hello", result["title"]!.ToString());
+        Assert.Equal(42, result["views"]!.Value<int>());
+        Assert.Equal(new[] { "a", "b" }, ((JArray)result["tags"]!).Select(t => t.ToString()));
+    }
+
+    // --- a deliberately foreign document model: line-based "key=value" ---
+
+    private sealed class KeyValueNode
+    {
+        public ILookup<string, string>? Root { get; init; }
+        public string? Value { get; init; }
+    }
+
+    private sealed class KeyValueBackend : ISchemaBackend<KeyValueNode>
+    {
+        public Task<KeyValueNode> RootAsync(string content)
+        {
+            var root = content
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(line => line.Split('=', 2))
+                .ToLookup(p => p[0], p => p[1]);
+
+            return Task.FromResult(new KeyValueNode { Root = root });
+        }
+
+        public IEnumerable<KeyValueNode> SelectMany(KeyValueNode scope, string selector)
+            => scope.Root![selector].Select(v => new KeyValueNode { Value = v });
+
+        public KeyValueNode? SelectOne(KeyValueNode scope, string selector)
+            => scope.Root![selector].FirstOrDefault() is { } v ? new KeyValueNode { Value = v } : null;
+
+        public object? ExtractRaw(KeyValueNode node, SchemaElement element) => node.Value;
+    }
+}

--- a/WebReaper/API.xml
+++ b/WebReaper/API.xml
@@ -166,15 +166,98 @@
                 Logger
             </summary>
         </member>
+        <member name="T:WebReaper.Core.Parser.Abstract.ISchemaBackend`1">
+            <summary>
+            One document shape = one backend. Supplies only the four
+            document-primitive operations the <see cref="T:WebReaper.Core.Parser.Concrete.SchemaContentParser`1"/>
+            fold needs; it does NOT know the <see cref="T:WebReaper.Domain.Parsing.Schema"/> grammar
+            (container / object-list / leaf / value-list), type coercion, the
+            missing-node policy, or the swallow-and-log scope — those live once,
+            in the fold. A new backend (HtmlAgilityPack, System.Text.Json, …) is
+            an implementation of this seam, not a re-derivation of the walk.
+            </summary>
+            <typeparam name="TNode">
+            The backend's opaque scope cursor — an AngleSharp node, a
+            <c>JToken</c>, etc. The fold never names it; it only threads it back
+            through these methods.
+            </typeparam>
+        </member>
+        <member name="M:WebReaper.Core.Parser.Abstract.ISchemaBackend`1.RootAsync(System.String)">
+            <summary>Parse a raw document string into its root scope.</summary>
+        </member>
+        <member name="M:WebReaper.Core.Parser.Abstract.ISchemaBackend`1.SelectMany(`0,System.String)">
+            <summary>Every node under <paramref name="scope"/> matching the selector (list paths).</summary>
+        </member>
+        <member name="M:WebReaper.Core.Parser.Abstract.ISchemaBackend`1.SelectOne(`0,System.String)">
+            <summary>The first node under <paramref name="scope"/> matching the selector, or null if none.</summary>
+        </member>
+        <member name="M:WebReaper.Core.Parser.Abstract.ISchemaBackend`1.ExtractRaw(`0,WebReaper.Domain.Parsing.SchemaElement)">
+            <summary>
+            The raw leaf value of <paramref name="node"/> for <paramref name="element"/>:
+            a <see cref="T:System.String"/> for text/markup backends, a native value for
+            structured ones. The fold applies any <see cref="P:WebReaper.Domain.Parsing.SchemaElement.Type"/>
+            coercion; an untyped leaf is this value verbatim. Backend-local quirks
+            (e.g. the AngleSharp <c>src</c>→<c>title</c> rewrite) belong here and
+            nowhere else.
+            </summary>
+        </member>
+        <member name="T:WebReaper.Core.Parser.Concrete.AngleSharpContentParser">
+            <summary>
+            HTML content parser: the shared <see cref="T:WebReaper.Core.Parser.Concrete.SchemaContentParser`1"/>
+            fold over the <see cref="T:WebReaper.Core.Parser.Concrete.AngleSharpSchemaBackend"/>. Kept as a named
+            type with its original <c>(ILogger)</c> constructor so it stays the
+            default and a drop-in for existing callers.
+            </summary>
+        </member>
+        <member name="T:WebReaper.Core.Parser.Concrete.AngleSharpSchemaBackend">
+            <summary>
+            HTML backend for <see cref="T:WebReaper.Core.Parser.Concrete.SchemaContentParser`1"/>: AngleSharp
+            DOM, CSS selectors. The scope cursor is <see cref="T:AngleSharp.Dom.IParentNode"/>
+            (the document at the top, a matched element when recursing). This is
+            the ONLY place the <c>src</c>→<c>title</c> rewrite and the
+            attr/markup/text rules live — the shared fold never sees them.
+            </summary>
+        </member>
         <member name="T:WebReaper.Core.Parser.Concrete.JsonContentParser">
             <summary>
             Parses a JSON response instead of HTML (issue #27 — scraping JSON
-            endpoints such as the WordPress REST API). Each
-            <see cref="P:WebReaper.Domain.Parsing.SchemaElement.Selector"/> is a JSONPath expression
-            evaluated with Newtonsoft's <c>SelectToken</c>/<c>SelectTokens</c>,
-            relative to the current scope. <see cref="P:WebReaper.Domain.Parsing.SchemaElement.IsList"/>
-            works the same way it does for the HTML parser.
+            endpoints such as the WordPress REST API). The shared
+            <see cref="T:WebReaper.Core.Parser.Concrete.SchemaContentParser`1"/> fold over the
+            <see cref="T:WebReaper.Core.Parser.Concrete.JsonSchemaBackend"/>: each <see cref="P:WebReaper.Domain.Parsing.SchemaElement.Selector"/>
+            is a JSONPath expression and <see cref="P:WebReaper.Domain.Parsing.SchemaElement.IsList"/> works
+            exactly as it does for the HTML parser. Kept as a named type with its
+            original <c>(ILogger)</c> constructor so <c>WithJsonContentParser</c>
+            and existing callers are unaffected.
             </summary>
+        </member>
+        <member name="T:WebReaper.Core.Parser.Concrete.JsonSchemaBackend">
+            <summary>
+            JSON backend for <see cref="T:WebReaper.Core.Parser.Concrete.SchemaContentParser`1"/> (issue #27 —
+            scraping JSON endpoints such as the WordPress REST API). The scope
+            cursor is a <see cref="T:Newtonsoft.Json.Linq.JToken"/> and each
+            <see cref="P:WebReaper.Domain.Parsing.SchemaElement.Selector"/> is a JSONPath expression.
+            <see cref="M:WebReaper.Core.Parser.Concrete.JsonSchemaBackend.ExtractRaw(Newtonsoft.Json.Linq.JToken,WebReaper.Domain.Parsing.SchemaElement)"/> returns the native token, so an untyped leaf
+            keeps its JSON type (a number stays a number) — the structured-side
+            of the divergence the shared fold passes straight through.
+            </summary>
+        </member>
+        <member name="T:WebReaper.Core.Parser.Concrete.SchemaContentParser`1">
+            <summary>
+            The single recursive <see cref="T:WebReaper.Domain.Parsing.Schema"/> fold, shared by every
+            backend. It owns the grammar the parsers used to each re-implement:
+            the container / object-list / leaf / value-list branching, the
+            <see cref="P:WebReaper.Domain.Parsing.SchemaElement.Type"/> coercion, the missing-node →
+            log → empty-string policy, and the swallow-and-log scope (only a
+            leaf assignment is guarded; a container whose list selector is
+            missing still throws, exactly as before). Everything document-shaped
+            is delegated to <see cref="T:WebReaper.Core.Parser.Abstract.ISchemaBackend`1"/>.
+            </summary>
+            <remarks>
+            Public and generic on purpose: a new backend is
+            <c>new SchemaContentParser&lt;TNode&gt;(myBackend, logger)</c> passed
+            to <c>WithContentParser</c>, reusing this proven fold rather than
+            copying it. See docs/adr/0002.
+            </remarks>
         </member>
         <member name="M:WebReaper.Core.Scheduler.Abstract.IScheduler.Complete">
             <summary>

--- a/WebReaper/Builders/SpiderBuilder.cs
+++ b/WebReaper/Builders/SpiderBuilder.cs
@@ -62,9 +62,12 @@ public class SpiderBuilder
 
     /// <summary>
     /// Parse responses as JSON instead of HTML (issue #27). Schema
-    /// selectors become JSONPath expressions. For a custom HTML parser
-    /// (e.g. HtmlAgilityPack), implement <see cref="IContentParser"/>
-    /// and pass it to <see cref="WithContentParser"/>.
+    /// selectors become JSONPath expressions. For a different document
+    /// shape (e.g. HtmlAgilityPack, XPath), implement
+    /// <see cref="Core.Parser.Abstract.ISchemaBackend{TNode}"/> and pass
+    /// <c>new SchemaContentParser&lt;TNode&gt;(backend, logger)</c> to
+    /// <see cref="WithContentParser"/> — it reuses the shared Schema fold
+    /// rather than re-implementing the walk.
     /// </summary>
     public SpiderBuilder WithJsonContentParser()
     {

--- a/WebReaper/Core/Parser/Abstract/ISchemaBackend.cs
+++ b/WebReaper/Core/Parser/Abstract/ISchemaBackend.cs
@@ -1,0 +1,39 @@
+using WebReaper.Domain.Parsing;
+
+namespace WebReaper.Core.Parser.Abstract;
+
+/// <summary>
+/// One document shape = one backend. Supplies only the four
+/// document-primitive operations the <see cref="Concrete.SchemaContentParser{TNode}"/>
+/// fold needs; it does NOT know the <see cref="Schema"/> grammar
+/// (container / object-list / leaf / value-list), type coercion, the
+/// missing-node policy, or the swallow-and-log scope — those live once,
+/// in the fold. A new backend (HtmlAgilityPack, System.Text.Json, …) is
+/// an implementation of this seam, not a re-derivation of the walk.
+/// </summary>
+/// <typeparam name="TNode">
+/// The backend's opaque scope cursor — an AngleSharp node, a
+/// <c>JToken</c>, etc. The fold never names it; it only threads it back
+/// through these methods.
+/// </typeparam>
+public interface ISchemaBackend<TNode> where TNode : class
+{
+    /// <summary>Parse a raw document string into its root scope.</summary>
+    Task<TNode> RootAsync(string content);
+
+    /// <summary>Every node under <paramref name="scope"/> matching the selector (list paths).</summary>
+    IEnumerable<TNode> SelectMany(TNode scope, string selector);
+
+    /// <summary>The first node under <paramref name="scope"/> matching the selector, or null if none.</summary>
+    TNode? SelectOne(TNode scope, string selector);
+
+    /// <summary>
+    /// The raw leaf value of <paramref name="node"/> for <paramref name="element"/>:
+    /// a <see cref="string"/> for text/markup backends, a native value for
+    /// structured ones. The fold applies any <see cref="SchemaElement.Type"/>
+    /// coercion; an untyped leaf is this value verbatim. Backend-local quirks
+    /// (e.g. the AngleSharp <c>src</c>→<c>title</c> rewrite) belong here and
+    /// nowhere else.
+    /// </summary>
+    object? ExtractRaw(TNode node, SchemaElement element);
+}

--- a/WebReaper/Core/Parser/Concrete/AngleSharpContentParser.cs
+++ b/WebReaper/Core/Parser/Concrete/AngleSharpContentParser.cs
@@ -1,5 +1,3 @@
-using AngleSharp;
-using AngleSharp.Dom;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using WebReaper.Core.Parser.Abstract;
@@ -7,169 +5,18 @@ using WebReaper.Domain.Parsing;
 
 namespace WebReaper.Core.Parser.Concrete;
 
+/// <summary>
+/// HTML content parser: the shared <see cref="SchemaContentParser{TNode}"/>
+/// fold over the <see cref="AngleSharpSchemaBackend"/>. Kept as a named
+/// type with its original <c>(ILogger)</c> constructor so it stays the
+/// default and a drop-in for existing callers.
+/// </summary>
 public class AngleSharpContentParser : IContentParser
 {
+    private readonly SchemaContentParser<AngleSharp.Dom.IParentNode> _inner;
+
     public AngleSharpContentParser(ILogger logger)
-    {
-        Logger = logger;
-    }
+        => _inner = new SchemaContentParser<AngleSharp.Dom.IParentNode>(new AngleSharpSchemaBackend(), logger);
 
-    private ILogger Logger { get; }
-
-    public async Task<JObject> ParseAsync(string html, Schema schema) // TODO: consider passing url or headers... or http response
-    {
-        ArgumentNullException.ThrowIfNull(schema);
-
-        var config = Configuration.Default.WithDefaultLoader();
-
-        var context = BrowsingContext.New(config);
-
-        // TODO temp fix
-        using var doc =
-            await context.OpenAsync(resp => resp.Header("Content-Type", "text/html; charset=utf-8").Content(html));
-
-        return GetJson(doc, schema);
-    }
-
-    private JObject GetJson(IDocument doc, Schema schema)
-    {
-        var output = new JObject();
-
-        foreach (var item in schema.Children) FillOutput(output, doc, item);
-
-        return output;
-    }
-
-    // scope is the node selectors are evaluated against: the document at
-    // the top level, or a single list-item element when recursing into a
-    // list of objects (issue #28).
-    private void FillOutput(JObject result, IParentNode scope, SchemaElement item)
-    {
-        if (item.Field is null) throw new InvalidOperationException("Schema is invalid");
-
-        if (item is Schema container)
-        {
-            if (container.IsList)
-            {
-                result[item.Field] = GetObjectList(scope, container);
-            }
-            else
-            {
-                var obj = new JObject();
-
-                foreach (var el in container.Children)
-                {
-                    FillOutput(obj, scope, el);
-                }
-
-                result[item.Field] = obj;
-            }
-
-            return;
-        }
-
-        try
-        {
-            result[item.Field] = item.IsList ? GetValueList(scope, item) : GetSingleValue(scope, item);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error during parsing phase");
-        }
-    }
-
-    private JArray GetObjectList(IParentNode scope, Schema container)
-    {
-        RequireSelector(container);
-
-        var array = new JArray();
-
-        foreach (var element in scope.QuerySelectorAll(container.Selector))
-        {
-            var obj = new JObject();
-
-            foreach (var child in container.Children)
-            {
-                FillOutput(obj, element, child);
-            }
-
-            array.Add(obj);
-        }
-
-        return array;
-    }
-
-    private JArray GetValueList(IParentNode scope, SchemaElement item)
-    {
-        RequireSelector(item);
-
-        var array = new JArray();
-
-        foreach (var node in scope.QuerySelectorAll(item.Selector))
-        {
-            var raw = ExtractValue(node, item);
-            array.Add(item.Type is null ? raw : GetTypedValue(item, raw));
-        }
-
-        return array;
-    }
-
-    private JToken GetSingleValue(IParentNode scope, SchemaElement item)
-    {
-        var node = scope.QuerySelector(item.Selector);
-
-        if (node is null)
-        {
-            Logger.LogError(
-                "Cannot find element by selector {selector}. Corresponding field will be empty in the result",
-                item.Selector);
-
-            return string.Empty;
-        }
-
-        var data = ExtractValue(node, item);
-
-        return item.Type is null ? data : GetTypedValue(item, data);
-    }
-
-    private static void RequireSelector(SchemaElement item)
-    {
-        if (string.IsNullOrEmpty(item.Selector))
-        {
-            throw new InvalidOperationException(
-                $"Schema element '{item.Field}' has IsList = true but no selector.");
-        }
-    }
-
-    private JToken GetTypedValue(SchemaElement item, string data) => item.Type switch
-    {
-        DataType.Integer => int.Parse(data),
-        DataType.Boolean => bool.Parse(data),
-        DataType.DataTime => DateTime.Parse(data),
-        DataType.String => data,
-        DataType.Float => float.Parse(data),
-        _ => data
-    };
-
-    private static string ExtractValue(IElement node, SchemaElement el)
-    {
-        string? content;
-
-        if (el.Attr is not null)
-        {
-            if (el.Attr == "src") el.Attr = "title";
-
-            content = node.GetAttribute(el.Attr);
-        }
-        else if (el.GetHtml == false)
-        {
-            content = node.Text();
-        }
-        else
-        {
-            content = node.InnerHtml;
-        }
-
-        return content ?? string.Empty;
-    }
+    public Task<JObject> ParseAsync(string html, Schema? schema) => _inner.ParseAsync(html, schema);
 }

--- a/WebReaper/Core/Parser/Concrete/AngleSharpSchemaBackend.cs
+++ b/WebReaper/Core/Parser/Concrete/AngleSharpSchemaBackend.cs
@@ -1,0 +1,56 @@
+using AngleSharp;
+using AngleSharp.Dom;
+using WebReaper.Core.Parser.Abstract;
+using WebReaper.Domain.Parsing;
+
+namespace WebReaper.Core.Parser.Concrete;
+
+/// <summary>
+/// HTML backend for <see cref="SchemaContentParser{TNode}"/>: AngleSharp
+/// DOM, CSS selectors. The scope cursor is <see cref="IParentNode"/>
+/// (the document at the top, a matched element when recursing). This is
+/// the ONLY place the <c>src</c>→<c>title</c> rewrite and the
+/// attr/markup/text rules live — the shared fold never sees them.
+/// </summary>
+internal sealed class AngleSharpSchemaBackend : ISchemaBackend<IParentNode>
+{
+    public async Task<IParentNode> RootAsync(string content)
+    {
+        var config = Configuration.Default.WithDefaultLoader();
+        var context = BrowsingContext.New(config);
+
+        // TODO temp fix
+        return await context.OpenAsync(resp =>
+            resp.Header("Content-Type", "text/html; charset=utf-8").Content(content));
+    }
+
+    public IEnumerable<IParentNode> SelectMany(IParentNode scope, string selector)
+        => scope.QuerySelectorAll(selector);
+
+    public IParentNode? SelectOne(IParentNode scope, string selector)
+        => scope.QuerySelector(selector);
+
+    public object? ExtractRaw(IParentNode node, SchemaElement element)
+    {
+        var el = (IElement)node;
+
+        string? content;
+
+        if (element.Attr is not null)
+        {
+            if (element.Attr == "src") element.Attr = "title";
+
+            content = el.GetAttribute(element.Attr);
+        }
+        else if (element.GetHtml == false)
+        {
+            content = el.Text();
+        }
+        else
+        {
+            content = el.InnerHtml;
+        }
+
+        return content ?? string.Empty;
+    }
+}

--- a/WebReaper/Core/Parser/Concrete/JsonContentParser.cs
+++ b/WebReaper/Core/Parser/Concrete/JsonContentParser.cs
@@ -7,125 +7,20 @@ namespace WebReaper.Core.Parser.Concrete;
 
 /// <summary>
 /// Parses a JSON response instead of HTML (issue #27 — scraping JSON
-/// endpoints such as the WordPress REST API). Each
-/// <see cref="SchemaElement.Selector"/> is a JSONPath expression
-/// evaluated with Newtonsoft's <c>SelectToken</c>/<c>SelectTokens</c>,
-/// relative to the current scope. <see cref="SchemaElement.IsList"/>
-/// works the same way it does for the HTML parser.
+/// endpoints such as the WordPress REST API). The shared
+/// <see cref="SchemaContentParser{TNode}"/> fold over the
+/// <see cref="JsonSchemaBackend"/>: each <see cref="SchemaElement.Selector"/>
+/// is a JSONPath expression and <see cref="SchemaElement.IsList"/> works
+/// exactly as it does for the HTML parser. Kept as a named type with its
+/// original <c>(ILogger)</c> constructor so <c>WithJsonContentParser</c>
+/// and existing callers are unaffected.
 /// </summary>
 public class JsonContentParser : IContentParser
 {
-    public JsonContentParser(ILogger logger) => Logger = logger;
+    private readonly SchemaContentParser<JToken> _inner;
 
-    private ILogger Logger { get; }
+    public JsonContentParser(ILogger logger)
+        => _inner = new SchemaContentParser<JToken>(new JsonSchemaBackend(), logger);
 
-    public Task<JObject> ParseAsync(string json, Schema schema)
-    {
-        ArgumentNullException.ThrowIfNull(schema);
-
-        var root = JToken.Parse(json);
-        var output = new JObject();
-
-        foreach (var item in schema.Children)
-        {
-            FillOutput(output, root, item);
-        }
-
-        return Task.FromResult(output);
-    }
-
-    private void FillOutput(JObject result, JToken scope, SchemaElement item)
-    {
-        if (item.Field is null) throw new InvalidOperationException("Schema is invalid");
-
-        if (item is Schema container)
-        {
-            if (container.IsList)
-            {
-                var array = new JArray();
-
-                foreach (var token in SelectMany(scope, container))
-                {
-                    var obj = new JObject();
-                    foreach (var child in container.Children)
-                    {
-                        FillOutput(obj, token, child);
-                    }
-                    array.Add(obj);
-                }
-
-                result[item.Field] = array;
-            }
-            else
-            {
-                var obj = new JObject();
-                foreach (var child in container.Children)
-                {
-                    FillOutput(obj, scope, child);
-                }
-                result[item.Field] = obj;
-            }
-
-            return;
-        }
-
-        try
-        {
-            if (item.IsList)
-            {
-                var array = new JArray();
-                foreach (var token in SelectMany(scope, item))
-                {
-                    array.Add(Convert(item, token));
-                }
-                result[item.Field] = array;
-            }
-            else
-            {
-                var token = scope.SelectToken(RequireSelector(item));
-
-                if (token is null)
-                {
-                    Logger.LogError(
-                        "JSONPath {selector} matched nothing. Field {field} will be empty",
-                        item.Selector, item.Field);
-                    result[item.Field] = string.Empty;
-                    return;
-                }
-
-                result[item.Field] = Convert(item, token);
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error during JSON parsing phase");
-        }
-    }
-
-    private static IEnumerable<JToken> SelectMany(JToken scope, SchemaElement item)
-        => scope.SelectTokens(RequireSelector(item));
-
-    private static string RequireSelector(SchemaElement item)
-    {
-        if (string.IsNullOrEmpty(item.Selector))
-        {
-            throw new InvalidOperationException(
-                $"Schema element '{item.Field}' has no JSONPath selector.");
-        }
-
-        return item.Selector;
-    }
-
-    // With an explicit Type, coerce via string (consistent with the HTML
-    // parser). Otherwise keep the native JSON value (number stays number,
-    // bool stays bool) instead of stringifying it.
-    private JToken Convert(SchemaElement item, JToken token) => item.Type switch
-    {
-        DataType.Integer => int.Parse(token.ToString()),
-        DataType.Boolean => bool.Parse(token.ToString()),
-        DataType.DataTime => DateTime.Parse(token.ToString()),
-        DataType.Float => float.Parse(token.ToString()),
-        DataType.String => token.ToString(),
-        _ => token.DeepClone()
-    };
+    public Task<JObject> ParseAsync(string json, Schema? schema) => _inner.ParseAsync(json, schema);
 }

--- a/WebReaper/Core/Parser/Concrete/JsonSchemaBackend.cs
+++ b/WebReaper/Core/Parser/Concrete/JsonSchemaBackend.cs
@@ -1,0 +1,29 @@
+using Newtonsoft.Json.Linq;
+using WebReaper.Core.Parser.Abstract;
+using WebReaper.Domain.Parsing;
+
+namespace WebReaper.Core.Parser.Concrete;
+
+/// <summary>
+/// JSON backend for <see cref="SchemaContentParser{TNode}"/> (issue #27 —
+/// scraping JSON endpoints such as the WordPress REST API). The scope
+/// cursor is a <see cref="JToken"/> and each
+/// <see cref="SchemaElement.Selector"/> is a JSONPath expression.
+/// <see cref="ExtractRaw"/> returns the native token, so an untyped leaf
+/// keeps its JSON type (a number stays a number) — the structured-side
+/// of the divergence the shared fold passes straight through.
+/// </summary>
+internal sealed class JsonSchemaBackend : ISchemaBackend<JToken>
+{
+    public Task<JToken> RootAsync(string content) => Task.FromResult(JToken.Parse(content));
+
+    public IEnumerable<JToken> SelectMany(JToken scope, string selector)
+        => scope.SelectTokens(selector);
+
+    public JToken? SelectOne(JToken scope, string selector)
+        => scope.SelectToken(selector);
+
+    // JSON has no attribute / markup notion; the native token is the raw
+    // value (DeepClone so the result is detached from the parsed tree).
+    public object? ExtractRaw(JToken node, SchemaElement element) => node.DeepClone();
+}

--- a/WebReaper/Core/Parser/Concrete/SchemaContentParser.cs
+++ b/WebReaper/Core/Parser/Concrete/SchemaContentParser.cs
@@ -1,0 +1,167 @@
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using WebReaper.Core.Parser.Abstract;
+using WebReaper.Domain.Parsing;
+
+namespace WebReaper.Core.Parser.Concrete;
+
+/// <summary>
+/// The single recursive <see cref="Schema"/> fold, shared by every
+/// backend. It owns the grammar the parsers used to each re-implement:
+/// the container / object-list / leaf / value-list branching, the
+/// <see cref="SchemaElement.Type"/> coercion, the missing-node →
+/// log → empty-string policy, and the swallow-and-log scope (only a
+/// leaf assignment is guarded; a container whose list selector is
+/// missing still throws, exactly as before). Everything document-shaped
+/// is delegated to <see cref="ISchemaBackend{TNode}"/>.
+/// </summary>
+/// <remarks>
+/// Public and generic on purpose: a new backend is
+/// <c>new SchemaContentParser&lt;TNode&gt;(myBackend, logger)</c> passed
+/// to <c>WithContentParser</c>, reusing this proven fold rather than
+/// copying it. See docs/adr/0002.
+/// </remarks>
+public class SchemaContentParser<TNode> : IContentParser where TNode : class
+{
+    private readonly ISchemaBackend<TNode> _backend;
+    private readonly ILogger _logger;
+
+    public SchemaContentParser(ISchemaBackend<TNode> backend, ILogger logger)
+    {
+        _backend = backend;
+        _logger = logger;
+    }
+
+    public async Task<JObject> ParseAsync(string content, Schema? schema)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+
+        var root = await _backend.RootAsync(content);
+
+        try
+        {
+            var output = new JObject();
+
+            foreach (var item in schema.Children) FillOutput(output, root, item);
+
+            return output;
+        }
+        finally
+        {
+            // AngleSharp's IDocument is IDisposable and must outlive the
+            // fold; a JToken root is not. Mirrors the old `using var doc`.
+            (root as IDisposable)?.Dispose();
+        }
+    }
+
+    // scope is the node selectors are evaluated against: the root at the
+    // top level, or a single list-item node when recursing into a list of
+    // objects (issue #28).
+    private void FillOutput(JObject result, TNode scope, SchemaElement item)
+    {
+        if (item.Field is null) throw new InvalidOperationException("Schema is invalid");
+
+        if (item is Schema container)
+        {
+            // Container branch is intentionally NOT guarded: an object-list
+            // with no selector throws and aborts the parse, as it always has.
+            if (container.IsList)
+            {
+                result[item.Field] = GetObjectList(scope, container);
+            }
+            else
+            {
+                var obj = new JObject();
+
+                foreach (var child in container.Children) FillOutput(obj, scope, child);
+
+                result[item.Field] = obj;
+            }
+
+            return;
+        }
+
+        try
+        {
+            result[item.Field] = item.IsList ? GetValueList(scope, item) : GetSingleValue(scope, item);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during parsing phase");
+        }
+    }
+
+    private JArray GetObjectList(TNode scope, Schema container)
+    {
+        var selector = RequireSelector(container);
+
+        var array = new JArray();
+
+        foreach (var element in _backend.SelectMany(scope, selector))
+        {
+            var obj = new JObject();
+
+            foreach (var child in container.Children) FillOutput(obj, element, child);
+
+            array.Add(obj);
+        }
+
+        return array;
+    }
+
+    private JArray GetValueList(TNode scope, SchemaElement item)
+    {
+        var selector = RequireSelector(item);
+
+        var array = new JArray();
+
+        foreach (var node in _backend.SelectMany(scope, selector))
+        {
+            array.Add(Coerce(item.Type, _backend.ExtractRaw(node, item)));
+        }
+
+        return array;
+    }
+
+    private JToken GetSingleValue(TNode scope, SchemaElement item)
+    {
+        var node = _backend.SelectOne(scope, RequireSelector(item));
+
+        if (node is null)
+        {
+            _logger.LogError(
+                "Selector {selector} matched nothing; field {field} will be empty",
+                item.Selector, item.Field);
+
+            return string.Empty;
+        }
+
+        return Coerce(item.Type, _backend.ExtractRaw(node, item));
+    }
+
+    private static string RequireSelector(SchemaElement item)
+    {
+        if (string.IsNullOrEmpty(item.Selector))
+        {
+            throw new InvalidOperationException(
+                $"Schema element '{item.Field}' has no selector.");
+        }
+
+        return item.Selector;
+    }
+
+    // The typed switch was byte-for-byte identical across both old parsers
+    // once fed a string, so it is shared grammar here. An untyped leaf is
+    // the backend's raw value verbatim: a native JToken passes through
+    // (JSON keeps number/bool), anything else is wrapped (HTML stays a
+    // string). That one line is the whole HTML-vs-JSON divergence.
+    private static JToken Coerce(DataType? type, object? raw) => type switch
+    {
+        DataType.Integer => int.Parse(raw?.ToString() ?? string.Empty),
+        DataType.Float => float.Parse(raw?.ToString() ?? string.Empty),
+        DataType.Boolean => bool.Parse(raw?.ToString() ?? string.Empty),
+        DataType.DataTime => DateTime.Parse(raw?.ToString() ?? string.Empty),
+        DataType.String => raw?.ToString() ?? string.Empty,
+        _ => raw is JToken token ? token : JToken.FromObject(raw ?? string.Empty)
+    };
+}

--- a/docs/adr/0002-schema-fold-and-node-backend-seam.md
+++ b/docs/adr/0002-schema-fold-and-node-backend-seam.md
@@ -1,0 +1,75 @@
+# The Schema fold has one home; backends supply only document primitives
+
+The recursive walk over a `Schema` tree — container vs object-list vs leaf vs
+value-list, type coercion, the missing-node policy, the swallow-and-log scope —
+lived **twice**: once in `AngleSharpContentParser` (HTML/CSS) and once in
+`JsonContentParser` (JSON/JSONPath, shipped a week earlier for issue #27 by
+re-deriving the same ~130 lines). `Schema`/`SchemaElement` carried no behaviour,
+so every backend re-implemented the grammar. The duplication had already
+drifted: a `src`→`title` mutation and a string-vs-native untyped result existed
+in only one backend.
+
+The fold now has exactly one home: `SchemaContentParser<TNode>` (a public deep
+module implementing the unchanged `IContentParser`). A backend supplies only
+four document-shaped primitives through a narrow public seam
+`ISchemaBackend<TNode>`: `RootAsync`, `SelectMany`, `SelectOne`, `ExtractRaw`.
+AngleSharp and JSON become ~25-line internal adapters. `AngleSharpContentParser`
+/ `JsonContentParser` keep their exact `(ILogger)` constructors as thin shells.
+
+Why the fold lives in `Core.Parser`, not on `Schema` in `Domain`: ADR 0001 set
+the precedent that the *interpreter* lives in Core (`CrawlStep`) while the
+domain type stays data (`Job`). Core already references AngleSharp, Newtonsoft
+and `ILogger`, so the Core-placed fold emits `JObject` directly and logs
+directly — **no new dependency anywhere**. Putting the fold on `Schema` would
+have forced a parallel `ParseResult` union plus an `ISchemaLog` indirection into
+Domain purely to keep it serializer-free; that ceremony is an artifact of
+fighting the ADR-0001 precedent, not value.
+
+The genuine seam is *what a leaf's raw value is*, not *how it is coerced*. The
+typed-coercion switch (`DataType.Integer` → `int.Parse`, …) was byte-for-byte
+identical across both backends once fed a string; it is now shared grammar in
+the fold. The only real difference — AngleSharp's raw value is a `string`,
+JSON's is a native `JToken` — rides entirely on `ExtractRaw`'s return type, so
+the historical untyped divergence collapses to a one-line passthrough and is
+preserved exactly (pinned by `ListParsingTests` vs `JsonParsingTests`, and by a
+new explicit cross-backend test). The `src`→`title` mutation is quarantined
+inside `AngleSharpSchemaBackend.ExtractRaw`, unreachable from the shared fold
+and from any future backend.
+
+`ILinkParser` is deliberately **not** expressed through `ISchemaBackend`. It has
+no Schema, no tree, no recursion, and resolves hrefs against a base URL — a
+single-adapter seam with a fake node type. Both independent designs reached this
+conclusion; consistent with ADR 0001's rejection of indirection without
+variation.
+
+Intended, documented behaviour unifications (previously divergent by accident,
+now uniform — see CONTEXT.md "Flagged ambiguities"): the missing-node log
+message, the parsing-error log message, and the single-value path now requiring
+a selector the same way the list paths always did. Observable outcomes (field
+left empty / unset, parse not crashed) are unchanged; only the divergent log
+text and the single-value selector-miss *mechanism* are made uniform.
+
+Public surface is **additive** (`ISchemaBackend<TNode>`,
+`SchemaContentParser<TNode>` in `WebReaper.Core.Parser`); fully
+source-compatible. A new backend is now a ~25-line adapter reused against the
+proven fold — that reach is the deepening's deliverable, so the seam is public,
+not internal. Minor SemVer, in contrast to ADR 0001's major.
+
+## Considered options
+
+- **One Core fold + narrow public node-backend seam (chosen).** Typed coercion
+  is shared grammar; raw-value shape is the per-backend thing. Total
+  de-duplication including the coercion switch; no new dependency; quirks
+  quarantined at `ExtractRaw`; the divergence becomes a typed property, not
+  copied code.
+- **Node-navigator port, everything internal (rejected).** Same shape but the
+  seam stays `internal` and each adapter keeps its own copy of the
+  typed-coercion switch. Leaves the real duplication (the switch) in place and
+  delivers no reuse to consumers — a deepening only we benefit from.
+- **De-anemic `Schema`: the fold on/with the Domain type (rejected).** The
+  honest antithesis, but to keep Domain serializer-free it needs a parallel
+  `ParseResult` union + `ISchemaLog` + a `ParseResult`→`JObject` mapper —
+  surface and a translation pass that exist only to dodge a dependency Core
+  already has. Contradicts the just-merged ADR-0001 placement precedent.
+- **Fold `ILinkParser` into the same seam (rejected).** One real adapter, a
+  fake node type, no tree to fold; indirection without variation.


### PR DESCRIPTION
## What

The recursive `Schema` interpretation lived **twice** — `AngleSharpContentParser` (HTML/CSS) and `JsonContentParser` (JSON/JSONPath, added a week earlier for #27 by re-deriving the same ~130 lines). `Schema`/`SchemaElement` carried no behaviour, so every backend re-implemented the grammar — and it had **already drifted**: a `src`→`title` mutation and a string-vs-native untyped result existed in only one backend.

The fold now has one home: **`SchemaContentParser<TNode>`** — a public deep module implementing the unchanged `IContentParser`. A backend supplies only four document primitives through a narrow public seam **`ISchemaBackend<TNode>`** (`RootAsync` / `SelectMany` / `SelectOne` / `ExtractRaw`). AngleSharp and JSON become ~25-line internal adapters; `AngleSharpContentParser` / `JsonContentParser` keep their exact `(ILogger)` constructors as thin shells.

The genuine seam is **what a leaf's raw value *is*, not how it's coerced**: the typed-coercion switch was byte-identical across both backends once fed a string, so it is now shared grammar in the fold; the only real difference (AngleSharp raw = `string`, JSON raw = native `JToken`) collapses to a one-line passthrough on `ExtractRaw`'s return. The `src`→`title` mutation is quarantined inside `AngleSharpSchemaBackend.ExtractRaw`, unreachable from the shared fold and from any future backend.

## Design process

`explore → grilling → design-it-twice → synthesize`. Two independent designs were produced (a "node-navigator port, all internal" and a "de-anemic the Schema in Domain"); the chosen design is a synthesis that takes the true-seam insight from one (total dedup incl. the coercion switch) and the ADR-0001-consistent Core placement from the other (no `ParseResult`/`ISchemaLog` ceremony — Core already has every dependency). Recorded in `docs/adr/0002-schema-fold-and-node-backend-seam.md`; domain vocabulary added to `CONTEXT.md`.

## Breaking changes

**None.** Additive, fully source-compatible. `IContentParser`, `WithContentParser`, `WithJsonContentParser()`, `CrawlStep`, and every existing test compile and pass unchanged. New public surface: `ISchemaBackend<TNode>`, `SchemaContentParser<TNode>` in `WebReaper.Core.Parser`. **Minor** SemVer (contrast #34 = major). `<Version>` not bumped — release decision.

## Behaviour unifications (intended, documented)

Previously-divergent-by-accident, now uniform: the missing-node and parsing-error log message text, and the single-value path now requiring a selector the same way the list paths always did. **Observable outcomes are unchanged** (field left empty/unset, parse not aborted); only divergent log text and the single-value selector-miss mechanism are unified. The HTML-vs-JSON untyped-leaf difference is now a *deliberate, pinned* property — see CONTEXT.md "Flagged ambiguities" and ADR 0002.

## Testing

- **Unit: 31/31 pass** — 24 pre-existing (the regression net; already pins *both* sides of the divergence and the swallow-scope) + 7 new in `SchemaFoldTests.cs`: cross-backend structural equivalence, the deliberate untyped divergence, the `src`→`title` quarantine (present on HTML, absent on JSON), backend-independent typed coercion, the unified missing-node policy across all three backends, and a foreign `KeyValue` backend proving a new backend is a ~15-line adapter reusing the fold.
- **Integration: 4 passed / 1 pre-existing skip / 0 failed** (~1m20s, live site + real Puppeteer/Chromium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)