### PR TITLE
Fix PageActionBuilder.WaitForNetworkIdle() tagging WaitForSelector (#61)

### DIFF
--- a/WebReaper.Tests/WebReaper.UnitTests/PageActionBuilderTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/PageActionBuilderTests.cs
@@ -1,0 +1,54 @@
+using WebReaper.Builders;
+using WebReaper.Domain.PageActions;
+
+namespace WebReaper.UnitTests;
+
+// #61: PageActionBuilder.WaitForNetworkIdle() tagged the action
+// WaitForSelector (a copy-paste typo) — silently producing a different,
+// unimplemented action. These pin every single-action builder method to its
+// matching PageActionType so a future copy-paste typo fails a fast unit test
+// instead of silently at the Puppeteer dispatcher.
+public class PageActionBuilderTests
+{
+    [Fact]
+    public void WaitForNetworkIdle_tags_the_action_WaitForNetworkIdle()
+    {
+        var actions = new PageActionBuilder().WaitForNetworkIdle().Build();
+
+        var action = Assert.Single(actions);
+        Assert.Equal(PageActionType.WaitForNetworkIdle, action.Type);
+    }
+
+    [Fact]
+    public void Every_single_action_method_tags_the_action_with_its_matching_type()
+    {
+        Assert.Equal(PageActionType.Click,
+            Assert.Single(new PageActionBuilder().Click("sel").Build()).Type);
+        Assert.Equal(PageActionType.Wait,
+            Assert.Single(new PageActionBuilder().Wait(10).Build()).Type);
+        Assert.Equal(PageActionType.ScrollToEnd,
+            Assert.Single(new PageActionBuilder().ScrollToEnd().Build()).Type);
+        Assert.Equal(PageActionType.EvaluateExpression,
+            Assert.Single(new PageActionBuilder().EvaluateExpression("expr").Build()).Type);
+        Assert.Equal(PageActionType.WaitForSelector,
+            Assert.Single(new PageActionBuilder().WaitForSelector("sel", 100).Build()).Type);
+        Assert.Equal(PageActionType.WaitForNetworkIdle,
+            Assert.Single(new PageActionBuilder().WaitForNetworkIdle().Build()).Type);
+    }
+
+    [Fact]
+    public void RepeatAndWaitForNetworkIdle_repeats_the_seed_then_a_WaitForNetworkIdle()
+    {
+        // Sibling of the bug and a copy-paste hot spot: the action inserted
+        // between repeats must be WaitForNetworkIdle, not WaitForSelector.
+        var actions = new PageActionBuilder()
+            .ScrollToEnd()
+            .RepeatAndWaitForNetworkIdle(2)
+            .Build();
+
+        // seed ScrollToEnd, then 2x [ScrollToEnd, WaitForNetworkIdle]
+        Assert.Equal(5, actions.Count);
+        Assert.Equal(PageActionType.WaitForNetworkIdle, actions[2].Type);
+        Assert.Equal(PageActionType.WaitForNetworkIdle, actions[4].Type);
+    }
+}

--- a/WebReaper/Builders/PageActionBuilder.cs
+++ b/WebReaper/Builders/PageActionBuilder.cs
@@ -76,7 +76,7 @@ public class PageActionBuilder
 
     public PageActionBuilder WaitForNetworkIdle()
     {
-        _pageActions.Add(new PageAction(PageActionType.WaitForSelector));
+        _pageActions.Add(new PageAction(PageActionType.WaitForNetworkIdle));
         return this;
     }
 


### PR DESCRIPTION
## What

Fixes #61. `PageActionBuilder.WaitForNetworkIdle()` constructed `new PageAction(PageActionType.WaitForSelector)` instead of `WaitForNetworkIdle` — a copy-paste typo. A consumer calling `.WaitForNetworkIdle()` silently got a different, unimplemented action (`WaitForSelector` is one of the two `PageActionType`s the `WebReaper.Puppeteer` dispatcher does not handle), with no compile- or run-time signal.

One-line fix.

## Tests

New `PageActionBuilderTests`:
- pins `WaitForNetworkIdle()` → `PageActionType.WaitForNetworkIdle` (the regression)
- a cheap **sweep** asserting every single-action builder method tags the action with its matching type, so a future copy-paste typo fails a fast unit test instead of silently at the Puppeteer dispatcher
- `RepeatAndWaitForNetworkIdle` (the sibling copy-paste hot spot)

## Guardrail (green)

- Whole-solution build (`WebReaper.sln`, Examples + satellites): 0 errors.
- Unit suite: 72 passed, 0 failed (+3).
- `WebReaper.AotSmokeTest` Native-AOT publish (`osx-arm64`): native code generated, no IL2026/IL3050-family warnings.

## Out of scope (per ADR-0004)

The untyped `PageAction(params object[])` contract and the two unimplemented `PageActionType`s (`WaitForSelector`, `EvaluateExpression`) — deliberately deferred. This PR is only the typo.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)
