### PR TITLE
Migrate the three remaining file-backed adapters onto FilePersistencePrep (#57)

### DIFF
--- a/WebReaper.Tests/WebReaper.UnitTests/FilePersistenceAdaptersTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/FilePersistenceAdaptersTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Immutable;
+using Microsoft.Extensions.Logging.Abstractions;
+using WebReaper.Core.LinkTracker.Concrete;
+using WebReaper.Core.Scheduler.Concrete;
+using WebReaper.Domain;
+using WebReaper.Domain.Selectors;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0011 (#57): the three remaining file-backed adapters delegate directory
+// creation, cleanup-on-start and the missing-file policy to
+// FilePersistencePrep. These pin the migration through each adapter's PUBLIC
+// interface — a path in a not-yet-existing directory now works, where the old
+// per-adapter directory handling was conditional/divergent. Each adapter's own
+// essence (the in-memory mirror, the resumable cursor/poll loop, the buffered
+// drain) is untouched and covered by its existing tests / the kept FileSink
+// drain tests; GetAllAsync's poll loop is deliberately not driven here.
+public class FilePersistenceAdaptersTests
+{
+    private static string MissingNestedDir() =>
+        Path.Combine(Path.GetTempPath(), $"wr-fpa-{Guid.NewGuid():N}", "nested");
+
+    [Fact]
+    public async Task FileVisitedLinkedTracker_in_a_missing_directory_initializes_and_round_trips()
+    {
+        var dir = MissingNestedDir();
+        try
+        {
+            var tracker = new FileVisitedLinkedTracker(Path.Combine(dir, "visited.txt"));
+            await tracker.Initialization;
+
+            await tracker.AddVisitedLinkAsync("http://x/1");
+
+            Assert.Contains("http://x/1", await tracker.GetVisitedLinksAsync());
+            Assert.Equal(1, await tracker.GetVisitedLinksCount());
+        }
+        finally
+        {
+            var root = Directory.GetParent(dir)!.FullName;
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task FileScheduler_in_a_missing_directory_initializes_and_AddAsync_succeeds()
+    {
+        var dir = MissingNestedDir();
+        try
+        {
+            var scheduler = new FileScheduler(
+                Path.Combine(dir, "jobs.txt"),
+                Path.Combine(dir, "pos.txt"),
+                NullLogger.Instance);
+            await scheduler.Initialization;
+
+            await scheduler.AddAsync(new Job(
+                "http://x/1",
+                ImmutableQueue<LinkPathSelector>.Empty,
+                ImmutableQueue<string>.Empty));
+
+            Assert.True(File.Exists(Path.Combine(dir, "jobs.txt")));
+        }
+        finally
+        {
+            var root = Directory.GetParent(dir)!.FullName;
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/WebReaper.Tests/WebReaper.UnitTests/FileSinkTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/FileSinkTests.cs
@@ -4,15 +4,16 @@ using WebReaper.Sinks.Models;
 
 namespace WebReaper.UnitTests;
 
-// The file-sink deepening (ADR 0006). The buffered drain has one home
-// (BufferedFileSink); the only legitimate per-format variation is behind
-// IFileSinkFormat. The two pure format tests pin the quarantined quirk exactly
-// (no IO, the cheapest surface). The two ctor tests pin the headline bug fixes
-// — deterministic, no async drain: the directory is created even when not
-// cleaning (old JSON-lines only created it while cleaning, old CSV never), and
-// DataCleanupOnStart truncates a pre-existing file with zero rows emitted (old
-// CSV kept stale data on an empty crawl). Two drain tests prove the
-// producer→consumer→file path and the header-once ordering.
+// The file-sink deepening (ADR 0006) plus the file-persistence-prep
+// migration (ADR-0011). The buffered drain has one home (BufferedFileSink);
+// the only legitimate per-format variation is behind IFileSinkFormat. The
+// two pure format tests pin the quarantined quirk exactly (no IO, the
+// cheapest surface). The directory-creation and DataCleanupOnStart
+// assertions that used to live here moved to FilePersistencePrepTests when
+// BufferedFileSink was migrated to delegate that prep (ADR-0011); the two
+// drain tests (kept) still prove the producer→consumer→file path and the
+// header-once ordering — and exercise the delegated directory creation
+// implicitly, since they write under a not-yet-existing temp directory.
 public class FileSinkTests
 {
     private sealed class TempDir : IDisposable
@@ -66,30 +67,6 @@ public class FileSinkTests
 
         Assert.Equal("name,url", format.Header(row));
         Assert.Equal("\"a\",\"http://x/1\"", format.FormatRow(row));
-    }
-
-    [Fact]
-    public void Constructor_creates_the_directory_even_when_not_cleaning()
-    {
-        using var tmp = new TempDir();
-        var path = tmp.At("nested", "out.jsonl");
-
-        _ = new JsonLinesFileSink(path, dataCleanupOnStart: false);
-
-        Assert.True(Directory.Exists(System.IO.Path.GetDirectoryName(path)));
-    }
-
-    [Fact]
-    public void DataCleanupOnStart_truncates_a_preexisting_file_with_zero_rows_emitted()
-    {
-        using var tmp = new TempDir();
-        Directory.CreateDirectory(tmp.Root);
-        var path = tmp.At("stale.csv");
-        File.WriteAllText(path, "old,stale,data" + Environment.NewLine);
-
-        _ = new CsvFileSink(path, dataCleanupOnStart: true);
-
-        Assert.False(File.Exists(path));
     }
 
     [Fact]

--- a/WebReaper/Core/LinkTracker/Concrete/FileVisitedLinkedTracker.cs
+++ b/WebReaper/Core/LinkTracker/Concrete/FileVisitedLinkedTracker.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using WebReaper.Core.LinkTracker.Abstract;
+using WebReaper.DataAccess;
 
 namespace WebReaper.Core.LinkTracker.Concrete;
 
@@ -23,27 +24,23 @@ public class FileVisitedLinkedTracker : IVisitedLinkTracker
     
     private async Task InitializeAsync()
     {
-        if (DataCleanupOnStart)
+        // ADR-0011: directory creation, cleanup-on-start and the missing-file
+        // policy are delegated to FilePersistencePrep — eager and
+        // unconditional, fixing the old "directory created only when the file
+        // is absent" bug. The in-memory mirror is this adapter's own essence.
+        FilePersistencePrep.CleanupOnStart(_fileName, DataCleanupOnStart);
+        FilePersistencePrep.EnsureDirectory(_fileName);
+
+        var content = await FilePersistencePrep.ReadAllTextOrNullAsync(_fileName);
+        if (content is null)
         {
-            if (File.Exists(_fileName))
-            {
-                File.Delete(_fileName);
-            }
-        }
-        
-        if (!File.Exists(_fileName))
-        {
-            var fileInfo = new FileInfo(_fileName);
-            fileInfo.Directory?.Create();
-            
             _visitedLinks = new ConcurrentBag<string>();
-            var file = File.Create(_fileName);
-            file.Close();
+            File.Create(_fileName).Close();
             return;
         }
 
-        var allLinks = File.ReadLines(_fileName);
-        _visitedLinks = new ConcurrentBag<string>(allLinks);
+        _visitedLinks = new ConcurrentBag<string>(
+            content.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries));
     }
 
     public async Task AddVisitedLinkAsync(string visitedLink)

--- a/WebReaper/Core/Scheduler/Concrete/FileScheduler.cs
+++ b/WebReaper/Core/Scheduler/Concrete/FileScheduler.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using WebReaper.Core.Scheduler.Abstract;
+using WebReaper.DataAccess;
 using WebReaper.Domain;
 using WebReaper.Serialization;
 
@@ -30,20 +31,20 @@ public class FileScheduler : IScheduler
     
     private async Task InitializeAsync()
     {
-        if (DataCleanupOnStart)
-        {
-            if(File.Exists(_fileName)) File.Delete(_fileName);
-            if(File.Exists(_currentJobPositionFileName)) File.Delete(_currentJobPositionFileName);
-        }
-        
-        var fileInfo = new FileInfo(_fileName);
-        fileInfo.Directory?.Create();
-        
-        var fileInfo2 = new FileInfo(_currentJobPositionFileName);
-        fileInfo2.Directory?.Create();
+        // ADR-0011: directory creation, cleanup-on-start and the missing-file
+        // policy are delegated to FilePersistencePrep, for both the job file
+        // and the position file. The resumable cursor + poll loop in
+        // GetAllAsync is this adapter's own essence and is byte-unchanged (the
+        // file-as-queue is the named #58 candidate, out of scope here).
+        FilePersistencePrep.CleanupOnStart(_fileName, DataCleanupOnStart);
+        FilePersistencePrep.CleanupOnStart(_currentJobPositionFileName, DataCleanupOnStart);
 
-        if (File.Exists(_currentJobPositionFileName))
-            _currentJobPosition = int.Parse(await File.ReadAllTextAsync(_currentJobPositionFileName));
+        FilePersistencePrep.EnsureDirectory(_fileName);
+        FilePersistencePrep.EnsureDirectory(_currentJobPositionFileName);
+
+        var posText = await FilePersistencePrep.ReadAllTextOrNullAsync(_currentJobPositionFileName);
+        if (posText is not null)
+            _currentJobPosition = int.Parse(posText);
     }
 
     public async IAsyncEnumerable<Job> GetAllAsync(

--- a/WebReaper/Sinks/Concrete/BufferedFileSink.cs
+++ b/WebReaper/Sinks/Concrete/BufferedFileSink.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.Json.Nodes;
+using WebReaper.DataAccess;
 using WebReaper.Sinks.Abstract;
 using WebReaper.Sinks.Models;
 
@@ -12,7 +13,8 @@ namespace WebReaper.Sinks.Concrete;
 /// buffered-drain code that was copy-pasted across the two file sinks and had
 /// drifted into divergent bugs.
 ///
-/// Cleanup and directory creation happen once, eagerly, in the constructor —
+/// Cleanup and directory creation are delegated to FilePersistencePrep
+/// (ADR-0011) and happen once, eagerly, in the constructor —
 /// deterministic and correct even for a crawl that produces zero rows (the
 /// behaviour the old JSON-lines sink had and the old CSV sink lacked), and the
 /// directory is created regardless of <c>dataCleanupOnStart</c> (the old
@@ -43,12 +45,12 @@ public class BufferedFileSink : IScraperSink
         _format = format;
         DataCleanupOnStart = dataCleanupOnStart;
 
-        var directory = Path.GetDirectoryName(filePath);
-        if (!string.IsNullOrEmpty(directory))
-            Directory.CreateDirectory(directory);
-
-        if (dataCleanupOnStart && File.Exists(filePath))
-            File.Delete(filePath);
+        // ADR-0011: directory creation + cleanup-on-start delegated to
+        // FilePersistencePrep. The buffered drain, IFileSinkFormat and the
+        // per-row append are this adapter's own essence, unchanged —
+        // ADR-0006's open/close-per-row fence stands (not closed here).
+        FilePersistencePrep.EnsureDirectory(filePath);
+        FilePersistencePrep.CleanupOnStart(filePath, dataCleanupOnStart);
     }
 
     public bool DataCleanupOnStart { get; set; }


### PR DESCRIPTION
## What

Implements #57, completing ADR-0011: the three remaining file-backed adapters delegate the three pre-write concerns to `FilePersistencePrep` (the #56 helper). The dedup is now complete — eager unconditional directory creation, deterministic `DataCleanupOnStart`, and missing-file-as-empty have one home; the three single-copy bugs are unrepresentable.

Each adapter keeps its own essence untouched:

- **FileVisitedLinkedTracker** — in-memory mirror + its `SemaphoreSlim` per-call append unchanged; the "directory created only when the file is absent" bug is fixed.
- **FileScheduler** — `GetAllAsync`'s resumable cursor + 300 ms poll loop and `AddAsync`'s append are **byte-unchanged** (the file-as-queue is the named #58 candidate, out of scope); both the job file and the position file now get the prep.
- **BufferedFileSink** — the ADR-0006 `BlockingCollection` drain, `IFileSinkFormat`, and the per-row append are unchanged; **ADR-0006's open/close-per-row fence stands** (not closed here).

No public surface change, no held handle, no shared lock.

## Tests

- `FileSinkTests`: the two constructor tests removed — their directory-creation / `DataCleanupOnStart` assertions now live in `FilePersistencePrepTests` (#56). **`TempDir` is kept** — a deliberate deviation from #57's literal text: the kept drain tests depend on it, and the substantive intent (those assertions moving to the helper tests) is satisfied by removing the two ctor tests. Format + drain tests kept.
- New `FilePersistenceAdaptersTests` pins the tracker and scheduler migration through their **public interfaces** (a path in a not-yet-existing directory now initializes and round-trips), mirroring #56's nested-path FileBlobStore test. The sink's delegated directory creation is exercised implicitly by the kept drain tests (they write under a not-yet-existing temp dir).

## Guardrail (green)

- Whole-solution build (`WebReaper.sln`, Examples + satellites): 0 errors.
- Unit suite: 69 passed, 0 failed (−2 removed ctor tests, +2 new adapter regression tests).
- `WebReaper.AotSmokeTest` Native-AOT publish (`osx-arm64`): native code generated, no IL2026/IL3050-family warnings.

## Scope

Per ADR-0011: the rejected held-handle/lock substrate is not built; `FileScheduler`'s file-as-queue is #58 (design-first); ADR-0006's per-row open/close fence stands. CONTEXT.md already documents "File persistence prep" — no doc churn; this is the implementation of the documented decision.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)
