### PR TITLE
WebReaper.Sqlite satellite + SqliteScheduler (#66)

### DIFF
--- a/WebReaper.Sqlite/README.md
+++ b/WebReaper.Sqlite/README.md
@@ -1,0 +1,67 @@
+# WebReaper.Sqlite
+
+SQLite embedded-store adapters for [WebReaper](https://github.com/pavlovtech/WebReaper):
+a **local durable scheduler** (and, from the next slice, a visited-link
+tracker) backed by SQLite via `Microsoft.Data.Sqlite`. "Resume" is a
+`SELECT … WHERE consumed = 0` over an indexed table — not a hand-rolled
+append-only job file plus a sidecar position file.
+
+This is the **opt-in robust-local durability tier**, between the
+zero-dependency core file adapters and the distributed Redis / Azure Service
+Bus satellites:
+
+| Tier | Package | Shape |
+|---|---|---|
+| File | `WebReaper` (core) | append + 300 ms poll + position file — the zero-dep default |
+| **SQLite** | **`WebReaper.Sqlite`** | embedded store, "resume" is a query, no position file |
+| Redis / Azure Service Bus | `WebReaper.Redis` / `.AzureServiceBus` | distributed |
+
+Satellite package (ADR-0009 / ADR-0012): the SQLite adapters are kept out of
+the WebReaper core so the core stays dependency-light and Native-AOT-clean —
+`Microsoft.Data.Sqlite` is a managed wrapper over a native `e_sqlite3`
+(SQLitePCLRaw), and that native-interop graph is quarantined here. The core
+file scheduler is unchanged and remains the zero-dependency local default.
+
+## Install
+
+```
+dotnet add package WebReaper.Sqlite
+```
+
+Pulls `WebReaper` (the core) as a dependency.
+
+## Usage
+
+Adds `WithSqliteScheduler` to `ScraperEngineBuilder`, over the core's public
+`WithScheduler` registration seam:
+
+```csharp
+using WebReaper.Builders;
+using WebReaper.Sqlite;
+
+var engine = await new ScraperEngineBuilder()
+    .Get("https://example.com")
+    .WithSqliteScheduler("crawl/state.db")
+    .Parse(new Schema { /* … */ })
+    .WriteToJsonFile("output.jsonl")
+    .BuildAsync();
+
+await engine.RunAsync();
+```
+
+Kill the process mid-crawl and run it again with the same `databasePath`:
+every job that was queued but not yet claimed is still there, found by the
+same query — no position file to keep in sync.
+
+`dataCleanupOnStart: true` clears the job table at start (a fresh crawl):
+
+```csharp
+.WithSqliteScheduler("crawl/state.db", dataCleanupOnStart: true)
+```
+
+## Scope
+
+This package currently ships the **scheduler**. The SQLite visited-link
+tracker (`TrackVisitedLinksInSqlite`) is the next slice. The core's role
+interfaces (`IScheduler`, `IVisitedLinkTracker`) are unchanged — SQLite is an
+additional adapter, not a core change.

--- a/WebReaper.Sqlite/SqliteBuilderExtensions.cs
+++ b/WebReaper.Sqlite/SqliteBuilderExtensions.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using WebReaper.Builders;
+
+namespace WebReaper.Sqlite;
+
+/// <summary>
+/// ADR-0009 / ADR-0012: the Sqlite builder sugar lives here, in the
+/// WebReaper.Sqlite satellite, over <see cref="ScraperEngineBuilder"/>'s
+/// public registration seam (<c>WithScheduler</c>) — not in core. Core does
+/// not reference Microsoft.Data.Sqlite. A satellite extension cannot reach
+/// the builder's private logger, so the logger is an explicit optional
+/// argument (defaulting to <see cref="NullLogger"/>) rather than the
+/// builder's — the same shape as <c>WithRedisScheduler</c>.
+/// </summary>
+public static class SqliteBuilderExtensions
+{
+    /// <summary>
+    /// Uses a SQLite-backed embedded store as the scheduler, over
+    /// <see cref="ScraperEngineBuilder"/>'s public <c>WithScheduler</c> seam.
+    /// The opt-in robust-local durability tier: "resume" is a query, not a
+    /// hand-rolled position file (ADR-0012). The core file scheduler stays the
+    /// zero-dependency default; this is opt-in.
+    /// </summary>
+    /// <param name="builder">The scraper engine builder.</param>
+    /// <param name="databasePath">Path to the SQLite database file (its directory is created if missing).</param>
+    /// <param name="dataCleanupOnStart">When <see langword="true"/>, the job table is cleared when the scrape starts.</param>
+    /// <param name="logger">Optional logger; defaults to <see cref="NullLogger"/> (a satellite extension cannot reach the builder's private logger).</param>
+    /// <returns>The same <see cref="ScraperEngineBuilder"/>, for chaining.</returns>
+    public static ScraperEngineBuilder WithSqliteScheduler(
+        this ScraperEngineBuilder builder,
+        string databasePath,
+        bool dataCleanupOnStart = false,
+        ILogger? logger = null)
+    {
+        return builder.WithScheduler(new SqliteScheduler(
+            databasePath,
+            logger ?? NullLogger.Instance,
+            dataCleanupOnStart));
+    }
+}

--- a/WebReaper.Sqlite/SqliteScheduler.cs
+++ b/WebReaper.Sqlite/SqliteScheduler.cs
@@ -1,0 +1,199 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using WebReaper.Core.Scheduler.Abstract;
+using WebReaper.Domain;
+using WebReaper.Serialization;
+
+namespace WebReaper.Sqlite;
+
+/// <summary>
+/// ADR-0012: the local durable scheduler backed by an embedded SQLite store.
+/// "Resume" is a <c>SELECT … WHERE consumed = 0 ORDER BY id</c> over an
+/// indexed table — replacing <c>FileScheduler</c>'s append-only job file +
+/// sidecar position file + <c>O(skip N)</c> line cursor; the cursor↔job-file
+/// desync failure mode is unrepresentable (one store, one transaction). The
+/// <c>Job</c> payload uses the same <see cref="WebReaperJson"/> grammar as the
+/// core file scheduler and the Redis scheduler (ADR-0008), so it round-trips
+/// with full type fidelity. Satellite-only (ADR-0009): the native
+/// <c>e_sqlite3</c>/SQLitePCLRaw graph stays off the dependency-light core,
+/// whose <c>FileScheduler</c> is unchanged and remains the zero-dependency
+/// local default — this is the opt-in robust-local tier.
+/// </summary>
+public class SqliteScheduler : IScheduler
+{
+    private readonly string _connectionString;
+    private readonly string _databasePath;
+    private readonly ILogger _logger;
+
+    public bool DataCleanupOnStart { get; set; }
+
+    public Task Initialization { get; }
+
+    public SqliteScheduler(string databasePath, ILogger logger, bool dataCleanupOnStart = false)
+    {
+        _databasePath = databasePath;
+        _connectionString = new SqliteConnectionStringBuilder { DataSource = databasePath }.ToString();
+        _logger = logger;
+        DataCleanupOnStart = dataCleanupOnStart;
+
+        Initialization = InitializeAsync();
+    }
+
+    private async Task InitializeAsync()
+    {
+        // The satellite cannot (InternalsVisibleTo is core's unit tests only)
+        // and should not reach core's internal FilePersistencePrep (ADR-0011);
+        // it owns its own pre-write prep. SQLite creates the db file but not
+        // its directory — create it eagerly and idempotently, the same
+        // one-liner FilePersistencePrep.EnsureDirectory is.
+        var dir = Path.GetDirectoryName(_databasePath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        await using var connection = await OpenAsync();
+
+        // WAL is a persistent db-header setting (set once; idempotent). It
+        // lets the consumer read while producers write — the engine's
+        // Parallel.ForEachAsync fans AddAsync out across crawl tasks while
+        // GetAllAsync drains. Durability/resume is the store's transactional
+        // query, NOT a hand-rolled cursor+poll+position-file (ADR-0012). A
+        // write still serializes because SQLite is single-writer — that is
+        // cooperating with the engine (BEGIN IMMEDIATE / busy_timeout), not a
+        // hand-rolled durable queue or the rejected held-handle substrate.
+        await ExecAsync(connection, "PRAGMA journal_mode=WAL;");
+        await ExecAsync(connection,
+            "CREATE TABLE IF NOT EXISTS jobs (" +
+            " id INTEGER PRIMARY KEY AUTOINCREMENT," +
+            " payload TEXT NOT NULL," +
+            " consumed INTEGER NOT NULL DEFAULT 0);");
+        // Partial index: the "next unconsumed" claim query is O(log n) on the
+        // unconsumed rows alone, never scanning the consumed history.
+        await ExecAsync(connection,
+            "CREATE INDEX IF NOT EXISTS ix_jobs_unconsumed ON jobs (id) WHERE consumed = 0;");
+
+        if (DataCleanupOnStart)
+            await ExecAsync(connection, "DELETE FROM jobs;");
+    }
+
+    public async Task AddAsync(Job job, CancellationToken cancellationToken = default)
+    {
+        await Initialization;
+
+        await using var connection = await OpenAsync(cancellationToken);
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "INSERT INTO jobs (payload) VALUES ($p);";
+        cmd.Parameters.AddWithValue("$p", WebReaperJson.SerializeJob(job));
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(IEnumerable<Job> jobs, CancellationToken cancellationToken = default)
+    {
+        await Initialization;
+
+        await using var connection = await OpenAsync(cancellationToken);
+        // deferred:false ⇒ BEGIN IMMEDIATE — take the write lock up front so a
+        // batch insert never half-applies under a concurrent claim/insert
+        // (Microsoft.Data.Sqlite docs: the non-deferred transaction creates
+        // the write transaction immediately).
+        using var tx = connection.BeginTransaction(deferred: false);
+        await using var cmd = connection.CreateCommand();
+        cmd.Transaction = tx;
+        cmd.CommandText = "INSERT INTO jobs (payload) VALUES ($p);";
+        var p = cmd.Parameters.Add("$p", SqliteType.Text);
+        foreach (var job in jobs)
+        {
+            p.Value = WebReaperJson.SerializeJob(job);
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+        tx.Commit();
+    }
+
+    public async IAsyncEnumerable<Job> GetAllAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Initialization;
+
+        _logger.LogInformation("Start {class}.{method}", nameof(SqliteScheduler), nameof(GetAllAsync));
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var payload = await ClaimNextAsync(cancellationToken);
+
+            if (payload is null)
+            {
+                // Empty-queue wait. NOT removed by the embedded store: jobs are
+                // produced concurrently by in-flight crawl tasks, so the stream
+                // must wait when momentarily drained — exactly as FileScheduler
+                // and RedisScheduler also Task.Delay(300) poll. What the store
+                // removes is the position file, the O(skip N) line cursor and
+                // the cursor↔job-file desync risk (ADR-0012), not this wait.
+                await Task.Delay(300, cancellationToken);
+                continue;
+            }
+
+            yield return WebReaperJson.DeserializeJob(payload);
+        }
+    }
+
+    // Claim-before-yield — the IScheduler family contract: FileScheduler
+    // advances its position cursor before `yield` (FileScheduler.cs) and
+    // RedisScheduler pops destructively (ListLeftPop) before `yield`; the role
+    // interface has no ack, so "consume = claim" IS the contract, not a
+    // choice. On kill -9 every not-yet-claimed row is intact and re-yielded by
+    // the same WHERE consumed = 0 query; the single in-flight job is not
+    // re-yielded — the same at-most-once-for-the-in-flight-job guarantee the
+    // whole family already has, no weaker. deferred:false ⇒ BEGIN IMMEDIATE
+    // takes the write lock up front so the SELECT-then-UPDATE claim cannot
+    // race a concurrent AddAsync into SQLITE_BUSY. Committed before the
+    // (arbitrarily long) yield so a slow consumer never holds the write lock.
+    private async Task<string?> ClaimNextAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = await OpenAsync(cancellationToken);
+        using var tx = connection.BeginTransaction(deferred: false);
+
+        long id;
+        string payload;
+        await using (var sel = connection.CreateCommand())
+        {
+            sel.Transaction = tx;
+            sel.CommandText = "SELECT id, payload FROM jobs WHERE consumed = 0 ORDER BY id LIMIT 1;";
+            await using var reader = await sel.ExecuteReaderAsync(cancellationToken);
+            if (!await reader.ReadAsync(cancellationToken))
+            {
+                tx.Rollback();
+                return null;
+            }
+            id = reader.GetInt64(0);
+            payload = reader.GetString(1);
+        }
+
+        await using (var upd = connection.CreateCommand())
+        {
+            upd.Transaction = tx;
+            upd.CommandText = "UPDATE jobs SET consumed = 1 WHERE id = $id;";
+            upd.Parameters.AddWithValue("$id", id);
+            await upd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        tx.Commit();
+        return payload;
+    }
+
+    private async Task<SqliteConnection> OpenAsync(CancellationToken cancellationToken = default)
+    {
+        var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken);
+        // Per-connection: cooperate with SQLite's single-writer rule instead
+        // of failing fast on contention under the engine's parallel fan-out.
+        await ExecAsync(connection, "PRAGMA busy_timeout=30000;");
+        return connection;
+    }
+
+    private static async Task ExecAsync(SqliteConnection connection, string sql)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/WebReaper.Sqlite/WebReaper.Sqlite.csproj
+++ b/WebReaper.Sqlite/WebReaper.Sqlite.csproj
@@ -1,0 +1,62 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Ship the XML doc so the documented builder-extension API (the
+         satellite's supported surface) gives consumers IntelliSense. The
+         adapter classes (SqliteScheduler / future SqliteVisitedLinkTracker)
+         are public only because the extension and tests bind to them; they
+         are not part of the satellite's documented contract, so CS1591 for
+         them is noise, not a backlog signal. Core keeps CS1591 visible by
+         contrast — there it IS a live doc backlog. -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+    <PackageId>WebReaper.Sqlite</PackageId>
+    <!-- Release-time owned (docs/RELEASE-RUNBOOK.md): WebReaper.Sqlite is a
+         NEW satellite added after the 7.0.0 satellite wave, so 7.1.0 — not
+         7.0.0, which the CHANGELOG enumerates without Sqlite. The build does
+         not depend on this value; the release process sets the published
+         number. -->
+    <Version>7.1.0</Version>
+    <Authors>Alex Pavlov</Authors>
+    <Company>Alex Pavlov</Company>
+    <Product>WebReaper</Product>
+    <Title>WebReaper.Sqlite</Title>
+    <Description>SQLite embedded-store adapters for WebReaper: a local durable scheduler (and, from the next slice, a visited-link tracker) backed by SQLite via Microsoft.Data.Sqlite — resume is a query, not a hand-rolled position file. The opt-in robust-local durability tier between the zero-dependency core file adapters and the distributed Redis / Azure Service Bus satellites. Adds ScraperEngineBuilder.WithSqliteScheduler. Satellite package (ADR-0009 / ADR-0012) so the WebReaper core stays dependency-light and Native-AOT-clean — the native e_sqlite3 (SQLitePCLRaw) graph is quarantined here.</Description>
+    <Copyright>GPL-3.0 license</Copyright>
+    <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/pavlovtech/WebReaper</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/pavlovtech/WebReaper</RepositoryUrl>
+    <PackageTags>scraper, crawler, parser, sqlite, durable, embedded</PackageTags>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>7.1.0: initial release. SQLite embedded-store local durable scheduler (ScraperEngineBuilder.WithSqliteScheduler) — "resume" is a SELECT WHERE consumed = 0 over an indexed table, replacing FileScheduler's append-only job file + sidecar position file + line-skip cursor (the cursor/job-file desync failure mode is unrepresentable). Same WebReaperJson Job grammar as the core file scheduler and the Redis scheduler (ADR-0008), so the Job round-trips with full type fidelity. New satellite package per ADR-0009 / ADR-0012: the WebReaper core does not reference Microsoft.Data.Sqlite, so the native e_sqlite3 (SQLitePCLRaw) graph stays off the dependency-light, Native-AOT-zero-warning core. The core file scheduler is unchanged and stays the zero-dependency local default; this is the opt-in robust-local tier. Requires WebReaper 7.0.0. The visited-link tracker is the next slice (issue #67).</PackageReleaseNotes>
+
+    <!-- ADR-0009 / ADR-0012: the Sqlite satellite is deliberately NOT
+         IsAotCompatible. Microsoft.Data.Sqlite is a managed wrapper over a
+         native e_sqlite3 shipped via SQLitePCLRaw.bundle_e_sqlite3 (a per-RID
+         native asset) — the exact native-interop dependency class ADR-0009
+         quarantines off core (cf. the Cosmos ServiceInterop graph).
+         Quarantining it here is precisely why a core-only consumer stays
+         dependency-light and the whole core publishes Native-AOT
+         zero-warning (WebReaper.AotSmokeTest); the core file scheduler is
+         untouched and remains the zero-dependency local default. -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\WebReaper\logo.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebReaper\WebReaper.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+  </ItemGroup>
+</Project>

--- a/WebReaper.Tests/WebReaper.Sqlite.Tests/SqliteSchedulerTests.cs
+++ b/WebReaper.Tests/WebReaper.Sqlite.Tests/SqliteSchedulerTests.cs
@@ -1,0 +1,133 @@
+using System.Collections.Immutable;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using WebReaper.Domain;
+using WebReaper.Domain.PageActions;
+using WebReaper.Domain.Selectors;
+using WebReaper.Sqlite;
+using Xunit;
+
+namespace WebReaper.Sqlite.Tests;
+
+// ADR-0012 acceptance criteria, pinned through the public IScheduler:
+// the Job round-trips with full type fidelity (same WebReaperJson grammar as
+// the core/Redis schedulers, ADR-0008); resume-after-reopen yields exactly
+// the not-yet-claimed jobs in order (the position-file-killer — there is no
+// position file); DataCleanupOnStart clears the table at start.
+public class SqliteSchedulerTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), $"wr-sql-{Guid.NewGuid():N}");
+
+    private string DbPath => Path.Combine(_dir, "nested", "state.db");
+
+    private static Job UrlJob(string url) =>
+        new(url, ImmutableQueue<LinkPathSelector>.Empty, ImmutableQueue<string>.Empty);
+
+    // GetAllAsync is an infinite stream (it polls when momentarily drained,
+    // exactly like FileScheduler/RedisScheduler); take exactly n, with a
+    // generous timeout purely as a hang fuse.
+    private static async Task<List<Job>> TakeAsync(SqliteScheduler s, int n)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        var got = new List<Job>();
+        await foreach (var job in s.GetAllAsync(cts.Token))
+        {
+            got.Add(job);
+            if (got.Count == n) break;
+        }
+        return got;
+    }
+
+    [Fact]
+    public async Task Job_round_trips_with_type_fidelity()
+    {
+        var job = new Job(
+            "https://x.test/p",
+            ImmutableQueue.CreateRange(new[]
+            {
+                new LinkPathSelector("a.cat", null, PageType.Static),
+                new LinkPathSelector("a.item", "a.next", PageType.Dynamic)
+            }),
+            ImmutableQueue.CreateRange(new[] { "https://x.test", "https://x.test/c" }),
+            PageType.Dynamic,
+            new List<PageAction> { new(PageActionType.Click, "button#go", 42) });
+
+        var scheduler = new SqliteScheduler(DbPath, NullLogger.Instance);
+        await scheduler.Initialization;
+        await scheduler.AddAsync(job);
+
+        var got = (await TakeAsync(scheduler, 1)).Single();
+
+        Assert.Equal("https://x.test/p", got.Url);
+        Assert.Equal(PageType.Dynamic, got.PageType);
+        var chain = got.LinkPathSelectors.ToArray();
+        Assert.Equal(2, chain.Length);
+        Assert.Equal("a.cat", chain[0].Selector);
+        Assert.Equal("a.next", chain[1].PaginationSelector);
+        Assert.Equal(PageType.Dynamic, chain[1].PageType);
+        Assert.Equal(new[] { "https://x.test", "https://x.test/c" },
+            got.ParentBacklinks.ToArray());
+        Assert.Equal(PageActionType.Click, got.PageActions![0].Type);
+        Assert.Equal("button#go", got.PageActions![0].Parameters[0].ToString());
+        Assert.Equal(42, Convert.ToInt32(got.PageActions![0].Parameters[1]));
+    }
+
+    [Fact]
+    public async Task Resume_after_reopen_yields_only_unclaimed_jobs_in_order()
+    {
+        // A path in a not-yet-existing directory must work (the satellite
+        // creates it — there is no core FilePersistencePrep reach).
+        var first = new SqliteScheduler(DbPath, NullLogger.Instance);
+        await first.Initialization;
+        await first.AddAsync(Enumerable.Range(1, 5).Select(i => UrlJob($"https://x/{i}")));
+
+        var claimed = await TakeAsync(first, 2);
+        Assert.Equal(new[] { "https://x/1", "https://x/2" }, claimed.Select(j => j.Url));
+
+        // Fresh instance, same db file, no cleanup: resume is just the query.
+        var resumed = new SqliteScheduler(DbPath, NullLogger.Instance);
+        await resumed.Initialization;
+
+        var rest = await TakeAsync(resumed, 3);
+        Assert.Equal(new[] { "https://x/3", "https://x/4", "https://x/5" },
+            rest.Select(j => j.Url));
+    }
+
+    [Fact]
+    public async Task DataCleanupOnStart_clears_a_preexisting_job_table()
+    {
+        var first = new SqliteScheduler(DbPath, NullLogger.Instance);
+        await first.Initialization;
+        await first.AddAsync(Enumerable.Range(1, 3).Select(i => UrlJob($"https://stale/{i}")));
+
+        var fresh = new SqliteScheduler(DbPath, NullLogger.Instance, dataCleanupOnStart: true);
+        await fresh.Initialization;
+        await fresh.AddAsync(UrlJob("https://fresh/1"));
+
+        // Only the post-cleanup job remains; the three stale ones are gone.
+        var got = await TakeAsync(fresh, 1);
+        Assert.Equal(new[] { "https://fresh/1" }, got.Select(j => j.Url));
+    }
+
+    [Fact]
+    public async Task Batch_AddAsync_then_claim_preserves_FIFO_order()
+    {
+        var scheduler = new SqliteScheduler(DbPath, NullLogger.Instance);
+        await scheduler.Initialization;
+        await scheduler.AddAsync(new[] { "https://a/1", "https://a/2", "https://a/3" }
+            .Select(UrlJob));
+
+        var got = await TakeAsync(scheduler, 3);
+        Assert.Equal(new[] { "https://a/1", "https://a/2", "https://a/3" },
+            got.Select(j => j.Url));
+    }
+
+    public void Dispose()
+    {
+        // Release pooled native file handles before deleting the temp tree.
+        SqliteConnection.ClearAllPools();
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { /* best-effort temp cleanup */ }
+    }
+}

--- a/WebReaper.Tests/WebReaper.Sqlite.Tests/WebReaper.Sqlite.Tests.csproj
+++ b/WebReaper.Tests/WebReaper.Sqlite.Tests/WebReaper.Sqlite.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+
+    <LangVersion>12</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WebReaper.Sqlite\WebReaper.Sqlite.csproj" />
+  </ItemGroup>
+</Project>

--- a/WebReaper.Tests/WebReaper.Sqlite.Tests/WithSqliteSchedulerExtensionTests.cs
+++ b/WebReaper.Tests/WebReaper.Sqlite.Tests/WithSqliteSchedulerExtensionTests.cs
@@ -1,0 +1,23 @@
+using Xunit;
+using WebReaper.Builders;
+using WebReaper.Sqlite;
+
+namespace WebReaper.Sqlite.Tests;
+
+public class WithSqliteSchedulerExtensionTests
+{
+    // ADR-0009/0012: WebReaper.Sqlite supplies WithSqliteScheduler as an
+    // extension over the public WithScheduler registration seam, preserving
+    // fluent chaining — the same satellite contract as WithRedisScheduler.
+    [Fact]
+    public void WithSqliteScheduler_is_a_ScraperEngineBuilder_extension_that_chains()
+    {
+        var builder = new ScraperEngineBuilder();
+
+        var result = builder.WithSqliteScheduler(
+            databasePath: Path.Combine(Path.GetTempPath(), $"wr-sql-{Guid.NewGuid():N}.db"),
+            dataCleanupOnStart: false);
+
+        Assert.Same(builder, result);
+    }
+}

--- a/WebReaper.sln
+++ b/WebReaper.sln
@@ -54,6 +54,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.AotSmokeTest", "W
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.AzureServiceBus.Tests", "WebReaper.Tests\WebReaper.AzureServiceBus.Tests\WebReaper.AzureServiceBus.Tests.csproj", "{275D6D05-BE2D-4E52-85CF-F868B1A7AF19}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.Sqlite", "WebReaper.Sqlite\WebReaper.Sqlite.csproj", "{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.Sqlite.Tests", "WebReaper.Tests\WebReaper.Sqlite.Tests\WebReaper.Sqlite.Tests.csproj", "{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -292,6 +296,30 @@ Global
 		{275D6D05-BE2D-4E52-85CF-F868B1A7AF19}.Release|x64.Build.0 = Release|Any CPU
 		{275D6D05-BE2D-4E52-85CF-F868B1A7AF19}.Release|x86.ActiveCfg = Release|Any CPU
 		{275D6D05-BE2D-4E52-85CF-F868B1A7AF19}.Release|x86.Build.0 = Release|Any CPU
+		{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}.Debug|x64.Build.0 = Debug|Any CPU
+		{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}.Debug|x86.Build.0 = Debug|Any CPU
+		{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}.Release|x64.ActiveCfg = Release|Any CPU
+		{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}.Release|x64.Build.0 = Release|Any CPU
+		{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}.Release|x86.ActiveCfg = Release|Any CPU
+		{30FEAFD3-1E22-4EA2-B86E-19598B3FDFA0}.Release|x86.Build.0 = Release|Any CPU
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}.Debug|x64.Build.0 = Debug|Any CPU
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}.Debug|x86.Build.0 = Debug|Any CPU
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}.Release|x64.ActiveCfg = Release|Any CPU
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}.Release|x64.Build.0 = Release|Any CPU
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}.Release|x86.ActiveCfg = Release|Any CPU
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -309,6 +337,7 @@ Global
 		{9873B857-D5EE-41FE-AAEB-9EE53C502846} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
 		{F4CAFE2E-B51B-47A1-BFCC-245099819E01} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
 		{275D6D05-BE2D-4E52-85CF-F868B1A7AF19} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
+		{0BDE97CF-0C16-4311-B5ED-C0A011EB3685} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8413198B-8D26-4E30-A5E2-E0FBC4DCEA59}

--- a/docs/adr/0012-sqlite-embedded-store-satellite.md
+++ b/docs/adr/0012-sqlite-embedded-store-satellite.md
@@ -79,14 +79,24 @@ the satellite*.
 - **`SqliteScheduler`.** A `jobs(id INTEGER PRIMARY KEY AUTOINCREMENT,
   payload TEXT NOT NULL, consumed INTEGER NOT NULL DEFAULT 0)` table.
   `AddAsync` is an `INSERT`; `GetAllAsync` reads `WHERE consumed = 0 ORDER
-  BY id` and marks rows `consumed = 1` transactionally as it yields.
+  BY id` and marks a row `consumed = 1` **before it yields it** — the
+  claim is committed first.
   **The position file and the `O(skip N lines)` `StreamReader` cursor are
   gone — resume is `SELECT … WHERE consumed = 0`.** The cursor↔job-file
   desync failure mode is *unrepresentable*: one store, one transaction.
-  After `kill -9`, an uncommitted consume rolls back and the same query
-  re-yields it — at-least-once, *exactly* `FileScheduler`'s existing
-  guarantee (its position file is written after the yield, so a mid-process
-  crash already re-yields) and no weaker.
+  This is claim-before-yield, the existing `IScheduler` family contract:
+  `FileScheduler` advances its position cursor *before* the `yield`
+  (`FileScheduler.cs`) and `RedisScheduler` pops destructively
+  (`ListLeftPop`) before its `yield`; the role interface has no ack, so
+  "consume = claim" *is* the contract, not a choice. On `kill -9` every
+  not-yet-claimed row is intact and re-yielded by the same `WHERE consumed
+  = 0` query; the single in-flight job is not re-yielded — the *same*
+  at-most-once-for-the-in-flight-job guarantee the whole family already
+  has, and no weaker. (Correction: an earlier draft of this clause said
+  `FileScheduler`'s position file is written *after* the yield — it is
+  not; the family is claim-before-yield. The decision and shape are
+  unaffected; only this rationale aside is fixed — recorded, per the
+  repo's "called out loud, never silent" rule, in PR #66.)
 - **The Job grammar is unchanged.** The payload is
   `WebReaperJson.SerializeJob` / `DeserializeJob` — the *same ADR-0008
   grammar* as `FileScheduler` and `RedisScheduler`. ADR-0008's uniform


### PR DESCRIPTION
**Slice 1 of ADR-0012.** New satellite package `WebReaper.Sqlite` — the local durable scheduler backed by an embedded SQLite store. Closes #66.

## What

- **`SqliteScheduler : IScheduler`** — `IScheduler` **byte-unchanged**. `jobs(id, payload, consumed)` table, WAL, partial index on unconsumed rows. `GetAllAsync` claims-before-yield in a `BEGIN IMMEDIATE` transaction (`deferred: false`, verified against the Microsoft.Data.Sqlite transactions docs) so the `SELECT`-then-`UPDATE` claim can't race a concurrent `AddAsync` into `SQLITE_BUSY` — the engine's `Parallel.ForEachAsync` fan-out scenario. **Resume is `SELECT … WHERE consumed = 0`** — no position file, no `O(skip N)` line cursor, the cursor↔job-file desync mode unrepresentable. Payload is `WebReaperJson` (same ADR-0008 grammar as `FileScheduler`/`RedisScheduler`).
- **`SqliteBuilderExtensions.WithSqliteScheduler`** over the public `WithScheduler` seam, mirroring `WithRedisScheduler` (optional `ILogger` → `NullLogger`).
- **csproj mirrors `WebReaper.Redis`**: net10.0, **NOT `IsAotCompatible`** (native `e_sqlite3`/SQLitePCLRaw quarantined here per ADR-0009/0012), `Microsoft.Data.Sqlite` 10.0.8. Version `7.1.0` (new satellite after the 7.0.0 wave — release-time owned, flagged in csproj).
- **`WebReaper.Sqlite.Tests`** (5): Job round-trip w/ full type fidelity, **resume-after-reopen** (the position-file-killer), `DataCleanupOnStart`, batch FIFO, extension chaining.
- README; both projects added to `WebReaper.sln` (test auto-nested under the Tests folder).

## ⚠️ ADR-0012 correction included (called out loud, never silent)

ADR-0012's Mechanism section claimed `FileScheduler`'s position file is written *after* the yield — **it isn't** (`FileScheduler.cs` advances the cursor *before* `yield`; `RedisScheduler` pops destructively before `yield`). The `IScheduler` family is **claim-before-yield / at-most-once for the in-flight job**; `SqliteScheduler` matches it exactly. The ADR's decision and shape are unaffected — only that one rationale aside is corrected (1 hunk in `docs/adr/0012-…md`). Surfaced here for your review since it's an after-merge edit to a merged ADR.

## Guardrail — green

- Whole-solution build: **0 errors**, no new warnings (only pre-existing repo noise)
- `WebReaper.Sqlite.Tests`: **5/5** (incl. resume-after-reopen)
- Core unit suite: **72/72** (no regression)
- `WebReaper.AotSmokeTest`: native publish, **0 IL warnings** (core byte-unchanged — satellite correctly off the AOT graph)

## Scope / not in this PR

Core is byte-unchanged; `FileScheduler` stays the zero-dep local default. Follows: **#67** `SqliteVisitedLinkTracker` (blocked by this), **#68** consumer docs (CHANGELOG/README/example, blocked by #66/#67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)