### PR TITLE
WebReaper.Sqlite consumer docs: CHANGELOG + README (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 7.1.0 — WebReaper.Sqlite satellite: opt-in robust-local durable scheduler & tracker (additive)
+
+New satellite package **WebReaper.Sqlite** — a local durable scheduler and
+visited-link tracker backed by an embedded SQLite store via
+`Microsoft.Data.Sqlite`. "Resume" is a `SELECT … WHERE consumed = 0` over an
+indexed table: `FileScheduler`'s append-only job file + sidecar position file
++ `O(skip N)` line cursor (and the cursor↔job-file desync failure mode) are
+gone for the consumer who opts in. Rationale, the satellite-not-core
+constraint, and the considered options:
+[`docs/adr/0012-sqlite-embedded-store-satellite.md`](docs/adr/0012-sqlite-embedded-store-satellite.md).
+
+This is **additive** — nothing is removed or changed in core or the existing
+satellites. The core file scheduler and visited-link tracker are
+byte-unchanged and remain the zero-dependency local default; SQLite is the
+opt-in robust-local tier between them and the distributed Redis / Azure
+Service Bus satellites.
+
+- `ScraperEngineBuilder.WithSqliteScheduler(databasePath, dataCleanupOnStart?, logger?)`
+  over the public `WithScheduler` seam; `SqliteScheduler : IScheduler`.
+- `ScraperEngineBuilder.TrackVisitedLinksInSqlite(databasePath, dataCleanupOnStart?)`
+  over the public `WithLinkTracker` seam; `SqliteVisitedLinkTracker :
+  IVisitedLinkTracker`. The `visited(url PRIMARY KEY)` table *is* the set —
+  no in-memory mirror (a deliberate ADR-0012 deviation from the file
+  tracker, mirroring the Redis tracker).
+- The `Job` payload uses the same `WebReaperJson` grammar as the core file
+  scheduler and the Redis scheduler (ADR-0008) — full type fidelity.
+- Satellite per ADR-0009 / ADR-0012: core does not reference
+  `Microsoft.Data.Sqlite`, so the native `e_sqlite3` (SQLitePCLRaw) graph
+  stays off the dependency-light, Native-AOT-zero-warning core. Like the
+  other satellites it is deliberately not marked `IsAotCompatible`.
+- Versioned `7.1.0`: a new satellite added after the `7.0.0` satellite wave;
+  it depends on `WebReaper` core `7.0.0`.
+
+ADR-0012 itself carried a one-line correction (landed with the first
+implementation slice, called out loud): its Mechanism section had wrongly
+said `FileScheduler` writes its position file *after* the yield — the whole
+`IScheduler` family is claim-before-yield / at-most-once for the in-flight
+job, and `SqliteScheduler` matches it. Decision and shape unaffected.
+
 ## 7.0.0 — Satellite adapter packages; dependency-light core (breaking)
 
 Heavy third-party adapters move out of the core `WebReaper` package into

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ a simple, extensible fluent API.
 
 As of **7.0.0** the core `WebReaper` package is **dependency-light, Native-AOT-ready and Newtonsoft-free**:
 a plain HTTP → file crawl pulls only AngleSharp, `Microsoft.Extensions.*` and Polly. Heavier capabilities
-(headless browser, MongoDB, Redis, Azure Cosmos DB, Azure Service Bus) ship as **optional satellite
-packages** you add only when you need them — see [Packages](#packages).
+(headless browser, MongoDB, Redis, Azure Cosmos DB, Azure Service Bus, SQLite-backed local durable
+scheduler/tracker) ship as **optional satellite packages** you add only when you need them — see
+[Packages](#packages).
 
 ## Quick start
 
@@ -83,12 +84,14 @@ dotnet add package WebReaper.Mongo            # MongoDB sink + config/cookie sto
 dotnet add package WebReaper.Redis            # Redis scheduler, tracker, sink, storage
 dotnet add package WebReaper.AzureServiceBus  # Azure Service Bus distributed scheduler
 dotnet add package WebReaper.Cosmos           # Azure Cosmos DB sink
+dotnet add package WebReaper.Sqlite           # SQLite local durable scheduler + visited-link tracker
 ```
 
 ## Packages
 
-Every package is versioned in lockstep (`7.0.0`) and GPL-3.0-or-later. Satellites depend on the
-matching core version and wire themselves in through the builder's public registration seam.
+The core and the original satellite set are versioned in lockstep (`7.0.0`); `WebReaper.Sqlite` was
+added afterwards and is `7.1.0` (it depends on core `7.0.0`). All packages are GPL-3.0-or-later, and
+every satellite wires itself in through the builder's public registration seam.
 
 | Package | Add it for | Key builder calls |
 |---|---|---|
@@ -98,6 +101,7 @@ matching core version and wire themselves in through the builder's public regist
 | **WebReaper.Redis** | Redis scheduler, visited-link tracker, result sink, config / cookie storage | `.WithRedisScheduler(...)` `.TrackVisitedLinksInRedis(...)` `.WriteToRedis(...)` `.WithRedisConfigStorage(...)` `.WithRedisCookieStorage(...)` |
 | **WebReaper.AzureServiceBus** | Distributed scheduler over an Azure Service Bus queue | `.WithAzureServiceBusScheduler(...)` |
 | **WebReaper.Cosmos** | Azure Cosmos DB result sink | `.WriteToCosmosDb(...)` |
+| **WebReaper.Sqlite** | Local **durable** scheduler & visited-link tracker on an embedded SQLite store — resume is a query, no position file. Opt-in robust-local tier (no server, unlike Redis). | `.WithSqliteScheduler(...)` `.TrackVisitedLinksInSqlite(...)` |
 
 > The core default page loader is **HTTP-only**. Crawling a dynamic page (`GetWithBrowser` /
 > `FollowWithBrowser` / `PaginateWithBrowser`) without `WebReaper.Puppeteer` registered throws an
@@ -229,6 +233,30 @@ var engine = await new ScraperEngineBuilder()
     .BuildAsync();
 ```
 
+The file scheduler is the zero-dependency default: an append-only job file, a 300 ms poll and a
+sidecar position file. For a long single-machine crawl that must survive `kill -9` and resume by
+query — without standing up a Redis server — add the `WebReaper.Sqlite` satellite and swap the two
+local backends. "Resume" becomes a `SELECT` over an indexed table; there is no position file to keep
+in sync (the visited-link table *is* the set — no in-memory mirror). The core file adapters are
+unchanged and stay the default; this is opt-in:
+
+```C#
+using WebReaper.Builders;
+using WebReaper.Sqlite;   // dotnet add package WebReaper.Sqlite
+
+var engine = await new ScraperEngineBuilder()
+    .Get("https://rutracker.org/forum/index.php?c=33")
+    .Follow(".forumlink>a")
+    .Paginate("a.torTopic", ".pg")
+    .Parse(new() { new("name", "#topic-title") })
+    .WriteToJsonFile("result.json")
+    .WithSqliteScheduler("crawl/state.db")        // resume is a query, not a position file
+    .TrackVisitedLinksInSqlite("crawl/state.db")  // the table is the set
+    .BuildAsync();
+```
+
+Pass `dataCleanupOnStart: true` to either call to start a fresh crawl (clears that table at start).
+
 ### Authorization
 
 If the site needs authorization, call `SetCookies` and fill the `CookieContainer` with the cookies
@@ -313,8 +341,8 @@ from satellites.
 
 | Seam | Core (in-memory default + file) | Satellite options |
 |---|---|---|
-| Scheduler | in-memory, `WithTextFileScheduler` | `WithRedisScheduler` (Redis), `WithAzureServiceBusScheduler` (Azure Service Bus) |
-| Visited-link tracker | in-memory, `TrackVisitedLinksInFile` | `TrackVisitedLinksInRedis` (Redis) |
+| Scheduler | in-memory, `WithTextFileScheduler` | `WithSqliteScheduler` (SQLite, local durable), `WithRedisScheduler` (Redis), `WithAzureServiceBusScheduler` (Azure Service Bus) |
+| Visited-link tracker | in-memory, `TrackVisitedLinksInFile` | `TrackVisitedLinksInSqlite` (SQLite, local durable), `TrackVisitedLinksInRedis` (Redis) |
 | Config storage | in-memory, `WithFileConfigStorage` | `WithMongoDbConfigStorage`, `WithRedisConfigStorage` |
 | Cookie storage | in-memory, `WithFileCookieStorage` | `WithMongoDbCookieStorage`, `WithRedisCookieStorage` |
 | Result sink | `WriteToConsole`, `WriteToCsvFile`, `WriteToJsonFile` | `WriteToMongoDb`, `WriteToRedis`, `WriteToCosmosDb` |


### PR DESCRIPTION
**Slice 3 (final) of ADR-0012.** Docs-only — the consumer-facing docs that land **with** the now-shipped implementation (#66 scheduler, #67 tracker). Closes #68 and completes the ADR-0012 rollout.

## What

- **CHANGELOG.md**: additive `7.1.0` section, mirroring the `7.0.0` satellite-entry prose shape — explicitly additive (no breaking subsection), the satellite-not-core constraint, the no-mirror tracker deviation, the ADR-0008 same-`WebReaperJson`-grammar `Job` payload, the `7.1.0` versioning, and a note that ADR-0012's claim-before-yield correction landed in #66.
- **README.md**:
  - Overview satellite list, Install line, Packages-table row.
  - **Corrected the "versioned in lockstep (`7.0.0`)" line** — it became inaccurate once `WebReaper.Sqlite` shipped at `7.1.0`. Now: core + original set `7.0.0`; `WebReaper.Sqlite` `7.1.0` on core `7.0.0`.
  - **Example** added to *Persist the progress locally* with the tier framing (file = zero-dep default; SQLite = opt-in robust-local, no server; resume is a query; the visited table *is* the set).
  - Storage/scheduler seam table updated.

## Scope / guardrail

No example **project** added — consistent with the other satellites (Redis has none either; usage is documented via README snippets), so the issue's conditional whole-solution-build clause doesn't apply. Changeset is **exactly 2 `.md` files** — zero compilable files changed, zero build impact (the ADR-0009/0011/0012 docs-PR precedent: no build/test/AOT run for docs-only).

## ADR-0012 rollout complete on merge

| Issue | Slice | State |
|---|---|---|
| #58 | Design pass / ADR-0012 | merged (PR #65) |
| #66 | `SqliteScheduler` + satellite | merged (PR #69) |
| #67 | `SqliteVisitedLinkTracker` | merged (PR #70) |
| **#68** | **Consumer docs** | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)