### PR TITLE
Housekeeping: resync CLAUDE.md with current toolchain + architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,9 @@ dotnet run --project Examples/WebReaper.ConsoleApplication   # run an example sc
 - **Unit tests** (`WebReaper.Tests/WebReaper.UnitTests`) — offline, parse `TestData/TestPage.html`. Use these for fast iteration.
 - **Integration tests** (`WebReaper.Tests/WebReaper.IntegrationTests`) — hit the **live** site `alexpavlov.dev`, launch real Puppeteer/Chromium, and assert after fixed `Task.Delay` (up to 25s). Slow and network-flaky by design; failures there are often environmental, not regressions.
 
-### .NET version mismatch (gotcha)
+### Toolchain
 
-All projects target **net8.0**; `global.json` requires SDK ≥ 7.0.0 (`rollForward: latestMajor`, prerelease allowed). But `.github/workflows/CI.yml` installs **6.0.x** — stale and inconsistent with what the projects actually need. Build locally with an SDK ≥ 8.
+All projects target **net10.0**; `global.json` pins SDK `10.0.100` (`rollForward: latestMinor`, no prerelease) and `.github/workflows/CI.yml` installs `10.0.x` — aligned. Build with a .NET 10 SDK. CI runs `dotnet restore` → `dotnet build` → unit tests over the **whole solution** (Examples/ and Misc/ included), so verify with a full-solution build, not just the library project.
 
 ## Architecture
 
@@ -37,12 +37,12 @@ Fluent builder → immutable config + pluggable spider → parallel job loop.
 
 **Run path:** `ScraperEngine.RunAsync` seeds the `IScheduler` with one `Job` per start URL, then drives `Parallel.ForEachAsync` over `Scheduler.GetAllAsync()` (an async stream). Each job → `Spider.CrawlAsync` (wrapped in `Infra.Executor.RetryAsync`, Polly-backed); resulting child jobs are pushed back into the scheduler. The loop terminates by throwing `PageCrawlLimitException` once the visited-link count hits the limit.
 
-**Job model:** `Job` is a record carrying the URL, an `ImmutableQueue<LinkPathSelector>`, parent backlinks, and `PageType` (Static vs Dynamic). `Job.PageCategory` is **derived**, not stored — from the selector queue: 0 selectors left ⇒ `TargetPage` (parse it), 1 with pagination ⇒ `PageWithPagination`, otherwise `TransitPage` (just follow links). This is the core state machine: each crawl dequeues one selector, so the queue length drives crawl-vs-parse behavior.
+**Job model:** `Job` is a record carrying the URL, an `ImmutableQueue<LinkPathSelector>`, parent backlinks, and `PageType` (Static vs Dynamic). The crawl-vs-parse decision is **not** stored on `Job` (`Job.PageCategory` was removed) — it is computed by `CrawlStep` from the selector chain (0 left ⇒ parse the target page; exactly 1 with pagination ⇒ paginate; else follow links) and returned as a closed `CrawlOutcome` sum (`Parsed | Followed | Paginated`). Chain length is the state machine: each step dequeues one selector. Authoritative: `CONTEXT.md` + `docs/adr/0001-crawl-outcome-closed-sum.md`.
 
 **Spider.CrawlAsync per job:**
 1. Load page — `IStaticPageLoader` (HTTP) or `IBrowserPageLoader` (Puppeteer) depending on `PageType`.
-2. If `TargetPage`: `IContentParser` (AngleSharp) applies the parsing `Schema` → `ParsedData` → fanned out to every `IScraperSink`, plus the `PostProcessor` callback and `ScrapedData` event. No child jobs.
-3. Else: `ILinkParser` extracts links for the current selector → child jobs; pagination selectors produce additional jobs.
+2. `CrawlStep.StepAsync` returns a `CrawlOutcome`. `Parsed` ⇒ `ParsedData` fanned out to every `IScraperSink` plus the `PostProcessor` callback and `ScrapedData` event, no child jobs. `Followed`/`Paginated` ⇒ child jobs (and pagination jobs).
+3. Content parsing is the shared `SchemaContentParser<TNode>` fold over an `ISchemaBackend<TNode>` (AngleSharp HTML or JSON); link extraction is `ILinkParser`. Authoritative: `docs/adr/0002-schema-fold-and-node-backend-seam.md`.
 
 **Pluggable seams** (interface in `*/Abstract`, implementations in `*/Concrete`; swap via `ScraperEngineBuilder` methods):
 
@@ -65,4 +65,3 @@ Namespace mirrors folder path throughout (`WebReaper.Core.Spider.Concrete` = `We
 - The "JSON" sink writes **JSON Lines** (`JsonLinesFileSink`), one object per line, not a JSON array.
 - `ConfigBuilder.Build()` throws if `Get`/`GetWithBrowser` or `Parse` was never called — builder order matters.
 - First dynamic-page run downloads Chromium via Puppeteer.
-- `WebReaper.csproj` `RepositoryUrl`/`Product` still say "ExoScraper" (old name); the shipped package id is `WebReaper`.


### PR DESCRIPTION
Docs-only housekeeping (no code/behavior change). CLAUDE.md had drifted from reality on three points:

- **Toolchain.** Claimed projects target net8.0, `global.json` requires SDK ≥7.0.0 (latestMajor, prerelease), CI installs 6.0.x. Reality (verified from source): **net10.0**, `global.json` pins **10.0.100** (latestMinor, no prerelease), CI installs **10.0.x** — aligned, not a "mismatch". Added a note that CI builds the **whole solution** (Examples/ + Misc/) — the verification gap that let the #36 NU1605 break reach master.
- **Architecture.** Still described the **deleted** `Job.PageCategory` state machine (`TargetPage`/`TransitPage`/`PageWithPagination`) as the core model. It was removed in #34 (shipped in 4.0.0). Now points at `CrawlStep` → closed `CrawlOutcome` and the `SchemaContentParser<TNode>` / `ISchemaBackend<TNode>` fold, with `CONTEXT.md` and `docs/adr/0001`/`0002` as authoritative.
- **Gotcha.** Dropped the "csproj still says ExoScraper" note — fixed in #37.

Also in this housekeeping pass (outside this PR, git ops): deleted this session's merged branches (#34/#35/#36/#37) and tagged `v4.0.0` at the published commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)