### PR TITLE
Add FilePersistencePrep; migrate FileBlobStore (#56)

### DIFF
--- a/WebReaper.Tests/WebReaper.UnitTests/FilePersistencePrepTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/FilePersistencePrepTests.cs
@@ -1,0 +1,96 @@
+using WebReaper.DataAccess;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0011: the three pre-write responsibilities, asserted once at the
+// helper's own interface (the deduplicated home of a previously copy-pasted,
+// bug-prone policy). FilePersistencePrep is internal; this assembly has
+// InternalsVisibleTo access.
+public class FilePersistencePrepTests
+{
+    private static string FreshRoot() =>
+        Path.Combine(Path.GetTempPath(), $"wr-fpp-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void EnsureDirectory_creates_missing_nested_directory()
+    {
+        var root = FreshRoot();
+        try
+        {
+            var path = Path.Combine(root, "a", "b", "c.txt"); // a/, b/ do not exist
+            FilePersistencePrep.EnsureDirectory(path);
+            Assert.True(Directory.Exists(Path.GetDirectoryName(path)));
+        }
+        finally { if (Directory.Exists(root)) Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void EnsureDirectory_is_idempotent_and_tolerates_a_bare_filename()
+    {
+        var root = FreshRoot();
+        try
+        {
+            var path = Path.Combine(root, "x.txt");
+            FilePersistencePrep.EnsureDirectory(path);
+            FilePersistencePrep.EnsureDirectory(path);          // second call: no throw
+            FilePersistencePrep.EnsureDirectory("bare-name.txt"); // no directory part: no throw
+            Assert.True(Directory.Exists(root));
+        }
+        finally { if (Directory.Exists(root)) Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void CleanupOnStart_deletes_an_existing_file_when_true_with_zero_writes()
+    {
+        var root = FreshRoot();
+        try
+        {
+            Directory.CreateDirectory(root);
+            var path = Path.Combine(root, "stale.txt");
+            File.WriteAllText(path, "stale");
+
+            FilePersistencePrep.CleanupOnStart(path, dataCleanupOnStart: true);
+
+            Assert.False(File.Exists(path)); // gone deterministically, no write needed
+        }
+        finally { if (Directory.Exists(root)) Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void CleanupOnStart_keeps_the_file_when_false()
+    {
+        var root = FreshRoot();
+        try
+        {
+            Directory.CreateDirectory(root);
+            var path = Path.Combine(root, "keep.txt");
+            File.WriteAllText(path, "keep");
+
+            FilePersistencePrep.CleanupOnStart(path, dataCleanupOnStart: false);
+
+            Assert.True(File.Exists(path));
+        }
+        finally { if (Directory.Exists(root)) Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public async Task ReadAllTextOrNullAsync_returns_null_for_an_absent_file()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"wr-fpp-absent-{Guid.NewGuid():N}.txt");
+        Assert.Null(await FilePersistencePrep.ReadAllTextOrNullAsync(path));
+    }
+
+    [Fact]
+    public async Task ReadAllTextOrNullAsync_returns_content_for_a_present_file()
+    {
+        var root = FreshRoot();
+        try
+        {
+            Directory.CreateDirectory(root);
+            var path = Path.Combine(root, "p.txt");
+            await File.WriteAllTextAsync(path, "hello");
+            Assert.Equal("hello", await FilePersistencePrep.ReadAllTextOrNullAsync(path));
+        }
+        finally { if (Directory.Exists(root)) Directory.Delete(root, true); }
+    }
+}

--- a/WebReaper.Tests/WebReaper.UnitTests/KeyedBlobStoreTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/KeyedBlobStoreTests.cs
@@ -78,4 +78,28 @@ public class KeyedBlobStoreTests
             Assert.Equal(payload, await store.GetAsync(key));
         }
     }
+
+    // ADR-0011 bug fix, pinned through the public IKeyedBlobStore interface:
+    // FileBlobStore's key IS the path; a key in a not-yet-existing directory
+    // previously threw (no directory creation). FilePersistencePrep now
+    // ensures the directory eagerly, so this round-trips.
+    [Fact]
+    public async Task FileBlobStore_Put_to_a_key_in_a_missing_directory_succeeds()
+    {
+        var root = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), $"wr-blob-nested-{Guid.NewGuid():N}");
+        try
+        {
+            var key = System.IO.Path.Combine(root, "nested", "config.json"); // dir absent
+            var store = new FileBlobStore();
+
+            await store.PutAsync(key, "v"); // previously threw DirectoryNotFoundException
+
+            Assert.Equal("v", await store.GetAsync(key));
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, true);
+        }
+    }
 }

--- a/WebReaper/DataAccess/FileBlobStore.cs
+++ b/WebReaper/DataAccess/FileBlobStore.cs
@@ -5,12 +5,20 @@ namespace WebReaper.DataAccess;
 /// path — this preserves the historical
 /// <c>new FileScraperConfigStorage("config.json")</c> behaviour of writing to
 /// exactly that file. UTF-8, no BOM (the <see cref="File"/> default).
+///
+/// Directory creation and the missing-file policy are delegated to
+/// <see cref="FilePersistencePrep"/> (ADR-0011); whole-file replace
+/// (last-write-wins) is this adapter's own essence. No lock is taken — the
+/// engine writes a config once at build time.
 /// </summary>
 public class FileBlobStore : IKeyedBlobStore
 {
     public Task PutAsync(string key, string value)
-        => File.WriteAllTextAsync(key, value);
+    {
+        FilePersistencePrep.EnsureDirectory(key);
+        return File.WriteAllTextAsync(key, value);
+    }
 
-    public async Task<string?> GetAsync(string key)
-        => File.Exists(key) ? await File.ReadAllTextAsync(key) : null;
+    public Task<string?> GetAsync(string key)
+        => FilePersistencePrep.ReadAllTextOrNullAsync(key);
 }

--- a/WebReaper/DataAccess/FilePersistencePrep.cs
+++ b/WebReaper/DataAccess/FilePersistencePrep.cs
@@ -1,0 +1,52 @@
+namespace WebReaper.DataAccess;
+
+/// <summary>
+/// The one home (ADR-0011, CONTEXT.md "File persistence prep") for the three
+/// things every file-backed adapter must get right <em>before</em> it writes:
+/// eager, unconditional directory creation; a deterministic
+/// <c>DataCleanupOnStart</c> applied at start (not lazily on first write); and
+/// a missing file read as empty rather than throwing.
+///
+/// A small <em>stateless</em> helper — deliberately not a held-handle
+/// durability layer and not a shared lock (the rejected substrate, see
+/// ADR-0011). Each adapter keeps its own write/read essence (whole-file
+/// replace, the resumable cursor, the in-memory mirror, the buffered drain)
+/// and only delegates this prep, so the three single-copy bugs the four
+/// adapters had drifted into become unrepresentable.
+/// </summary>
+internal static class FilePersistencePrep
+{
+    /// <summary>
+    /// Ensure the directory containing <paramref name="path"/> exists. Eager,
+    /// unconditional and idempotent (a no-op if it already exists). Safe for a
+    /// bare filename with no directory part. Call before any write so a key /
+    /// file in a not-yet-existing directory does not throw.
+    /// </summary>
+    public static void EnsureDirectory(string path)
+    {
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+    }
+
+    /// <summary>
+    /// Deterministic cleanup-on-start: when <paramref name="dataCleanupOnStart"/>
+    /// is <c>true</c>, delete <paramref name="path"/> now — at start, before
+    /// any write — so a run that produces zero rows still clears stale state.
+    /// A no-op when the flag is <c>false</c> or the file is absent.
+    /// </summary>
+    public static void CleanupOnStart(string path, bool dataCleanupOnStart)
+    {
+        if (dataCleanupOnStart && File.Exists(path))
+            File.Delete(path);
+    }
+
+    /// <summary>
+    /// Whole-file read; an absent file reads as <c>null</c> rather than
+    /// throwing. The role above decides what absence <em>means</em> (the
+    /// keyed-blob seam maps it to "key absent"). UTF-8, no BOM — the
+    /// <see cref="File"/> default, unchanged.
+    /// </summary>
+    public static async Task<string?> ReadAllTextOrNullAsync(string path)
+        => File.Exists(path) ? await File.ReadAllTextAsync(path) : null;
+}

--- a/WebReaper/WebReaper.csproj
+++ b/WebReaper/WebReaper.csproj
@@ -81,4 +81,12 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
+
+  <!-- ADR-0011: FilePersistencePrep is an internal stateless helper; the unit
+       test assembly asserts its three responsibilities at its own interface
+       (a pure utility has no public facade to test it through, unlike the
+       internal SpiderBuilder which is reached via ScraperEngineBuilder). -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="WebReaper.UnitTests" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## What

Implements #56 (the ADR-0011 tracer bullet). Introduces `FilePersistencePrep` — a small **internal stateless** helper that is the one home for the three pre-write concerns four file-backed adapters had hand-rolled and drifted into single-copy bugs:

- eager, unconditional directory creation
- deterministic `DataCleanupOnStart` (at start, not lazily on first write)
- a missing file read as empty rather than throwing

`FileBlobStore` is migrated to delegate directory creation + the missing-file policy to the helper. Its whole-file replace/read essence is unchanged and **no lock is introduced** (ADR-0011 withdrew the "serialised replace" consequence). This fixes the bug where a key in a not-yet-existing directory threw `DirectoryNotFoundException`, contradicting `FileBlobStore`'s own "the key *is* the file path" doc.

`CleanupOnStart` is implemented now (it is the helper's defined home per ADR-0011) and covered by its own unit test; its adapter consumers (`FileScheduler` / `FileVisitedLinkedTracker` / `BufferedFileSink`) migrate in #57.

## Scope / decisions

- `FilePersistencePrep` is `internal` (ADR-0011, no public surface change). The repo has no `InternalsVisibleTo` — internal `SpiderBuilder` is tested via its public `ScraperEngineBuilder` facade. A pure utility has no such facade, and #56 requires asserting "deterministic cleanup with zero writes" at the helper, so one `<InternalsVisibleTo Include="WebReaper.UnitTests" />` MSBuild item is added.
- `KeyedBlobStoreTests`: the existing four `IKeyedBlobStore` contract theories are kept (still valid); a nested-path `[Fact]` is added pinning the bug fix through the public interface.
- Out of scope per ADR-0011: the rejected held-handle/lock substrate; `FileScheduler`'s file-as-queue (the #58 SQLite candidate); ADR-0006's per-row open/close fence (stands).

## Guardrail (green)

- Whole-solution build (`WebReaper.sln`, Examples + satellites): 0 errors.
- Unit suite: 69 passed, 0 failed.
- `WebReaper.AotSmokeTest` Native-AOT publish (`osx-arm64`): native code generated, no IL2026/IL3050-family warnings (only pre-existing CS1591 doc warnings, none in the changed files).

## Follow-up

- #57 — migrate the remaining three adapters onto the helper (blocked by this)
- #58 — SQLite candidate for local durable roles (design-first)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)
