### PR TITLE
SqliteVisitedLinkTracker + TrackVisitedLinksInSqlite (#67)

### DIFF
--- a/WebReaper.Sqlite/SqliteBuilderExtensions.cs
+++ b/WebReaper.Sqlite/SqliteBuilderExtensions.cs
@@ -38,4 +38,25 @@ public static class SqliteBuilderExtensions
             logger ?? NullLogger.Instance,
             dataCleanupOnStart));
     }
+
+    /// <summary>
+    /// Tracks visited links in a SQLite-backed durable set, over
+    /// <see cref="ScraperEngineBuilder"/>'s public <c>WithLinkTracker</c>
+    /// seam. The opt-in robust-local tier: the table <em>is</em> the set, no
+    /// in-memory mirror (ADR-0012). The core file tracker stays the
+    /// zero-dependency default; this is opt-in.
+    /// </summary>
+    /// <param name="builder">The scraper engine builder.</param>
+    /// <param name="databasePath">Path to the SQLite database file (its directory is created if missing).</param>
+    /// <param name="dataCleanupOnStart">When <see langword="true"/>, the visited-link table is cleared when the scrape starts.</param>
+    /// <returns>The same <see cref="ScraperEngineBuilder"/>, for chaining.</returns>
+    public static ScraperEngineBuilder TrackVisitedLinksInSqlite(
+        this ScraperEngineBuilder builder,
+        string databasePath,
+        bool dataCleanupOnStart = false)
+    {
+        return builder.WithLinkTracker(new SqliteVisitedLinkTracker(
+            databasePath,
+            dataCleanupOnStart));
+    }
 }

--- a/WebReaper.Sqlite/SqliteVisitedLinkTracker.cs
+++ b/WebReaper.Sqlite/SqliteVisitedLinkTracker.cs
@@ -1,0 +1,142 @@
+using Microsoft.Data.Sqlite;
+using WebReaper.Core.LinkTracker.Abstract;
+
+namespace WebReaper.Sqlite;
+
+/// <summary>
+/// ADR-0012: the local durable visited-link set backed by an embedded SQLite
+/// store. The <c>visited(url PRIMARY KEY)</c> table <em>is</em> the set —
+/// queried directly, with <strong>no in-memory mirror</strong>. This is a
+/// deliberate deviation from <c>FileVisitedLinkedTracker</c>, mirroring
+/// <c>RedisVisitedLinkTracker</c> instead: the mirror is the file adapter's
+/// own essence and is exactly the "load the entire visited set into process
+/// memory at start" an embedded durable store exists to remove — it does not
+/// survive the very-large-crawl scale at which a durable store is chosen.
+/// Shape consistency across the durable tier (Redis and SQLite both "the
+/// store is the source of truth") is the right consistency. The
+/// <c>url PRIMARY KEY</c> index keeps the per-page <see cref="GetNotVisitedLinks"/>
+/// fast and the crawl is page-fetch-I/O-bound regardless. Satellite-only
+/// (ADR-0009): the native <c>e_sqlite3</c>/SQLitePCLRaw graph stays off the
+/// dependency-light core, whose <c>FileVisitedLinkedTracker</c> is unchanged.
+/// </summary>
+public class SqliteVisitedLinkTracker : IVisitedLinkTracker
+{
+    private readonly string _connectionString;
+    private readonly string _databasePath;
+
+    public bool DataCleanupOnStart { get; set; }
+
+    public Task Initialization { get; }
+
+    public SqliteVisitedLinkTracker(string databasePath, bool dataCleanupOnStart = false)
+    {
+        _databasePath = databasePath;
+        _connectionString = new SqliteConnectionStringBuilder { DataSource = databasePath }.ToString();
+        DataCleanupOnStart = dataCleanupOnStart;
+
+        Initialization = InitializeAsync();
+    }
+
+    private async Task InitializeAsync()
+    {
+        // SQLite creates the db file but not its directory; create it eagerly
+        // and idempotently (the satellite owns its own pre-write prep — it
+        // cannot reach core's internal FilePersistencePrep, ADR-0011).
+        var dir = Path.GetDirectoryName(_databasePath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        await using var connection = await OpenAsync();
+
+        // WAL is a persistent db-header setting (idempotent if a sibling
+        // adapter on the same file already set it). The table IS the set;
+        // there is no in-memory mirror to load (ADR-0012).
+        await ExecAsync(connection, "PRAGMA journal_mode=WAL;");
+        await ExecAsync(connection,
+            "CREATE TABLE IF NOT EXISTS visited (url TEXT PRIMARY KEY);");
+
+        if (DataCleanupOnStart)
+            await ExecAsync(connection, "DELETE FROM visited;");
+    }
+
+    public async Task AddVisitedLinkAsync(string visitedLink)
+    {
+        await Initialization;
+
+        await using var connection = await OpenAsync();
+        await using var cmd = connection.CreateCommand();
+        // INSERT OR IGNORE = the set's idempotent add: a duplicate url hits
+        // the PRIMARY KEY and is silently dropped (RedisVisitedLinkTracker's
+        // SetAdd semantics).
+        cmd.CommandText = "INSERT OR IGNORE INTO visited (url) VALUES ($u);";
+        cmd.Parameters.AddWithValue("$u", visitedLink);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public async Task<List<string>> GetVisitedLinksAsync()
+    {
+        await Initialization;
+
+        await using var connection = await OpenAsync();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT url FROM visited;";
+        var result = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            result.Add(reader.GetString(0));
+        return result;
+    }
+
+    public async Task<List<string>> GetNotVisitedLinks(IEnumerable<string> links)
+    {
+        await Initialization;
+
+        // Membership-per-link against the indexed PRIMARY KEY, input order
+        // preserved — RedisVisitedLinkTracker's links.Where(!SetContains)
+        // semantics. Deliberately NOT a full SELECT url FROM visited: that
+        // would be the in-memory-mirror load ADR-0012 removed.
+        var candidates = links as ICollection<string> ?? links.ToList();
+
+        await using var connection = await OpenAsync();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT EXISTS(SELECT 1 FROM visited WHERE url = $u);";
+        var p = cmd.Parameters.Add("$u", SqliteType.Text);
+
+        var notVisited = new List<string>();
+        foreach (var link in candidates)
+        {
+            p.Value = link;
+            var exists = Convert.ToInt64(await cmd.ExecuteScalarAsync()) == 1;
+            if (!exists)
+                notVisited.Add(link);
+        }
+        return notVisited;
+    }
+
+    public async Task<long> GetVisitedLinksCount()
+    {
+        await Initialization;
+
+        await using var connection = await OpenAsync();
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM visited;";
+        return Convert.ToInt64(await cmd.ExecuteScalarAsync());
+    }
+
+    private async Task<SqliteConnection> OpenAsync()
+    {
+        var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+        // Cooperate with SQLite's single-writer rule under the engine's
+        // parallel fan-out instead of failing fast on contention.
+        await ExecAsync(connection, "PRAGMA busy_timeout=30000;");
+        return connection;
+    }
+
+    private static async Task ExecAsync(SqliteConnection connection, string sql)
+    {
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/WebReaper.Tests/WebReaper.Sqlite.Tests/SqliteVisitedLinkTrackerTests.cs
+++ b/WebReaper.Tests/WebReaper.Sqlite.Tests/SqliteVisitedLinkTrackerTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.Data.Sqlite;
+using WebReaper.Sqlite;
+using Xunit;
+
+namespace WebReaper.Sqlite.Tests;
+
+// ADR-0012 acceptance criteria, pinned through the public IVisitedLinkTracker:
+// add is an idempotent set add (INSERT OR IGNORE); GetNotVisitedLinks returns
+// only the unvisited inputs, in order; count and membership are served FROM
+// the table and survive a reopen with a fresh instance (the deliberate
+// no-in-memory-mirror behaviour — a brand-new instance, whose memory is
+// empty, answers correctly because the table IS the set); DataCleanupOnStart
+// clears the table at start.
+public class SqliteVisitedLinkTrackerTests : IDisposable
+{
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), $"wr-sqlvt-{Guid.NewGuid():N}");
+
+    private string DbPath => Path.Combine(_dir, "nested", "visited.db");
+
+    [Fact]
+    public async Task AddVisitedLink_is_an_idempotent_set_add()
+    {
+        var tracker = new SqliteVisitedLinkTracker(DbPath);
+        await tracker.Initialization;
+
+        await tracker.AddVisitedLinkAsync("https://x/a");
+        await tracker.AddVisitedLinkAsync("https://x/b");
+        await tracker.AddVisitedLinkAsync("https://x/a"); // duplicate ignored
+
+        Assert.Equal(2, await tracker.GetVisitedLinksCount());
+        var all = await tracker.GetVisitedLinksAsync();
+        Assert.Equal(new[] { "https://x/a", "https://x/b" }, all.OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task GetNotVisitedLinks_returns_only_unvisited_in_input_order()
+    {
+        var tracker = new SqliteVisitedLinkTracker(DbPath);
+        await tracker.Initialization;
+        await tracker.AddVisitedLinkAsync("https://x/a");
+        await tracker.AddVisitedLinkAsync("https://x/c");
+
+        var notVisited = await tracker.GetNotVisitedLinks(
+            new[] { "https://x/a", "https://x/b", "https://x/c", "https://x/d" });
+
+        Assert.Equal(new[] { "https://x/b", "https://x/d" }, notVisited);
+    }
+
+    [Fact]
+    public async Task Membership_and_count_survive_reopen_without_an_in_memory_mirror()
+    {
+        var first = new SqliteVisitedLinkTracker(DbPath);
+        await first.Initialization;
+        await first.AddVisitedLinkAsync("https://x/a");
+        await first.AddVisitedLinkAsync("https://x/b");
+        await first.AddVisitedLinkAsync("https://x/c");
+
+        // Fresh instance, same db, no cleanup: its in-memory state is empty,
+        // yet it answers from the table — proving the no-mirror design.
+        var reopened = new SqliteVisitedLinkTracker(DbPath);
+        await reopened.Initialization;
+
+        Assert.Equal(3, await reopened.GetVisitedLinksCount());
+        Assert.Equal(
+            new[] { "https://x/z" },
+            await reopened.GetNotVisitedLinks(new[] { "https://x/b", "https://x/z" }));
+        Assert.Equal(
+            new[] { "https://x/a", "https://x/b", "https://x/c" },
+            (await reopened.GetVisitedLinksAsync()).OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task DataCleanupOnStart_clears_a_preexisting_visited_table()
+    {
+        var first = new SqliteVisitedLinkTracker(DbPath);
+        await first.Initialization;
+        await first.AddVisitedLinkAsync("https://stale/1");
+        await first.AddVisitedLinkAsync("https://stale/2");
+
+        var fresh = new SqliteVisitedLinkTracker(DbPath, dataCleanupOnStart: true);
+        await fresh.Initialization;
+
+        Assert.Equal(0, await fresh.GetVisitedLinksCount());
+
+        await fresh.AddVisitedLinkAsync("https://fresh/1");
+        Assert.Equal(1, await fresh.GetVisitedLinksCount());
+        Assert.Equal(new[] { "https://fresh/1" }, await fresh.GetVisitedLinksAsync());
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { /* best-effort temp cleanup */ }
+    }
+}

--- a/WebReaper.Tests/WebReaper.Sqlite.Tests/TrackVisitedLinksInSqliteExtensionTests.cs
+++ b/WebReaper.Tests/WebReaper.Sqlite.Tests/TrackVisitedLinksInSqliteExtensionTests.cs
@@ -1,0 +1,23 @@
+using Xunit;
+using WebReaper.Builders;
+using WebReaper.Sqlite;
+
+namespace WebReaper.Sqlite.Tests;
+
+public class TrackVisitedLinksInSqliteExtensionTests
+{
+    // ADR-0009/0012: TrackVisitedLinksInSqlite is an extension over the
+    // public WithLinkTracker registration seam, preserving fluent chaining —
+    // the same satellite contract as TrackVisitedLinksInRedis.
+    [Fact]
+    public void TrackVisitedLinksInSqlite_is_a_ScraperEngineBuilder_extension_that_chains()
+    {
+        var builder = new ScraperEngineBuilder();
+
+        var result = builder.TrackVisitedLinksInSqlite(
+            databasePath: Path.Combine(Path.GetTempPath(), $"wr-sqlvt-{Guid.NewGuid():N}.db"),
+            dataCleanupOnStart: false);
+
+        Assert.Same(builder, result);
+    }
+}


### PR DESCRIPTION
**Slice 2 of ADR-0012.** `SqliteVisitedLinkTracker : IVisitedLinkTracker` in the `WebReaper.Sqlite` satellite. Closes #67.

## What

- **`SqliteVisitedLinkTracker : IVisitedLinkTracker`** — `IVisitedLinkTracker` **byte-unchanged**. `visited(url TEXT PRIMARY KEY)`. `AddVisitedLinkAsync` = `INSERT OR IGNORE` (idempotent set add). `GetNotVisitedLinks` = membership-per-link against the indexed PK, **input order preserved** (`RedisVisitedLinkTracker`'s `links.Where(!SetContains)` semantics). `GetVisitedLinksCount` = `SELECT COUNT(*)`. `DataCleanupOnStart` clears at start. WAL + `busy_timeout`, directory created eagerly.
- **Deliberate ADR-0012 deviation — no in-memory mirror.** The table *is* the set, mirroring `RedisVisitedLinkTracker`, not `FileVisitedLinkedTracker`. The mirror is the file adapter's essence and is exactly the load-everything-into-memory an embedded durable store exists to remove. Documented in the type doc and **pinned by a test** (`Membership_and_count_survive_reopen_without_an_in_memory_mirror`: a fresh instance with empty memory answers correctly from the table). `GetNotVisitedLinks` deliberately does *not* `SELECT` the whole table.
- **`TrackVisitedLinksInSqlite`** over the public `WithLinkTracker` seam, mirroring `TrackVisitedLinksInRedis` (no logger — `IVisitedLinkTracker` has none).
- **5 new tests** (`WebReaper.Sqlite.Tests` now **10**): idempotent add, NotVisited in input order, the no-mirror reopen, `DataCleanupOnStart`, extension chaining.

## Deliberate non-refactor (flagged)

`SqliteVisitedLinkTracker` carries its own ~5-line `OpenAsync` rather than refactoring #66's **merged** `SqliteScheduler` to share one. Sharing it would be scope creep into shipped code and extra review surface for a trivial connection-open; it's a named cleanup if ever wanted, not this slice. Keeps #67 purely additive (1 modified file: the extensions; 3 new).

## Guardrail — green

- Whole-solution build: **0 errors**, no new warnings
- `WebReaper.Sqlite.Tests`: **10/10** (5 from #66 + 5 here, incl. the no-mirror reopen)
- Core unit suite: **72/72** (no regression)
- `WebReaper.AotSmokeTest`: native publish, **0 IL warnings** (core byte-unchanged — satellite off the AOT graph)

## Scope

Core byte-unchanged; `FileVisitedLinkedTracker` stays the zero-dep local default. No `.sln`/core edits — additive to the satellite. Follows: **#68** consumer docs (CHANGELOG/README/example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)