### PR TITLE
Polish satellite NuGet packaging: README, icon, release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,12 @@ the JSON backend. Rationale and the doc-lag correction:
   references it. WebReaper's own APIs are `System.Text.Json` throughout, so a
   consumer that does not use Newtonsoft itself needs no change.
 
+No code or API change, listing only: each satellite package
+(`WebReaper.Cosmos` / `.Mongo` / `.Redis` / `.AzureServiceBus` / `.Puppeteer`)
+now ships a focused README, the shared WebReaper icon, and release notes in its
+`.nupkg`, so its nuget.org page renders like the core package's instead of
+blank.
+
 ## 6.0.0 — System.Text.Json typed pipeline (breaking, AOT-clean)
 
 The extraction and persistence pipeline moved off `Newtonsoft.Json` +

--- a/WebReaper.AzureServiceBus/README.md
+++ b/WebReaper.AzureServiceBus/README.md
@@ -1,0 +1,40 @@
+# WebReaper.AzureServiceBus
+
+Azure Service Bus scheduler for
+[WebReaper](https://github.com/pavlovtech/WebReaper): a distributed job queue
+backed by an Azure Service Bus queue, for sharing crawl state across workers
+and serverless functions.
+
+Satellite package (ADR-0009): the Azure Service Bus scheduler is kept out of
+the WebReaper core so the core stays dependency-light and Native-AOT-clean.
+
+## Install
+
+```
+dotnet add package WebReaper.AzureServiceBus
+```
+
+Pulls `WebReaper` (the core) as a dependency.
+
+## Usage
+
+Adds `WithAzureServiceBusScheduler(...)` to `ScraperEngineBuilder`:
+
+```csharp
+using WebReaper.Builders;
+using WebReaper.AzureServiceBus;
+
+var engine = await new ScraperEngineBuilder()
+    .Get("https://example.com/catalog")
+    .Parse(new() { new("title", "h1"), new("price", ".price") })
+    .WithAzureServiceBusScheduler(
+        connectionString: "<service-bus-connection-string>",
+        queueName: "scrape-jobs")
+    .BuildAsync();
+
+await engine.RunAsync();
+```
+
+## License
+
+GPL-3.0-or-later. Part of the WebReaper project.

--- a/WebReaper.AzureServiceBus/WebReaper.AzureServiceBus.csproj
+++ b/WebReaper.AzureServiceBus/WebReaper.AzureServiceBus.csproj
@@ -17,12 +17,20 @@
     <PackageProjectUrl>https://github.com/pavlovtech/WebReaper</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pavlovtech/WebReaper</RepositoryUrl>
     <PackageTags>scraper, crawler, parser, azure, servicebus, distributed</PackageTags>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>7.0.0: initial release. Azure Service Bus distributed scheduler (ScraperEngineBuilder.WithAzureServiceBusScheduler) extracted from the WebReaper core per ADR-0009 so the core stays dependency-light and Native-AOT-clean (core no longer references Azure.Messaging.ServiceBus). Requires WebReaper 7.0.0.</PackageReleaseNotes>
 
     <!-- ADR 0009: the Azure Service Bus satellite is deliberately NOT
          IsAotCompatible. Quarantining the Azure Service Bus scheduler here is
          exactly why the core stays dependency-light — a core-only consumer no
          longer pulls Azure.Messaging.ServiceBus. -->
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\WebReaper\logo.png" Pack="true" PackagePath="" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\WebReaper\WebReaper.csproj" />

--- a/WebReaper.Cosmos/README.md
+++ b/WebReaper.Cosmos/README.md
@@ -1,0 +1,42 @@
+# WebReaper.Cosmos
+
+Azure Cosmos DB sink for [WebReaper](https://github.com/pavlovtech/WebReaper).
+
+Satellite package (ADR-0009): the Cosmos sink is kept out of the WebReaper
+core so the core stays dependency-light and Native-AOT-clean. The Cosmos SDK
+drags Newtonsoft.Json and a native interop graph, so this package is
+deliberately not AOT-guaranteed — installing it is opting into that.
+
+## Install
+
+```
+dotnet add package WebReaper.Cosmos
+```
+
+Pulls `WebReaper` (the core) as a dependency.
+
+## Usage
+
+Adds `WriteToCosmosDb(...)` to `ScraperEngineBuilder`:
+
+```csharp
+using WebReaper.Builders;
+using WebReaper.Cosmos;
+
+var engine = await new ScraperEngineBuilder()
+    .Get("https://example.com/catalog")
+    .Parse(new() { new("title", "h1"), new("price", ".price") })
+    .WriteToCosmosDb(
+        endpointUrl: "https://my-account.documents.azure.com:443/",
+        authorizationKey: "<key>",
+        databaseId: "scrape",
+        containerId: "items",
+        dataCleanupOnStart: false)
+    .BuildAsync();
+
+await engine.RunAsync();
+```
+
+## License
+
+GPL-3.0-or-later. Part of the WebReaper project.

--- a/WebReaper.Cosmos/WebReaper.Cosmos.csproj
+++ b/WebReaper.Cosmos/WebReaper.Cosmos.csproj
@@ -17,6 +17,9 @@
     <PackageProjectUrl>https://github.com/pavlovtech/WebReaper</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pavlovtech/WebReaper</RepositoryUrl>
     <PackageTags>scraper, crawler, parser, cosmosdb, azure</PackageTags>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>7.0.0: initial release. Azure Cosmos DB sink (ScraperEngineBuilder.WriteToCosmosDb) extracted from the WebReaper core per ADR-0009 so the core stays dependency-light and Native-AOT-clean (core no longer references Microsoft.Azure.Cosmos). Requires WebReaper 7.0.0.</PackageReleaseNotes>
 
     <!-- ADR 0009: the Cosmos satellite is deliberately NOT IsAotCompatible.
          The Cosmos SDK drags Newtonsoft + native ServiceInterop; CosmosSink is
@@ -24,6 +27,11 @@
          scope). Quarantining it in this package is exactly why the core stays
          dependency-light and AOT-clean. -->
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\WebReaper\logo.png" Pack="true" PackagePath="" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\WebReaper\WebReaper.csproj" />

--- a/WebReaper.Mongo/README.md
+++ b/WebReaper.Mongo/README.md
@@ -1,0 +1,43 @@
+# WebReaper.Mongo
+
+MongoDB adapters for [WebReaper](https://github.com/pavlovtech/WebReaper): a
+result sink, plus MongoDB-backed scraper-config and cookie storage.
+
+Satellite package (ADR-0009): the Mongo adapters are kept out of the WebReaper
+core so the core stays dependency-light and Native-AOT-clean. MongoDB.Driver's
+BSON serialization is reflection-based and not trim/AOT-clean, so this package
+is deliberately not AOT-guaranteed.
+
+## Install
+
+```
+dotnet add package WebReaper.Mongo
+```
+
+Pulls `WebReaper` (the core) as a dependency.
+
+## Usage
+
+Adds `WriteToMongoDb`, `WithMongoDbConfigStorage` and
+`WithMongoDbCookieStorage` to `ScraperEngineBuilder`:
+
+```csharp
+using WebReaper.Builders;
+using WebReaper.Mongo;
+
+var engine = await new ScraperEngineBuilder()
+    .Get("https://example.com/catalog")
+    .Parse(new() { new("title", "h1"), new("price", ".price") })
+    .WriteToMongoDb(
+        connectionString: "mongodb://localhost:27017",
+        databaseName: "scrape",
+        collectionName: "items",
+        dataCleanupOnStart: false)
+    .BuildAsync();
+
+await engine.RunAsync();
+```
+
+## License
+
+GPL-3.0-or-later. Part of the WebReaper project.

--- a/WebReaper.Mongo/WebReaper.Mongo.csproj
+++ b/WebReaper.Mongo/WebReaper.Mongo.csproj
@@ -17,6 +17,9 @@
     <PackageProjectUrl>https://github.com/pavlovtech/WebReaper</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pavlovtech/WebReaper</RepositoryUrl>
     <PackageTags>scraper, crawler, parser, mongodb, mongo</PackageTags>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>7.0.0: initial release. MongoDB sink and MongoDB-backed scraper-config and cookie storage (ScraperEngineBuilder.WriteToMongoDb / WithMongoDbConfigStorage / WithMongoDbCookieStorage) extracted from the WebReaper core per ADR-0009 so the core stays dependency-light and Native-AOT-clean (core no longer references MongoDB.Driver). Requires WebReaper 7.0.0.</PackageReleaseNotes>
 
     <!-- ADR 0009: the Mongo satellite is deliberately NOT IsAotCompatible.
          MongoDB.Driver's BSON serialization is reflection-based and not
@@ -24,6 +27,11 @@
          the core stays dependency-light and AOT-clean — a core-only consumer
          no longer pulls MongoDB.Driver (nor the SharpCompress graph below). -->
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\WebReaper\logo.png" Pack="true" PackagePath="" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\WebReaper\WebReaper.csproj" />

--- a/WebReaper.Puppeteer/README.md
+++ b/WebReaper.Puppeteer/README.md
@@ -1,0 +1,42 @@
+# WebReaper.Puppeteer
+
+Headless-browser (Puppeteer/Chromium) page-load transport for
+[WebReaper](https://github.com/pavlovtech/WebReaper), for scraping
+JavaScript-rendered pages.
+
+Satellite package (ADR-0009): the headless-browser transport is kept out of
+the WebReaper core so the core stays dependency-light and Native-AOT-clean.
+The core is HTTP-only by default; **install this package and call
+`.WithPuppeteerPageLoader()` to scrape Dynamic pages** (`GetWithBrowser` /
+`FollowWithBrowser` / `PaginateWithBrowser`) — without it a Dynamic load
+throws an actionable message. The first Dynamic run downloads Chromium.
+
+## Install
+
+```
+dotnet add package WebReaper.Puppeteer
+```
+
+Pulls `WebReaper` (the core) as a dependency.
+
+## Usage
+
+Adds `WithPuppeteerPageLoader()` to `ScraperEngineBuilder`:
+
+```csharp
+using WebReaper.Builders;
+using WebReaper.Puppeteer;
+
+var engine = await new ScraperEngineBuilder()
+    .WithPuppeteerPageLoader()
+    .GetWithBrowser("https://example.com/blog")
+    .FollowWithBrowser(".post-link")
+    .Parse(new() { new("title", "h1"), new("text", "article") })
+    .BuildAsync();
+
+await engine.RunAsync();
+```
+
+## License
+
+GPL-3.0-or-later. Part of the WebReaper project.

--- a/WebReaper.Puppeteer/WebReaper.Puppeteer.csproj
+++ b/WebReaper.Puppeteer/WebReaper.Puppeteer.csproj
@@ -17,6 +17,9 @@
     <PackageProjectUrl>https://github.com/pavlovtech/WebReaper</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pavlovtech/WebReaper</RepositoryUrl>
     <PackageTags>scraper, crawler, parser, puppeteer, headless, browser, chromium</PackageTags>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>7.0.0: initial release. Headless-browser (Puppeteer/Chromium) page-load transport (ScraperEngineBuilder.WithPuppeteerPageLoader) extracted from the WebReaper core per ADR-0009 so the core stays dependency-light, Native-AOT-clean and HTTP-only by default (core no longer references PuppeteerSharp/PuppeteerExtraSharp or the Chromium provisioning path). Requires WebReaper 7.0.0.</PackageReleaseNotes>
 
     <!-- ADR 0009: the Puppeteer satellite is deliberately NOT IsAotCompatible.
          Quarantining the headless-browser transport here is exactly why the
@@ -28,6 +31,11 @@
          ADR 0004's one-IPageLoader / two-IPageLoadTransport seam is unchanged —
          only the default composition of the Dynamic slot moved out of core. -->
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\WebReaper\logo.png" Pack="true" PackagePath="" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\WebReaper\WebReaper.csproj" />

--- a/WebReaper.Redis/README.md
+++ b/WebReaper.Redis/README.md
@@ -1,0 +1,44 @@
+# WebReaper.Redis
+
+Redis adapters for [WebReaper](https://github.com/pavlovtech/WebReaper): a
+distributed scheduler, visited-link tracker, result sink, and Redis-backed
+scraper-config and cookie storage. Swapping the scheduler + config storage +
+link tracker to Redis lets multiple workers share crawl state.
+
+Satellite package (ADR-0009): the Redis adapters are kept out of the WebReaper
+core so the core stays dependency-light and Native-AOT-clean. All adapters in
+this package share one `ConnectionMultiplexer` per connection string
+(ADR-0005), preserved intra-package.
+
+## Install
+
+```
+dotnet add package WebReaper.Redis
+```
+
+Pulls `WebReaper` (the core) as a dependency.
+
+## Usage
+
+Adds `WriteToRedis`, `WithRedisScheduler`, `TrackVisitedLinksInRedis`,
+`WithRedisConfigStorage` and `WithRedisCookieStorage` to
+`ScraperEngineBuilder`:
+
+```csharp
+using WebReaper.Builders;
+using WebReaper.Redis;
+
+var engine = await new ScraperEngineBuilder()
+    .Get("https://example.com/catalog")
+    .Parse(new() { new("title", "h1"), new("price", ".price") })
+    .WithRedisScheduler("localhost:6379", queueName: "jobs")
+    .TrackVisitedLinksInRedis("localhost:6379", redisKey: "visited")
+    .WriteToRedis("localhost:6379", redisKey: "results")
+    .BuildAsync();
+
+await engine.RunAsync();
+```
+
+## License
+
+GPL-3.0-or-later. Part of the WebReaper project.

--- a/WebReaper.Redis/WebReaper.Redis.csproj
+++ b/WebReaper.Redis/WebReaper.Redis.csproj
@@ -17,6 +17,9 @@
     <PackageProjectUrl>https://github.com/pavlovtech/WebReaper</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pavlovtech/WebReaper</RepositoryUrl>
     <PackageTags>scraper, crawler, parser, redis, distributed</PackageTags>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>7.0.0: initial release. Redis scheduler, visited-link tracker, sink and Redis-backed scraper-config and cookie storage (ScraperEngineBuilder.WithRedisScheduler / TrackVisitedLinksInRedis / WriteToRedis / WithRedisConfigStorage / WithRedisCookieStorage), all sharing one ConnectionMultiplexer per connection string (ADR-0005). Extracted from the WebReaper core per ADR-0009 so the core stays dependency-light and Native-AOT-clean (core no longer references StackExchange.Redis). Requires WebReaper 7.0.0.</PackageReleaseNotes>
 
     <!-- ADR 0009: the Redis satellite is deliberately NOT IsAotCompatible.
          Quarantining the Redis adapters here is exactly why the core stays
@@ -26,6 +29,11 @@
          here whole and stays the single resolver every Redis adapter in this
          package goes through. -->
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\WebReaper\logo.png" Pack="true" PackagePath="" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\WebReaper\WebReaper.csproj" />


### PR DESCRIPTION
## Why

The 5 ADR-0009 satellite packages (`WebReaper.Cosmos` / `.Mongo` / `.Redis` / `.AzureServiceBus` / `.Puppeteer`) carried only minimal package metadata. Their nuget.org pages would render with **no readme, no icon, no release notes** — unlike the core `WebReaper` package. Since the whole point of ADR-0009 is that consumers `dotnet add package WebReaper.<Tech>`, those listings are the consumer's first contact with the split. This is the "polish satellites first" step before any 7.0.0 publish.

## What

Per satellite `.csproj`: add `PackageReadmeFile`, `PackageIcon`, `PackageReleaseNotes`, and a pack `ItemGroup` for a focused per-package `README.md` plus the shared core logo (`..\WebReaper\logo.png`, no file duplicated into each dir).

Each README is written against the extension-method signatures **verified from source** (`CosmosSinkBuilderExtensions` etc.), not from csproj `<Description>` prose: install line, a minimal honest builder snippet, the satellite rationale, GPL-3.0-or-later.

One non-breaking CHANGELOG note under the existing 7.0.0 Migration section.

**No code or API change.** `ProjectReference`→core still resolves to a `WebReaper` 7.0.0 package dependency at pack time.

## Verification

- Whole-solution Release build: **0 errors** (pre-existing warnings only).
- Tests: Unit 62, Cosmos 1, Mongo 3, Redis 8, ASB 1, Puppeteer 4 — all green.
- AOT publish zero-warning + smoke **9/9 exit 0**.
- Core still pulls **zero Newtonsoft** (this PR touches no core deps).
- `dotnet pack` of all 6 packages inspected: each satellite `.nupkg` carries `README.md` + `logo.png` at root and a nuspec with `<readme>`, `<icon>` and the `WebReaper 7.0.0` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)