### PR TITLE
Refresh NuGet dependencies (4.1.0): clear Snappier vuln, PuppeteerSharp 20→24, suppress unfixable SharpCompress

### DIFF
--- a/WebReaper/WebReaper.csproj
+++ b/WebReaper/WebReaper.csproj
@@ -15,7 +15,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>scraper, crawler, parser</PackageTags>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
-    <Version>4.0.0</Version>
+    <Version>4.1.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>$(MSBuildProjectDirectory)\API.xml</DocumentationFile>
     <LangVersion>12</LangVersion>

--- a/WebReaper/WebReaper.csproj
+++ b/WebReaper/WebReaper.csproj
@@ -41,16 +41,30 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="3.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageReference Include="MongoDB.Driver" Version="3.8.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Polly" Version="8.6.5" />
-    <PackageReference Include="PuppeteerExtraSharp" Version="3.0.2" />
-    <PackageReference Include="PuppeteerSharp" Version="20.2.4" />
-    <PackageReference Include="StackExchange.Redis" Version="2.10.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Polly" Version="8.6.6" />
+    <PackageReference Include="PuppeteerExtraSharp" Version="3.1.1" />
+    <PackageReference Include="PuppeteerSharp" Version="24.42.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.13.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
   </ItemGroup>
+
+  <!--
+    GHSA-6c8g-7p36-r338: zip-slip in SharpCompress WriteToDirectory (archive
+    extraction). Suppressed as not applicable: no patched version exists (all
+    releases <= 0.47.4 are affected); WebReaper has zero direct SharpCompress
+    usage; it is pulled only transitively by MongoDB.Driver for wire-protocol
+    stream compression (Zstd/zlib), which never calls the vulnerable
+    archive-extraction API. Revisit if SharpCompress ships a fix or
+    MongoDB.Driver drops the dependency.
+  -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-6c8g-7p36-r338" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Include="..\README.md">
       <Pack>True</Pack>


### PR DESCRIPTION
## What

Pure dependency refresh of the published library — **zero WebReaper source changes**. Targets the two known-vulnerable transitive deps flagged at the 4.0.0 release, plus a full freshen of outdated direct deps.

| Package | From | To | Note |
|---|---|---|---|
| MongoDB.Driver | 3.5.1 | 3.8.1 | pulls **Snappier 1.0.0 → 1.3.1** |
| PuppeteerSharp | 20.2.4 | 24.42.0 | **four majors**; builds clean, no code changes |
| PuppeteerExtraSharp | 3.0.2 | 3.1.1 | |
| StackExchange.Redis | 2.10.1 | 2.13.1 | |
| Polly | 8.6.5 | 8.6.6 | |
| Microsoft.Extensions.Http | 10.0.0 | 10.0.8 | |
| Microsoft.Extensions.Logging.Abstractions | 10.0.0 | 10.0.8 | |

(AngleSharp, Microsoft.Azure.Cosmos, Newtonsoft.Json, Azure.Messaging.ServiceBus were already latest.)

## Security outcome

- ✅ **Snappier high-severity (GHSA-pggp-6c3x-2xmx)** — cleared by MongoDB.Driver 3.8.1 → Snappier 1.3.1.
- ⚠️ **SharpCompress moderate (GHSA-6c8g-7p36-r338)** — **no patched version exists** (all releases ≤ 0.47.4 affected). It's a zip-slip in `WriteToDirectory()` (archive extraction). **Not applicable here**: WebReaper has zero direct SharpCompress usage; it is reachable only transitively via MongoDB.Driver's wire-protocol stream compression (Zstd/zlib), which never calls the vulnerable archive-extraction API. Handled with a **documented `NuGetAuditSuppress`** (justification recorded as an XML comment in the csproj, revisitable if upstream fixes it).
  - Note: `dotnet list package --vulnerable` will still report SharpCompress — that command intentionally ignores audit suppressions. The suppression **is** effective for restore / build / `pack` / CI / consumer restore-audits (verified: 0 vuln-audit warnings).

## Verification

- Release build: **0 errors, 0 vuln-audit warnings**, no WebReaper code changes required.
- Unit tests: **31/31** (Release).
- Integration tests (live site + **PuppeteerSharp 24** / real Chromium): **4 passed / 1 pre-existing skip / 0 failed** — identical profile to pre-bump, validating the ×4 PuppeteerSharp major end-to-end.

## Version

`4.1.0` — minor bump. WebReaper's public API is unchanged, but the four-major PuppeteerSharp jump is transitively visible to consumers and a patch would under-communicate it.

## Not done here

Publishing is deferred (your call after review). A republish requires a **rotated** nuget.org API key — the key used for 4.0.0 was exposed in chat and must not be reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update — also folded in:** fixed stale `ExoScraper` package metadata (`Product`, `RepositoryUrl`) → `WebReaper`, so the published package no longer points consumers at the old repo. Verified in the packed nuspec (`<repository url=".../WebReaper">`, zero `ExoScraper` references). Natural fit here since this PR is already csproj-only.
