### PR TITLE
ADR-0008 JSONPath cursor → in-repo JsonNode evaluator; core fully Newtonsoft-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ This release lands the full ADR-0009 satellite set: **Cosmos**, **Mongo**,
 package no longer references any of those SDKs — a plain HTTP→file crawl
 pulls none of them.
 
+It also closes the ADR-0008-named JSONPath follow-up: `JsonSchemaBackend`'s
+Newtonsoft `JToken` JSONPath cursor — the last Newtonsoft reach in core — is
+migrated to an in-repo JSONPath-subset evaluator over
+`System.Text.Json.Nodes.JsonNode`. The supported dialect is preserved exactly
+(optional `$`/`$.` root, `.`-separated property paths, trailing `[*]` array
+wildcard — the whole surface the `Schema` model drives, pinned by the JSON
+test corpus). With `CookieStore` already on System.Text.Json, **core is now
+entirely Newtonsoft-free**: the `Newtonsoft.Json` `PackageReference` is
+dropped and the *whole* core (not just a scoped path) publishes Native-AOT
+zero-warning — verified by `WebReaper.AotSmokeTest`, now extended to exercise
+the JSON backend. Rationale and the doc-lag correction:
+[`docs/adr/0008-system-text-json-typed-pipeline.md`](docs/adr/0008-system-text-json-typed-pipeline.md).
+
 ### Breaking changes
 
 - **`WriteToCosmosDb` moved to the `WebReaper.Cosmos` package.** It is now an
@@ -155,6 +168,11 @@ pulls none of them.
   `new ScraperEngineBuilder()…BuildSpider()` — the same `WithLogger` /
   `WithLinkTracker` / `AddSink` / etc. configuration, returning the same
   `ISpider`. Fluent `ScraperEngineBuilder` consumers need no change.
+- If your code used `Newtonsoft.Json` and relied on getting it *transitively*
+  through the `WebReaper` package, add an explicit
+  `<PackageReference Include="Newtonsoft.Json" .../>` — core no longer
+  references it. WebReaper's own APIs are `System.Text.Json` throughout, so a
+  consumer that does not use Newtonsoft itself needs no change.
 
 ## 6.0.0 — System.Text.Json typed pipeline (breaking, AOT-clean)
 

--- a/Misc/WebReaper.ProxyProviders/WebReaper.ProxyProviders.csproj
+++ b/Misc/WebReaper.ProxyProviders/WebReaper.ProxyProviders.csproj
@@ -9,4 +9,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\WebReaper\WebReaper.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- WebShareProxyProvider parses the WebShare API with Newtonsoft. Core
+         is now Newtonsoft-free (ADR-0008 JSONPath cursor migrated to STJ), so
+         this consumer declares the dependency directly instead of free-riding
+         on core's former transitive reference. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
 </Project>

--- a/WebReaper.Tests/WebReaper.AotSmokeTest/Program.cs
+++ b/WebReaper.Tests/WebReaper.AotSmokeTest/Program.cs
@@ -81,6 +81,27 @@ Check(parsed["title"]!.GetValue<string>() == "Hello"
       && parsed["views"]!.GetValue<int>() == 42,
     "typed JsonObject fold terminal (no Newtonsoft)");
 
+// 3b. Production JSON backend — the ADR-0008 JSONPath cursor on the
+//     Newtonsoft-free path. Before the JSONPath→STJ migration this reaches
+//     Newtonsoft JToken (Parse/SelectToken/SelectTokens) and FAILS the
+//     publish (IL2104/IL3053 whole-assembly rollup, promoted to error);
+//     after, JsonSchemaBackend is JsonNode-only and AOT-clean. Exercises the
+//     full used dialect: relative dotted, $-rooted, and $.a[*] wildcard.
+var jsonParser = new JsonContentParser(NullLogger.Instance);
+JsonObject jp = await jsonParser.ParseToJsonAsync(
+    @"{ ""post"": { ""title"": ""Hi"", ""views"": 42 }, ""tags"": [ ""a"", ""b"" ] }",
+    new Schema
+    {
+        new SchemaElement("title", "post.title", DataType.String),
+        new SchemaElement("views", "$.post.views", DataType.Integer),
+        new SchemaElement("tags", "$.tags[*]", DataType.String) { IsList = true }
+    });
+Check(jp["title"]!.GetValue<string>() == "Hi"
+      && jp["views"]!.GetValue<int>() == 42
+      && jp["tags"]!.AsArray().Count == 2
+      && jp["tags"]![0]!.GetValue<string>() == "a",
+    "JSON backend JSONPath cursor (Newtonsoft-free, AOT-clean)");
+
 // 4. Production JsonObject file formats.
 parsed["url"] = "https://x.test/p";
 Check(new JsonLinesFormat().FormatRow(parsed)

--- a/WebReaper.Tests/WebReaper.UnitTests/JsonParsingTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/JsonParsingTests.cs
@@ -50,6 +50,34 @@ namespace WebReaper.UnitTests
             Assert.Equal("B", posts[1]!["title"]!.ToString());
         }
 
+        // Characterization net (ADR-0008 JSONPath→STJ migration): the dialect
+        // the codebase drives is "optional $ / $. root, dotted property path,
+        // trailing [*] array wildcard". Pins two corners the rest of the JSON
+        // suite leaves implicit — leading "$." is equivalent to a relative
+        // path, and dotted paths nest arbitrarily deep — so the Newtonsoft→STJ
+        // backend swap is behaviour-preserving, not just compiling.
+        [Fact]
+        public async Task DollarRootedAndRelativePathsAreEquivalentAndNestDeep()
+        {
+            const string json =
+                @"{ ""a"": { ""b"": { ""c"": ""deep"" } }, ""x"": ""y"" }";
+
+            var schema = new Schema
+            {
+                new SchemaElement("rooted", "$.a.b.c"),
+                new SchemaElement("relative", "a.b.c"),
+                new SchemaElement("shallowRooted", "$.x"),
+                new SchemaElement("shallowRelative", "x")
+            };
+
+            var result = await Parser().ParseToJsonAsync(json, schema);
+
+            Assert.Equal("deep", result["rooted"]!.ToString());
+            Assert.Equal("deep", result["relative"]!.ToString());
+            Assert.Equal("y", result["shallowRooted"]!.ToString());
+            Assert.Equal("y", result["shallowRelative"]!.ToString());
+        }
+
         [Fact]
         public async Task ParsesJsonArrayOfScalarsKeepingNativeTypes()
         {

--- a/WebReaper/Core/Parser/Concrete/JsonContentParser.cs
+++ b/WebReaper/Core/Parser/Concrete/JsonContentParser.cs
@@ -1,6 +1,5 @@
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 using WebReaper.Core.Parser.Abstract;
 using WebReaper.Domain.Parsing;
 
@@ -16,18 +15,19 @@ namespace WebReaper.Core.Parser.Concrete;
 /// original <c>(ILogger)</c> constructor so <c>WithJsonContentParser</c>
 /// and existing callers are unaffected.
 /// <para>
-/// The <c>JToken</c> type argument is the JSON backend's Newtonsoft JSONPath
-/// scope cursor — System.Text.Json has no JSONPath — and is the named ADR-0008
-/// follow-up that gates a zero-warning whole-core <c>PublishAot</c>; it is not
-/// the removed JObject shim.
+/// ADR 0008 named follow-up, now closed: the scope cursor is a
+/// <see cref="JsonNode"/> queried by <see cref="JsonSchemaBackend"/>'s in-repo
+/// JSONPath-subset evaluator. Core no longer reaches Newtonsoft on the JSON
+/// path; the only remaining core Newtonsoft reach is the separate
+/// <c>CookieStore</c> payload-shell sibling.
 /// </para>
 /// </summary>
 public class JsonContentParser : IJsonContentParser
 {
-    private readonly SchemaContentParser<JToken> _inner;
+    private readonly SchemaContentParser<JsonNode> _inner;
 
     public JsonContentParser(ILogger logger)
-        => _inner = new SchemaContentParser<JToken>(new JsonSchemaBackend(), logger);
+        => _inner = new SchemaContentParser<JsonNode>(new JsonSchemaBackend(), logger);
 
     public Task<JsonObject> ParseToJsonAsync(string json, Schema? schema)
         => _inner.ParseToJsonAsync(json, schema);

--- a/WebReaper/Core/Parser/Concrete/JsonSchemaBackend.cs
+++ b/WebReaper/Core/Parser/Concrete/JsonSchemaBackend.cs
@@ -1,5 +1,4 @@
 using System.Text.Json.Nodes;
-using Newtonsoft.Json.Linq;
 using WebReaper.Core.Parser.Abstract;
 using WebReaper.Domain.Parsing;
 
@@ -7,58 +6,104 @@ namespace WebReaper.Core.Parser.Concrete;
 
 /// <summary>
 /// JSON backend for <see cref="SchemaContentParser{TNode}"/> (issue #27 —
-/// scraping JSON endpoints such as the WordPress REST API). The scope
-/// cursor is a Newtonsoft <see cref="JToken"/> and each
-/// <see cref="SchemaElement.Selector"/> is a JSONPath expression
-/// (System.Text.Json has no JSONPath — ADR 0008 Bounded scope; this cursor
-/// is the named follow-up gating a zero-warning whole-core PublishAot).
+/// scraping JSON endpoints such as the WordPress REST API). The scope cursor
+/// is a <see cref="JsonNode"/> and each <see cref="SchemaElement.Selector"/>
+/// is a JSONPath expression.
 /// <para>
-/// ADR 0008: <see cref="ExtractRaw"/> returns the native value already
-/// bridged to a <see cref="System.Text.Json.Nodes.JsonNode"/>. The
-/// Newtonsoft→STJ bridge lives HERE, in the one backend that has a
-/// Newtonsoft token, not in the shared fold — so the fold/typed terminal
-/// carry no Newtonsoft reference (ADR 0002: a backend's document quirk is
-/// backend-local). An untyped leaf still keeps its JSON type (a number
-/// stays a number) — the structured side of the ADR-0002 divergence,
-/// preserved through the bridge.
+/// ADR 0008 named follow-up (now closed): this backend's JSONPath cursor was
+/// the last Newtonsoft <c>JToken</c> reach in core — System.Text.Json has no
+/// JSONPath — and gated a zero-warning whole-core <c>PublishAot</c>. It is now
+/// an in-repo JSONPath-subset evaluator over <see cref="JsonNode"/>: pure
+/// reflection-free traversal, zero dependency, AOT-clean by construction
+/// (proven by <c>WebReaper.AotSmokeTest</c>). The supported dialect is exactly
+/// what the <see cref="Schema"/> model drives — verified against the whole
+/// JSON test corpus — an optional <c>$</c>/<c>$.</c> root anchor,
+/// <c>.</c>-separated property segments, and an optional trailing <c>[*]</c>
+/// array wildcard per segment. No indices, recursion, filters, slices or
+/// unions: Newtonsoft's <c>SelectToken</c>/<c>SelectTokens</c> supported them
+/// but nothing in WebReaper used them (ADR 0002: a backend's document
+/// mechanics are backend-local quirks; the contract is the pinned dialect).
+/// <see cref="ExtractRaw"/> returns the matched node deep-cloned so the fold
+/// can graft it into the output tree; the clone preserves JSON value kind (a
+/// number stays a number) — the structured side of the ADR-0002 untyped-leaf
+/// divergence, previously carried by a Newtonsoft→JsonNode bridge that lived
+/// here and is now deleted (the node is already a <see cref="JsonNode"/>).
 /// </para>
 /// </summary>
-internal sealed class JsonSchemaBackend : ISchemaBackend<JToken>
+internal sealed class JsonSchemaBackend : ISchemaBackend<JsonNode>
 {
-    public Task<JToken> RootAsync(string content) => Task.FromResult(JToken.Parse(content));
+    public Task<JsonNode> RootAsync(string content)
+        => Task.FromResult(JsonNode.Parse(content)
+            ?? throw new InvalidOperationException("JSON document parsed to null"));
 
-    public IEnumerable<JToken> SelectMany(JToken scope, string selector)
-        => scope.SelectTokens(selector);
+    public IEnumerable<JsonNode> SelectMany(JsonNode scope, string selector)
+        => Eval(scope, selector);
 
-    public JToken? SelectOne(JToken scope, string selector)
-        => scope.SelectToken(selector);
+    public JsonNode? SelectOne(JsonNode scope, string selector)
+        => Eval(scope, selector).FirstOrDefault();
 
-    // The native token bridged to a JsonNode (detached from the parsed tree).
-    // Reflection-free: switch on JTokenType, never JToken.ToObject/dynamic.
-    public object? ExtractRaw(JToken node, SchemaElement element) => ToNode(node);
+    // Detached from the parsed tree: a parented JsonNode cannot be re-added,
+    // and the fold grafts this into the output JsonObject/JsonArray. DeepClone
+    // preserves the JSON value kind (number/bool stay native) — the ADR-0002
+    // untyped-leaf divergence, carried natively now instead of via a bridge.
+    public object? ExtractRaw(JsonNode node, SchemaElement element)
+        => node.DeepClone();
 
-    private static JsonNode? ToNode(JToken t) => t.Type switch
+    private static IEnumerable<JsonNode> Eval(JsonNode? scope, string selector)
     {
-        JTokenType.Integer => JsonValue.Create((long)t),
-        JTokenType.Float => JsonValue.Create((double)t),
-        JTokenType.Boolean => JsonValue.Create((bool)t),
-        JTokenType.Null => null,
-        JTokenType.Array => ArrayFrom((JArray)t),
-        JTokenType.Object => ObjectFrom((JObject)t),
-        _ => JsonValue.Create((string?)t ?? string.Empty)
-    };
+        if (scope is null) yield break;
 
-    private static JsonArray ArrayFrom(JArray a)
-    {
-        var arr = new JsonArray();
-        foreach (var e in a) arr.Add(ToNode(e));
-        return arr;
+        IEnumerable<JsonNode?> current = new JsonNode?[] { scope };
+
+        foreach (var (name, wildcard) in Segments(selector))
+            current = Step(current, name, wildcard);
+
+        foreach (var node in current)
+            if (node is not null) yield return node;
     }
 
-    private static JsonObject ObjectFrom(JObject o)
+    private static IEnumerable<JsonNode?> Step(
+        IEnumerable<JsonNode?> nodes, string? name, bool wildcard)
     {
-        var obj = new JsonObject();
-        foreach (var p in o) obj[p.Key] = p.Value is null ? null : ToNode(p.Value);
-        return obj;
+        foreach (var node in nodes)
+        {
+            if (node is null) continue;
+
+            // Property step, unless the segment is a bare "[*]" (name null).
+            var scoped = name is null
+                ? node
+                : node is JsonObject obj && obj.TryGetPropertyValue(name, out var v)
+                    ? v
+                    : null;
+
+            if (scoped is null) continue;
+
+            if (wildcard)
+            {
+                if (scoped is JsonArray array)
+                    foreach (var element in array)
+                        yield return element;
+            }
+            else
+            {
+                yield return scoped;
+            }
+        }
+    }
+
+    private static IEnumerable<(string? Name, bool Wildcard)> Segments(string selector)
+    {
+        var s = selector.Trim();
+        if (s.StartsWith('$')) s = s[1..];
+        s = s.TrimStart('.');
+        if (s.Length == 0) yield break;
+
+        foreach (var raw in s.Split('.', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var part = raw;
+            var wildcard = part.EndsWith("[*]", StringComparison.Ordinal);
+            if (wildcard) part = part[..^3];
+            yield return (part.Length == 0 ? null : part, wildcard);
+        }
     }
 }

--- a/WebReaper/WebReaper.csproj
+++ b/WebReaper/WebReaper.csproj
@@ -16,7 +16,7 @@
     <PackageTags>scraper, crawler, parser</PackageTags>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <Version>7.0.0</Version>
-    <PackageReleaseNotes>7.0.0 (breaking, major): heavy third-party adapters move into per-technology satellite packages so the core stays dependency-light. WebReaper.Cosmos: WriteToCosmosDb and CosmosSink out of core (core no longer references Microsoft.Azure.Cosmos). WebReaper.Mongo: WriteToMongoDb / WithMongoDbConfigStorage / WithMongoDbCookieStorage and the MongoDbSink / MongoDbScraperConfigStorage / MongoDbCookieStorage / MongoBlobStore adapters out of core (core no longer references MongoDB.Driver, shedding its transitive SharpCompress GHSA-6c8g-7p36-r338). WebReaper.Redis: WithRedisScheduler / TrackVisitedLinksInRedis / WriteToRedis / WithRedisConfigStorage / WithRedisCookieStorage and the RedisScheduler / RedisVisitedLinkTracker / RedisSink / RedisScraperConfigStorage / RedisCookieStorage / RedisBlobStore / RedisConnectionPool adapters out of core (core no longer references StackExchange.Redis; the ADR-0005 one-multiplexer-per-connection-string invariant is preserved intra-package). WebReaper.AzureServiceBus: WithAzureServiceBusScheduler and the AzureServiceBusScheduler adapter out of core (core no longer references Azure.Messaging.ServiceBus). WebReaper.Puppeteer: the headless-browser page loader (BrowserPageLoadTransport, CookieExtensions/ToPuppeteerCookies) out of core behind the new ScraperEngineBuilder.WithLoadTransport seam, exposed as .WithPuppeteerPageLoader(); the core default page loader is HTTP-only and core no longer references PuppeteerSharp/PuppeteerExtraSharp or the Chromium provisioning path, carrying the ADR-0008-named BrowserPageLoadTransport Assembly.Location IL3000 finding out of core with it. All moved types are repackaged under namespace WebReaper.Cosmos / WebReaper.Mongo / WebReaper.Redis / WebReaper.AzureServiceBus / WebReaper.Puppeteer. Clean cut, no compat forwarders. ADR-0009 capstone: SpiderBuilder is now internal (its duplicate public adapter surface removed); the bare ISpider for the distributed-worker pattern is the new public ScraperEngineBuilder.BuildSpider(). Add the satellite package and a using to migrate. Rationale and migration: docs/adr/0009 and CHANGELOG.md.</PackageReleaseNotes>
+    <PackageReleaseNotes>7.0.0 (breaking, major): heavy third-party adapters move into per-technology satellite packages so the core stays dependency-light. WebReaper.Cosmos: WriteToCosmosDb and CosmosSink out of core (core no longer references Microsoft.Azure.Cosmos). WebReaper.Mongo: WriteToMongoDb / WithMongoDbConfigStorage / WithMongoDbCookieStorage and the MongoDbSink / MongoDbScraperConfigStorage / MongoDbCookieStorage / MongoBlobStore adapters out of core (core no longer references MongoDB.Driver, shedding its transitive SharpCompress GHSA-6c8g-7p36-r338). WebReaper.Redis: WithRedisScheduler / TrackVisitedLinksInRedis / WriteToRedis / WithRedisConfigStorage / WithRedisCookieStorage and the RedisScheduler / RedisVisitedLinkTracker / RedisSink / RedisScraperConfigStorage / RedisCookieStorage / RedisBlobStore / RedisConnectionPool adapters out of core (core no longer references StackExchange.Redis; the ADR-0005 one-multiplexer-per-connection-string invariant is preserved intra-package). WebReaper.AzureServiceBus: WithAzureServiceBusScheduler and the AzureServiceBusScheduler adapter out of core (core no longer references Azure.Messaging.ServiceBus). WebReaper.Puppeteer: the headless-browser page loader (BrowserPageLoadTransport, CookieExtensions/ToPuppeteerCookies) out of core behind the new ScraperEngineBuilder.WithLoadTransport seam, exposed as .WithPuppeteerPageLoader(); the core default page loader is HTTP-only and core no longer references PuppeteerSharp/PuppeteerExtraSharp or the Chromium provisioning path, carrying the ADR-0008-named BrowserPageLoadTransport Assembly.Location IL3000 finding out of core with it. All moved types are repackaged under namespace WebReaper.Cosmos / WebReaper.Mongo / WebReaper.Redis / WebReaper.AzureServiceBus / WebReaper.Puppeteer. Clean cut, no compat forwarders. ADR-0009 capstone: SpiderBuilder is now internal (its duplicate public adapter surface removed); the bare ISpider for the distributed-worker pattern is the new public ScraperEngineBuilder.BuildSpider(). ADR-0008 JSONPath follow-up closed: JsonSchemaBackend's Newtonsoft JToken cursor is migrated to an in-repo JSONPath-subset evaluator over System.Text.Json.Nodes.JsonNode (dialect preserved); with CookieStore already on System.Text.Json, core is now FULLY Newtonsoft-free (the Newtonsoft.Json PackageReference is dropped) and the whole core publishes Native-AOT zero-warning. Consumers that free-rode on core's transitive Newtonsoft.Json must now reference it directly. Add the satellite package and a using to migrate. Rationale and migration: docs/adr/0009 and CHANGELOG.md.</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>$(MSBuildProjectDirectory)\API.xml</DocumentationFile>
     <LangVersion>12</LangVersion>
@@ -24,10 +24,12 @@
 
     <!-- ADR 0008: the library declares AOT-compatibility so consumers can
          PublishAot it and so the trim/AOT analyzers run on every core build
-         and catch regressions. NOT a zero-warning guarantee yet: the named
-         follow-ups (JsonSchemaBackend's Newtonsoft JSONPath cursor, the
-         CookieStore payload shell, the [Obsolete] JObject shim) still reach
-         Newtonsoft and emit IL warnings by design until migrated. ADR 0009
+         and catch regressions. Core is now FULLY Newtonsoft-free: the
+         ADR-0008-named JSONPath follow-up is closed (JsonSchemaBackend's
+         Newtonsoft JToken cursor migrated to an in-repo JSONPath-subset
+         evaluator over System.Text.Json.Nodes.JsonNode), CookieStore is on
+         System.Text.Json, the [Obsolete] JObject shim was removed at 6.0.0,
+         and the Newtonsoft.Json PackageReference is dropped. ADR 0009
          moved CosmosSink out to WebReaper.Cosmos (Cosmos -> Newtonsoft +
          native ServiceInterop graph off the core) and the Mongo adapters out
          to WebReaper.Mongo (MongoDB.Driver + its transitive SharpCompress
@@ -38,8 +40,10 @@
          WebReaper.Puppeteer (PuppeteerSharp/PuppeteerExtraSharp + the Chromium
          provisioning path off the core, carrying the ADR-0008-named
          BrowserPageLoadTransport Assembly.Location IL3000 finding with it;
-         core is HTTP-only by default). The Newtonsoft-free path is proven
-         zero-warning by WebReaper.AotSmokeTest. -->
+         core is HTTP-only by default). With core fully Newtonsoft-free, the
+         WHOLE core (not only a scoped path) publishes Native-AOT
+         zero-warning — proven by WebReaper.AotSmokeTest, which now also
+         exercises the JSON backend's JSONPath cursor. -->
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
@@ -54,7 +58,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Newtonsoft.Json" />
     <None Remove="Fizzler.Systems.HtmlAgilityPack" />
     <None Remove="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
@@ -62,7 +65,6 @@
     <PackageReference Include="AngleSharp" Version="1.4.0" />
     <PackageReference Include="AngleSharp.XPath" Version="2.0.6" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Polly" Version="8.6.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
   </ItemGroup>

--- a/docs/adr/0008-system-text-json-typed-pipeline.md
+++ b/docs/adr/0008-system-text-json-typed-pipeline.md
@@ -346,3 +346,51 @@ and both it and `CrawlStep.cs` carried a dangling `<see cref="IContentParser"/>`
 `IContentParser`/`JObject` path was removed outright at 6.0.0, cref dropped.
 Comment-only — no behavioural/IL change. `SchemaContentParser.cs`'s doc was
 already accurate and was left untouched.
+
+## JSONPath follow-up closed (2026-05-17)
+
+The named follow-up this ADR repeatedly defers — *"the JSON backend's
+Newtonsoft `JToken` JSONPath cursor … the named follow-up that gates
+zero-warning core `PublishAot`"* (Discovered constraint; Bounded scope) — is
+**now implemented**, after the ADR-0009 satellite split (Cosmos/Mongo/Redis/
+Azure Service Bus/Puppeteer) and the `SpiderBuilder`-internal capstone landed.
+
+**What shipped.** `JsonSchemaBackend` no longer uses Newtonsoft. `RootAsync`
+is `JsonNode.Parse`; `SelectMany`/`SelectOne` are an in-repo JSONPath-subset
+evaluator over `System.Text.Json.Nodes.JsonNode`; `ExtractRaw` returns the
+matched node `DeepClone()`d (detached so the fold can graft it; the clone
+preserves JSON value kind — the ADR-0002 untyped-leaf divergence, now carried
+natively, the old `JTokenType`→`JsonNode` bridge deleted). The chosen option
+was the **in-repo evaluator, not a JSONPath dependency**: the only dialect the
+`Schema` model drives — an optional `$`/`$.` root, `.`-separated property
+segments, a trailing `[*]` array wildcard — is small and fully pinned by the
+JSON test corpus (`JsonParsingTests`/`SchemaFoldTests`/`TypedFoldTests`), and
+a new core dependency would have contradicted the ADR-0009 dependency-light
+result while an RFC-9535 library would have rejected WebReaper's relative
+(non-`$`) selectors anyway. Behaviour is preserved (the JSON suite is green
+unmodified, plus an added `$`-vs-relative / deep-path characterization test);
+the deliverable is proven by `WebReaper.AotSmokeTest`, **extended to drive the
+JSON backend** (it previously avoided it by design) — RED before
+(`IL2104`/`IL3053` Newtonsoft rollup), green after.
+
+**Bounded-scope prose was stale (docs-follow-code, as above).** This ADR's
+*Bounded scope* names `CookieStore` as a Newtonsoft sibling *"preserved
+verbatim here"*. Verified against shipped `master`: `CookieStore` already
+serialises via the `WebReaperJson` System.Text.Json source-gen over a flat
+`CookieDto` — *"no Newtonsoft"* per its own doc. It was migrated with the
+6.0.0 typed pipeline; the *Bounded scope* sentence lagged the code (same
+doc-lag class as the Post-release correction). Consequently, with the
+JSONPath cursor migrated, **core has zero Newtonsoft code reach**: the
+`Newtonsoft.Json` `PackageReference` is dropped from `WebReaper.csproj`, and
+the *whole* core (not the scoped Newtonsoft-free path this ADR could
+originally promise) publishes Native-AOT zero-warning. The "necessary but not
+sufficient" / "gated on a separate JSONPath migration" qualifications
+throughout this ADR are now **satisfied**. (`WebReaper.Cosmos`'s `CosmosSink`
+is still Newtonsoft-coupled via the Cosmos SDK — that is the satellite, off
+the core graph by ADR-0009, and deliberately not `IsAotCompatible`.)
+
+**Unaffected.** The Schema fold, the typed terminal, the STJ source-gen
+config/scheduler grammar, and every ADR-0002/0003/0005 structural result are
+unchanged; only the JSON backend's document-local cursor changed (ADR-0002:
+a backend's mechanics are backend-local), and a now-dead `PackageReference`
+was removed.

--- a/docs/adr/0009-registration-seam-and-satellite-adapters.md
+++ b/docs/adr/0009-registration-seam-and-satellite-adapters.md
@@ -132,7 +132,10 @@ guardrail that this stays consistent.
   transitive deps; a zero-warning core `PublishAot` remains **gated on ADR
   0008's named JSONPath-for-STJ migration**. Necessary surface reduction,
   not the AOT gate itself — the ADR 0008 "necessary but not sufficient"
-  posture, restated.
+  posture, restated. **(Update 2026-05-17: that gate is now closed — the
+  JSONPath cursor was migrated to an in-repo `JsonNode` evaluator and core is
+  fully Newtonsoft-free; see ADR-0008's "JSONPath follow-up closed" note. The
+  ADR-0009 work itself is unchanged by this.)**
 - **The seam interfaces.** `IScraperSink`, `IScheduler`,
   `IKeyedBlobStore`, `ICookiesStorage`, `IVisitedLinkTracker`,
   `ISchemaBackend<TNode>`, `IPageLoader`/`IPageLoadTransport` are unchanged.


### PR DESCRIPTION
Closes the **ADR-0008-named follow-up** that gated a zero-warning core `PublishAot`: `JsonSchemaBackend`'s Newtonsoft `JToken` JSONPath cursor — the last Newtonsoft reach in core — is replaced by an in-repo JSONPath-subset evaluator over `System.Text.Json.Nodes.JsonNode`.

## What changed
- `RootAsync` → `JsonNode.Parse`; `SelectMany`/`SelectOne` → a ~40-line reflection-free evaluator; `ExtractRaw` → matched node `DeepClone()`d (detached so the fold can graft it; the clone preserves JSON value kind — the ADR-0002 untyped-leaf divergence, now carried natively; the old `JTokenType`→`JsonNode` bridge is **deleted**).
- **Dialect preserved exactly** — optional `$`/`$.` root, `.`-separated property paths, trailing `[*]` array wildcard — the entire surface the `Schema` model drives, pinned by the JSON test corpus. In-repo, not a JSONPath dependency: a new core dep would contradict the ADR-0009 dependency-light result, and an RFC-9535 library rejects WebReaper's relative (non-`$`) selectors anyway.

## Bigger than planned (verified from source)
`CookieStore` was **already** on System.Text.Json — ADR-0008's *Bounded scope* prose naming it a still-Newtonsoft sibling was stale doc-lag (same class as that ADR's own Post-release correction). So migrating the cursor leaves **zero Newtonsoft code reach in core**: the `Newtonsoft.Json` `PackageReference` is dropped and the *whole* core (not just a scoped path) publishes Native-AOT zero-warning. `Misc/WebReaper.ProxyProviders` (which free-rode on core's transitive Newtonsoft) now declares it directly — the ADR-0009 consumer-reconcile pattern. `WebReaper.Cosmos`'s `CosmosSink` stays Newtonsoft-coupled via the Cosmos SDK; that satellite is off the core graph by ADR-0009.

## TDD honest-RED→GREEN
- Characterization test pins `$`-vs-relative / deep-path equivalence **GREEN on the old Newtonsoft impl** (spec lock before refactor).
- Tracer: the AOT smoke test, **extended to drive `JsonContentParser`** (it previously avoided it by design), goes **RED** with `error IL2104`/`IL3053` (Newtonsoft assembly rollup) before, **GREEN** after — clean publish, smoke **9/9** incl. the new *"JSON backend JSONPath cursor (Newtonsoft-free, AOT-clean)"*.

## Guardrail (all green)
- Whole-solution Release: **0 errors**.
- Unit **62/62** (behavior preserved through the refactor + 1 new characterization test); Cosmos 1 / Mongo 3 / Redis 8 / AzureServiceBus 1 / Puppeteer 4/4.
- AOT publish clean; smoke **9/9** exit 0.
- **Core pulls zero Newtonsoft** — authoritative (`dotnet list WebReaper/WebReaper.csproj package --include-transitive`): PackageReference + transitive.

## Docs
ADR-0008 *"JSONPath follow-up closed (2026-05-17)"* note (docs-follow-code, incl. the stale `CookieStore` prose correction); ADR-0009 gate pointer; core csproj `IsAotCompatible` comment + `PackageReleaseNotes`; CHANGELOG (under the unreleased 7.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)