### PR TITLE
Correct ADR-0008 to shipped 6.0.0 reality; fix stale doc comments

### DIFF
--- a/WebReaper/API.xml
+++ b/WebReaper/API.xml
@@ -210,7 +210,7 @@
             pure method. <see cref="T:WebReaper.Core.Parser.Abstract.ILinkParser"/> / <see cref="T:WebReaper.Core.Parser.Abstract.IJsonContentParser"/>
             are internal seams — injected, never surfaced on <see cref="T:WebReaper.Core.Crawling.Abstract.ICrawlStep"/>.
             ADR 0008: the content seam is the typed <see cref="T:WebReaper.Core.Parser.Abstract.IJsonContentParser"/>
-            (JsonObject), not the legacy <see cref="!:IContentParser"/> (JObject).
+            (JsonObject); the legacy <c>IContentParser</c> (JObject) was removed at 6.0.0.
             </summary>
         </member>
         <member name="T:WebReaper.Core.Crawling.CrawlOutcome">
@@ -342,10 +342,11 @@
             <summary>
             The typed Schema-fold seam (ADR 0008). The fold's terminal projection is
             <see cref="T:System.Text.Json.Nodes.JsonObject"/> — AOT-clean, no Newtonsoft —
-            and is the path <see cref="!:ParsedData"/>/sinks move to. It lives
-            <em>beside</em> the legacy <see cref="!:IContentParser"/> (<c>JObject</c>),
-            which is retained as a compat shell and <c>[Obsolete]</c>. One fold (ADR
-            0002); only what it emits differs.
+            and is the path <see cref="T:WebReaper.Sinks.Models.ParsedData"/>/sinks use. This is the sole
+            content-parser seam: the legacy Newtonsoft <c>JObject</c>-returning
+            <c>IContentParser</c> was removed outright at the 6.0.0 major — no compat
+            shell (see the ADR 0008 post-release correction). One fold (ADR 0002);
+            only what it emits differs.
             </summary>
         </member>
         <member name="T:WebReaper.Core.Parser.Abstract.ISchemaBackend`1">

--- a/WebReaper/Core/Crawling/Concrete/CrawlStep.cs
+++ b/WebReaper/Core/Crawling/Concrete/CrawlStep.cs
@@ -15,7 +15,7 @@ namespace WebReaper.Core.Crawling.Concrete;
 /// pure method. <see cref="ILinkParser"/> / <see cref="IJsonContentParser"/>
 /// are internal seams — injected, never surfaced on <see cref="ICrawlStep"/>.
 /// ADR 0008: the content seam is the typed <see cref="IJsonContentParser"/>
-/// (JsonObject), not the legacy <see cref="IContentParser"/> (JObject).
+/// (JsonObject); the legacy <c>IContentParser</c> (JObject) was removed at 6.0.0.
 /// </summary>
 public sealed class CrawlStep : ICrawlStep
 {

--- a/WebReaper/Core/Parser/Abstract/IJsonContentParser.cs
+++ b/WebReaper/Core/Parser/Abstract/IJsonContentParser.cs
@@ -6,10 +6,11 @@ namespace WebReaper.Core.Parser.Abstract;
 /// <summary>
 /// The typed Schema-fold seam (ADR 0008). The fold's terminal projection is
 /// <see cref="System.Text.Json.Nodes.JsonObject"/> — AOT-clean, no Newtonsoft —
-/// and is the path <see cref="ParsedData"/>/sinks move to. It lives
-/// <em>beside</em> the legacy <see cref="IContentParser"/> (<c>JObject</c>),
-/// which is retained as a compat shell and <c>[Obsolete]</c>. One fold (ADR
-/// 0002); only what it emits differs.
+/// and is the path <see cref="WebReaper.Sinks.Models.ParsedData"/>/sinks use. This is the sole
+/// content-parser seam: the legacy Newtonsoft <c>JObject</c>-returning
+/// <c>IContentParser</c> was removed outright at the 6.0.0 major — no compat
+/// shell (see the ADR 0008 post-release correction). One fold (ADR 0002);
+/// only what it emits differs.
 /// </summary>
 public interface IJsonContentParser
 {

--- a/docs/adr/0008-system-text-json-typed-pipeline.md
+++ b/docs/adr/0008-system-text-json-typed-pipeline.md
@@ -1,5 +1,15 @@
 # The serialization grammar is System.Text.Json source-gen; Newtonsoft `JObject` + `TypeNameHandling.Auto` are superseded
 
+> **Post-release correction (2026-05-17, after 6.0.0 shipped).** What 6.0.0
+> actually shipped diverges from the *Staging* / *SemVer* / *Considered options*
+> sections below: `IContentParser` and the `JObject` path were **removed
+> outright in the 6.0.0 major (big-bang)** — not retained as an `[Obsolete]`
+> compat shell for a later-major removal. The shipped artifact is authoritative;
+> the staged-migration prose below is **superseded** and reads as historical
+> intent only. Full reconciliation at the foot of this ADR ("Post-release
+> correction"). Shipped code is unchanged by this correction — documentation
+> only.
+
 The extraction and persistence pipeline ran on `Newtonsoft.Json` across **21
 core files**. Two distinct uses, one root cause:
 
@@ -288,3 +298,51 @@ break isolated behind a compat shell, not a silent regression.
   `[ScrapeSchema]` materialiser needs a `JsonSerializerContext` to extend.
   Choosing `JsonNode`-only now would force re-introducing the context later —
   indirection deferred, not avoided.
+
+## Post-release correction (2026-05-17)
+
+Recorded after 6.0.0 was published to NuGet (permanent, unlist-only) and PR #41
+merged to `master`. Found by a post-release verification pass.
+
+**Discrepancy.** Verified against the shipped source on `master`: there is no
+`IContentParser` type and no `[Obsolete]` `JObject` compat seam in 6.0.0; the
+Newtonsoft `JObject`-returning `ParseAsync` is gone (CHANGELOG: *"`IContentParser`
+removed … is gone"*; `SchemaContentParser`'s own doc comment concurs —
+*"`IContentParser` were removed at the 6.0.0 major"*). That is the **big-bang
+`JObject`→typed swap** this ADR's *Considered options* explicitly **rejected**,
+and it contradicts, in this same ADR: *Staging* step 1 (*"retain the
+`JObject`-returning `IContentParser` as the legacy seam"*) and step 4 (*"`[Obsolete]`
+on the `JObject` path"*); *SemVer* (*"the `JObject` path is `[Obsolete]`d with a
+deprecation window … removed in a later major"*); and the body's *"additive
+public surface, compat shell, staged … **never big-bang**"*.
+
+**Resolution — docs follow code, never the reverse.** The shipped 6.0.0 artifact
+is authoritative and is **not** changed by this correction; a clean break for a
+library with few external consumers is a defensible call, and reverting code to
+match stale prose would be the wrong direction. This ADR's *decision* is
+corrected to: **`IContentParser` and the `JObject` public surface were removed in
+the 6.0.0 major (big-bang); no compat shell and no deprecation window shipped.**
+The *Staging* and *SemVer* sections above are superseded accordingly and retained
+only as historical intent.
+
+**Unaffected.** The structural results this ADR preserves still hold — ADR-0002's
+one-fold, ADR-0003's keyed-blob-store/payload-shell, the closed ADR-0005
+`RedisScheduler` asymmetry, and the STJ source-gen mechanism are all unchanged.
+Only the *migration shape* (big-bang vs. staged compat shell) is corrected; the
+serialization-grammar decision itself stands.
+
+**Rationale for the deviation: to be confirmed by the maintainer.** Why the
+staged compat-shell plan was dropped for an immediate removal is not recorded in
+the work that produced 6.0.0; this note deliberately does not invent one.
+(Unconfirmed candidate: the dual `JObject`/typed public surface judged not worth
+its cost given the consumer base.)
+
+**Sibling documentation defects — fixed (2026-05-17, doc comments only).** Two
+XML-doc sites referenced the removed type: `IJsonContentParser.cs` falsely
+asserted the legacy interface *"is retained as a compat shell and `[Obsolete]`"*,
+and both it and `CrawlStep.cs` carried a dangling `<see cref="IContentParser"/>`
+(unresolvable since the type was removed; shipped in `API.xml` via
+`GenerateDocumentationFile=true`). Both corrected to state the legacy
+`IContentParser`/`JObject` path was removed outright at 6.0.0, cref dropped.
+Comment-only — no behavioural/IL change. `SchemaContentParser.cs`'s doc was
+already accurate and was left untouched.


### PR DESCRIPTION
**Documentation only — no code/behaviour/IL change, no SemVer bump.** Post-release correction found by a verification pass after 6.0.0 was published (permanent, unlist-only) and PR #41 merged to master.

### The defect
ADR-0008's *Staging* / *SemVer* / *Considered options* describe a staged `[Obsolete]` `JObject` compat shell ("never big-bang") and explicitly mark the big-bang swap **rejected**. 6.0.0 actually shipped the **outright removal** of `IContentParser` and the `JObject` path — i.e. the rejected option. Two XML-doc sites also falsely claimed a "retained compat shell" and carried dangling `<see cref>`s to the removed type, which shipped in `API.xml` (`GenerateDocumentationFile=true`). The CHANGELOG was already correct.

### Changes (docs only)
- **ADR-0008** — post-release correction banner + section; supersedes the stale staged/SemVer prose; records shipped reality. Deviation rationale marked *to be confirmed by the maintainer* (not fabricated).
- **IJsonContentParser.cs / CrawlStep.cs** — false "compat shell" claim removed; dangling `IContentParser` cref dropped; a pre-existing unresolved `ParsedData` cref fully-qualified. Comment-only.
- **API.xml** — regenerated to match (the `!:` unresolved-cref markers are now resolved).
- **SchemaContentParser.cs** — already accurate, untouched.
- Untracked strategy files (`docs/REPOSITIONING-PLAN.md`, `research/`, `.claude/settings.json`) deliberately excluded — unrelated.

### Verification
`dotnet build WebReaper.csproj` → **0 errors**; targeted `CS1574` crefs resolved (387 → 386 warnings). No IL change → unit guardrail (65/65) unaffected by construction. master / NuGet 6.0.0 / AOT-smoke unaffected.

### Open
The reason the staged compat-shell was dropped for immediate removal is unrecorded; the ADR says *to be confirmed by the maintainer* — supply it and it's a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)