### PR TITLE
WebReaper.AzureServiceBus satellite: Azure Service Bus scheduler out of core (ADR-0009); 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ per-technology satellite packages, wired through the builder's public
 registration seam. Rationale, design, and the deliberate clean-cut (no compat
 shell): [`docs/adr/0009-registration-seam-and-satellite-adapters.md`](docs/adr/0009-registration-seam-and-satellite-adapters.md).
 
-This release lands the **Cosmos**, **Mongo** and **Redis** satellites. The
-remaining satellites (`WebReaper.AzureServiceBus`, `WebReaper.Puppeteer`) land
-in the same 7.0.0 line.
+This release lands the **Cosmos**, **Mongo**, **Redis** and **Azure Service
+Bus** satellites. The remaining satellite (`WebReaper.Puppeteer`) lands in the
+same 7.0.0 line.
 
 ### Breaking changes
 
@@ -60,13 +60,22 @@ in the same 7.0.0 line.
 - The Redis builder extensions that took a logger no longer auto-use the
   builder's; each takes an optional `ILogger` argument (defaults to
   `NullLogger`).
+- **`WithAzureServiceBusScheduler` moved to the `WebReaper.AzureServiceBus`
+  package.** It is now an extension method over `ScraperEngineBuilder`'s public
+  `WithScheduler` registration seam, not a core builder method. There was no
+  `SpiderBuilder` equivalent to remove.
+- **`AzureServiceBusScheduler` moved** to namespace and package
+  `WebReaper.AzureServiceBus` (was `WebReaper.Core.Scheduler.Concrete`).
+- **Core no longer references `Azure.Messaging.ServiceBus`.** A core-only
+  consumer no longer pulls it. `WithAzureServiceBusScheduler` took no logger,
+  so its signature is unchanged.
 
 ### Why
 
 - Dependency-light core: a plain HTTP→file crawl stops transitively pulling
   Cosmos + Newtonsoft + native interop, `MongoDB.Driver` + its transitive
-  SharpCompress CVE, and `StackExchange.Redis` (and, as later satellites land,
-  Azure Service Bus, Chromium).
+  SharpCompress CVE, `StackExchange.Redis`, and `Azure.Messaging.ServiceBus`
+  (and, as the last satellite lands, Chromium).
 - The builder deepens into a small public registration seam; per-adapter
   `WriteToX` sugar ships with its adapter. See ADR-0009.
 
@@ -90,6 +99,10 @@ in the same 7.0.0 line.
   `RedisScraperConfigStorage` / `RedisCookieStorage` / `RedisBlobStore` /
   `RedisConnectionPool` types. Existing arguments are unchanged (an optional
   `ILogger` is appended where one was passed).
+- Add the package: `dotnet add package WebReaper.AzureServiceBus`.
+- Add `using WebReaper.AzureServiceBus;` wherever you call
+  `.WithAzureServiceBusScheduler(...)` or reference the
+  `AzureServiceBusScheduler` type. Its arguments are unchanged.
 
 ## 6.0.0 — System.Text.Json typed pipeline (breaking, AOT-clean)
 

--- a/Examples/WebReaper.AzureFuncs/StartScraping.cs
+++ b/Examples/WebReaper.AzureFuncs/StartScraping.cs
@@ -14,7 +14,7 @@ using WebReaper.Builders;
 using WebReaper.Domain;
 using WebReaper.Domain.Parsing;
 using WebReaper.Core;
-using WebReaper.Core.Scheduler.Concrete;
+using WebReaper.AzureServiceBus;
 
 namespace WebReaper.AzureFuncs
 {

--- a/Examples/WebReaper.AzureFuncs/WebReaper.AzureFuncs.csproj
+++ b/Examples/WebReaper.AzureFuncs/WebReaper.AzureFuncs.csproj
@@ -32,5 +32,6 @@
     <ProjectReference Include="..\..\WebReaper\WebReaper.csproj" />
     <ProjectReference Include="..\..\WebReaper.Cosmos\WebReaper.Cosmos.csproj" />
     <ProjectReference Include="..\..\WebReaper.Redis\WebReaper.Redis.csproj" />
+    <ProjectReference Include="..\..\WebReaper.AzureServiceBus\WebReaper.AzureServiceBus.csproj" />
   </ItemGroup>
 </Project>

--- a/Examples/WebReaper.DistributedScraperWorkerService/ScrapingWorker.cs
+++ b/Examples/WebReaper.DistributedScraperWorkerService/ScrapingWorker.cs
@@ -1,6 +1,7 @@
 ﻿using WebReaper.Builders;
 using WebReaper.Cosmos;
 using WebReaper.Redis;
+using WebReaper.AzureServiceBus;
 using WebReaper.Core;
 using WebReaper.Domain.Parsing;
 

--- a/Examples/WebReaper.DistributedScraperWorkerService/WebReaper.DistributedScraperWorkerService.csproj
+++ b/Examples/WebReaper.DistributedScraperWorkerService/WebReaper.DistributedScraperWorkerService.csproj
@@ -27,5 +27,6 @@
     <ProjectReference Include="..\..\WebReaper\WebReaper.csproj" />
     <ProjectReference Include="..\..\WebReaper.Cosmos\WebReaper.Cosmos.csproj" />
     <ProjectReference Include="..\..\WebReaper.Redis\WebReaper.Redis.csproj" />
+    <ProjectReference Include="..\..\WebReaper.AzureServiceBus\WebReaper.AzureServiceBus.csproj" />
   </ItemGroup>
 </Project>

--- a/WebReaper.AzureServiceBus/AzureServiceBusBuilderExtensions.cs
+++ b/WebReaper.AzureServiceBus/AzureServiceBusBuilderExtensions.cs
@@ -1,0 +1,25 @@
+using WebReaper.Builders;
+
+namespace WebReaper.AzureServiceBus;
+
+/// <summary>
+/// ADR-0009: the Azure Service Bus builder sugar lives here, in the
+/// WebReaper.AzureServiceBus satellite, over <see cref="ScraperEngineBuilder"/>'s
+/// public <c>WithScheduler</c> registration seam — not in core. Core no longer
+/// references Azure.Messaging.ServiceBus. The scheduler takes no logger, so
+/// (unlike the Redis sugar) this extension has no logger argument.
+/// </summary>
+public static class AzureServiceBusBuilderExtensions
+{
+    public static ScraperEngineBuilder WithAzureServiceBusScheduler(
+        this ScraperEngineBuilder builder,
+        string connectionString,
+        string queueName,
+        bool dataCleanupOnStart = false)
+    {
+        return builder.WithScheduler(new AzureServiceBusScheduler(
+            connectionString,
+            queueName,
+            dataCleanupOnStart));
+    }
+}

--- a/WebReaper.AzureServiceBus/AzureServiceBusScheduler.cs
+++ b/WebReaper.AzureServiceBus/AzureServiceBusScheduler.cs
@@ -5,7 +5,7 @@ using WebReaper.Domain;
 using WebReaper.Serialization;
 using Azure.Messaging.ServiceBus.Administration;
 
-namespace WebReaper.Core.Scheduler.Concrete;
+namespace WebReaper.AzureServiceBus;
 
 public class AzureServiceBusScheduler : IScheduler, IAsyncDisposable
 {

--- a/WebReaper.AzureServiceBus/WebReaper.AzureServiceBus.csproj
+++ b/WebReaper.AzureServiceBus/WebReaper.AzureServiceBus.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12</LangVersion>
+
+    <PackageId>WebReaper.AzureServiceBus</PackageId>
+    <Version>7.0.0</Version>
+    <Authors>Alex Pavlov</Authors>
+    <Company>Alex Pavlov</Company>
+    <Product>WebReaper</Product>
+    <Title>WebReaper.AzureServiceBus</Title>
+    <Description>Azure Service Bus scheduler for WebReaper: a distributed job queue backed by an Azure Service Bus queue, for sharing crawl state across workers and serverless functions. Adds ScraperEngineBuilder.WithAzureServiceBusScheduler. Satellite package (ADR-0009) so the WebReaper core stays dependency-light and AOT-clean.</Description>
+    <Copyright>GPL-3.0 license</Copyright>
+    <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/pavlovtech/WebReaper</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/pavlovtech/WebReaper</RepositoryUrl>
+    <PackageTags>scraper, crawler, parser, azure, servicebus, distributed</PackageTags>
+
+    <!-- ADR 0009: the Azure Service Bus satellite is deliberately NOT
+         IsAotCompatible. Quarantining the Azure Service Bus scheduler here is
+         exactly why the core stays dependency-light — a core-only consumer no
+         longer pulls Azure.Messaging.ServiceBus. -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebReaper\WebReaper.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+  </ItemGroup>
+</Project>

--- a/WebReaper.Tests/WebReaper.AzureServiceBus.Tests/WebReaper.AzureServiceBus.Tests.csproj
+++ b/WebReaper.Tests/WebReaper.AzureServiceBus.Tests/WebReaper.AzureServiceBus.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+
+    <LangVersion>12</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WebReaper.AzureServiceBus\WebReaper.AzureServiceBus.csproj" />
+  </ItemGroup>
+</Project>

--- a/WebReaper.Tests/WebReaper.AzureServiceBus.Tests/WithAzureServiceBusSchedulerExtensionTests.cs
+++ b/WebReaper.Tests/WebReaper.AzureServiceBus.Tests/WithAzureServiceBusSchedulerExtensionTests.cs
@@ -1,0 +1,29 @@
+using Xunit;
+using WebReaper.Builders;
+using WebReaper.AzureServiceBus;
+
+namespace WebReaper.AzureServiceBus.Tests;
+
+public class WithAzureServiceBusSchedulerExtensionTests
+{
+    // ADR-0009 satellite contract over the public WithScheduler registration
+    // seam: WebReaper.AzureServiceBus supplies WithAzureServiceBusScheduler as
+    // a ScraperEngineBuilder extension that preserves fluent chaining — not a
+    // core builder method (core no longer references Azure.Messaging.ServiceBus).
+    // Offline-safe: a well-formed connection string parses without dialing the
+    // broker (the AMQP link is lazy), and dataCleanupOnStart:false makes the
+    // scheduler's InitializeAsync a no-op, so no Service Bus namespace is
+    // needed to assert the builder wiring.
+    [Fact]
+    public void WithAzureServiceBusScheduler_is_a_ScraperEngineBuilder_extension_that_chains()
+    {
+        var builder = new ScraperEngineBuilder();
+
+        var result = builder.WithAzureServiceBusScheduler(
+            connectionString: "Endpoint=sb://localhost.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=fake",
+            queueName: "jobs",
+            dataCleanupOnStart: false);
+
+        Assert.Same(builder, result);
+    }
+}

--- a/WebReaper.sln
+++ b/WebReaper.sln
@@ -42,6 +42,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.Redis", "WebReape
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.Redis.Tests", "WebReaper.Tests\WebReaper.Redis.Tests\WebReaper.Redis.Tests.csproj", "{E490F5B6-9CF4-4288-96F3-7B21AE77BF84}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.AzureServiceBus", "WebReaper.AzureServiceBus\WebReaper.AzureServiceBus.csproj", "{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.AzureServiceBus.Tests", "WebReaper.Tests\WebReaper.AzureServiceBus.Tests\WebReaper.AzureServiceBus.Tests.csproj", "{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -220,6 +224,30 @@ Global
 		{E490F5B6-9CF4-4288-96F3-7B21AE77BF84}.Release|x64.Build.0 = Release|Any CPU
 		{E490F5B6-9CF4-4288-96F3-7B21AE77BF84}.Release|x86.ActiveCfg = Release|Any CPU
 		{E490F5B6-9CF4-4288-96F3-7B21AE77BF84}.Release|x86.Build.0 = Release|Any CPU
+		{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}.Debug|x64.Build.0 = Debug|Any CPU
+		{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}.Debug|x86.Build.0 = Debug|Any CPU
+		{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}.Release|x64.ActiveCfg = Release|Any CPU
+		{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}.Release|x64.Build.0 = Release|Any CPU
+		{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}.Release|x86.ActiveCfg = Release|Any CPU
+		{3D9F228B-2B80-4B3C-9323-CBC731C9A0B1}.Release|x86.Build.0 = Release|Any CPU
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}.Debug|x64.Build.0 = Debug|Any CPU
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}.Debug|x86.Build.0 = Debug|Any CPU
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}.Release|x64.ActiveCfg = Release|Any CPU
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}.Release|x64.Build.0 = Release|Any CPU
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}.Release|x86.ActiveCfg = Release|Any CPU
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -234,6 +262,7 @@ Global
 		{9E7BBB9A-7ECD-4710-A951-41D874D7114B} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
 		{C39F425A-D165-4C44-9B6F-00C2628C297F} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
 		{E490F5B6-9CF4-4288-96F3-7B21AE77BF84} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
+		{7376E47B-3F6A-4BD8-8A74-A9CCEAE526A6} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8413198B-8D26-4E30-A5E2-E0FBC4DCEA59}

--- a/WebReaper/Builders/ScraperEngineBuilder.cs
+++ b/WebReaper/Builders/ScraperEngineBuilder.cs
@@ -246,15 +246,6 @@ public class ScraperEngineBuilder
         return this;
     }
 
-    public ScraperEngineBuilder WithAzureServiceBusScheduler(
-        string connectionString,
-        string queueName,
-        bool dataCleanupOnStart = false)
-    {
-        Scheduler = new AzureServiceBusScheduler(connectionString, queueName, dataCleanupOnStart);
-        return this;
-    }
-
     public ScraperEngineBuilder WithTextFileScheduler(
         string fileName,
         string currentJobPositionFileName,

--- a/WebReaper/WebReaper.csproj
+++ b/WebReaper/WebReaper.csproj
@@ -16,7 +16,7 @@
     <PackageTags>scraper, crawler, parser</PackageTags>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <Version>7.0.0</Version>
-    <PackageReleaseNotes>7.0.0 (breaking, major): heavy third-party adapters move into per-technology satellite packages so the core stays dependency-light. WebReaper.Cosmos: WriteToCosmosDb and CosmosSink out of core (core no longer references Microsoft.Azure.Cosmos). WebReaper.Mongo: WriteToMongoDb / WithMongoDbConfigStorage / WithMongoDbCookieStorage and the MongoDbSink / MongoDbScraperConfigStorage / MongoDbCookieStorage / MongoBlobStore adapters out of core (core no longer references MongoDB.Driver, shedding its transitive SharpCompress GHSA-6c8g-7p36-r338). WebReaper.Redis: WithRedisScheduler / TrackVisitedLinksInRedis / WriteToRedis / WithRedisConfigStorage / WithRedisCookieStorage and the RedisScheduler / RedisVisitedLinkTracker / RedisSink / RedisScraperConfigStorage / RedisCookieStorage / RedisBlobStore / RedisConnectionPool adapters out of core (core no longer references StackExchange.Redis; the ADR-0005 one-multiplexer-per-connection-string invariant is preserved intra-package). All moved types are repackaged under namespace WebReaper.Cosmos / WebReaper.Mongo / WebReaper.Redis. Clean cut, no compat forwarders. Add the satellite package and a using to migrate. Rationale and migration: docs/adr/0009 and CHANGELOG.md.</PackageReleaseNotes>
+    <PackageReleaseNotes>7.0.0 (breaking, major): heavy third-party adapters move into per-technology satellite packages so the core stays dependency-light. WebReaper.Cosmos: WriteToCosmosDb and CosmosSink out of core (core no longer references Microsoft.Azure.Cosmos). WebReaper.Mongo: WriteToMongoDb / WithMongoDbConfigStorage / WithMongoDbCookieStorage and the MongoDbSink / MongoDbScraperConfigStorage / MongoDbCookieStorage / MongoBlobStore adapters out of core (core no longer references MongoDB.Driver, shedding its transitive SharpCompress GHSA-6c8g-7p36-r338). WebReaper.Redis: WithRedisScheduler / TrackVisitedLinksInRedis / WriteToRedis / WithRedisConfigStorage / WithRedisCookieStorage and the RedisScheduler / RedisVisitedLinkTracker / RedisSink / RedisScraperConfigStorage / RedisCookieStorage / RedisBlobStore / RedisConnectionPool adapters out of core (core no longer references StackExchange.Redis; the ADR-0005 one-multiplexer-per-connection-string invariant is preserved intra-package). WebReaper.AzureServiceBus: WithAzureServiceBusScheduler and the AzureServiceBusScheduler adapter out of core (core no longer references Azure.Messaging.ServiceBus). All moved types are repackaged under namespace WebReaper.Cosmos / WebReaper.Mongo / WebReaper.Redis / WebReaper.AzureServiceBus. Clean cut, no compat forwarders. Add the satellite package and a using to migrate. Rationale and migration: docs/adr/0009 and CHANGELOG.md.</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>$(MSBuildProjectDirectory)\API.xml</DocumentationFile>
     <LangVersion>12</LangVersion>
@@ -31,9 +31,11 @@
          moved CosmosSink out to WebReaper.Cosmos (Cosmos -> Newtonsoft +
          native ServiceInterop graph off the core) and the Mongo adapters out
          to WebReaper.Mongo (MongoDB.Driver + its transitive SharpCompress
-         graph off the core) and the Redis adapters out to WebReaper.Redis
-         (StackExchange.Redis off the core). The Newtonsoft-free path is
-         proven zero-warning by WebReaper.AotSmokeTest. -->
+         graph off the core), the Redis adapters out to WebReaper.Redis
+         (StackExchange.Redis off the core) and the Azure Service Bus
+         scheduler out to WebReaper.AzureServiceBus (Azure.Messaging.ServiceBus
+         off the core). The Newtonsoft-free path is proven zero-warning by
+         WebReaper.AotSmokeTest. -->
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
@@ -51,7 +53,6 @@
     <None Remove="Newtonsoft.Json" />
     <None Remove="Fizzler.Systems.HtmlAgilityPack" />
     <None Remove="Microsoft.Extensions.Logging.Abstractions" />
-    <None Remove="Azure.Messaging.ServiceBus" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.4.0" />
@@ -62,7 +63,6 @@
     <PackageReference Include="PuppeteerExtraSharp" Version="3.1.1" />
     <PackageReference Include="PuppeteerSharp" Version="24.42.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fourth ADR-0009 satellite slice (after Cosmos #44, Mongo #45, Redis #46). The smallest/most mechanical: one scheduler adapter, one builder method, one SDK `PackageReference`, no shared internals, no `SpiderBuilder` equivalent, no existing unit test to relocate.

## What

- **`AzureServiceBusScheduler` moved** `WebReaper.Core.Scheduler.Concrete` → namespace and package `WebReaper.AzureServiceBus` (via `git mv`, recorded as a rename).
- **`WithAzureServiceBusScheduler` moved** off core `ScraperEngineBuilder` into a `WebReaper.AzureServiceBus` extension over the public `WithScheduler` registration seam. The scheduler takes no logger, so (unlike the Redis sugar) the signature is unchanged — no `ILogger` argument added.
- **Core no longer references `Azure.Messaging.ServiceBus`** (PackageReference + `<None Remove>` dropped).
- Examples `DistributedScraperWorkerService` (builder extension) and `AzureFuncs` (direct `new AzureServiceBusScheduler(...)`) reference the satellite and add `using WebReaper.AzureServiceBus;`.
- CHANGELOG + core `<PackageReleaseNotes>` + ADR-0008 `IsAotCompatible` comment updated. Clean cut, no compat forwarders (ADR-0009).

## TDD (honest-RED)

Core method + adapter removed first → core builds **0 errors** while the chaining test fails with exactly `CS1061: 'ScraperEngineBuilder' does not contain a definition for 'WithAzureServiceBusScheduler'` (capability genuinely absent, not false-passing a lingering core method) → satellite extension added → GREEN. The test is offline-safe: a well-formed connection string parses without dialing the broker (lazy AMQP) and `dataCleanupOnStart: false` makes the scheduler's `InitializeAsync` a no-op.

## Guardrail (green)

- Whole-solution Release build: **0 errors**
- Unit **62/62**; Cosmos **1/1**, Mongo **3/3**, Redis **8/8**, AzureServiceBus **1/1**
- AOT smoke **8/8**, exit 0 (Newtonsoft-free path intact)
- Dependency-light: a core-only consumer pulls **zero** `Azure.Messaging.ServiceBus` (and still none of `StackExchange.Redis` / `MongoDB.Driver` / `Microsoft.Azure.Cosmos` / `SharpCompress`)

Remaining ADR-0009 work after this merges: `WebReaper.Puppeteer` (non-mechanical — new load-transport seam, core default flips HTTP-only, touches ADR-0004), then `SpiderBuilder` → internal (capstone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)