### PR TITLE
9.0.0: the core public surface is the documented contract (ADR-0023)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -62,3 +62,16 @@ dotnet_diagnostic.CS1591.severity = error
 
 [WebReaper/Exceptions/*.cs]
 dotnet_diagnostic.CS1591.severity = error
+
+# Slice 5a — the last Tier-1 the deletion test pulled back from "looks like
+# Tier-2": ScraperEngine (the runtime object BuildAsync returns) and the only
+# built-in IProxySource / IProxyValidator the public WithValidatedProxies seam
+# takes. File-scoped — their dirs still hold Tier-2 until Slice 5b.
+[WebReaper/Core/ScraperEngine.cs]
+dotnet_diagnostic.CS1591.severity = error
+
+[WebReaper/Proxy/Concrete/StaticProxySource.cs]
+dotnet_diagnostic.CS1591.severity = error
+
+[WebReaper/Proxy/Concrete/HttpProxyValidator.cs]
+dotnet_diagnostic.CS1591.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+# ADR-0023: the core public surface is a documented contract, ratcheted
+# closed area-by-area. CS1591 (missing XML doc) is promoted to a build
+# ERROR for each core Tier-1 area as that area reaches zero — the documented
+# surface is monotone (a new undocumented public member there fails the
+# build, the way the ~552 backlog accumulated). These path-scoped sections
+# grow one per slice; at the end state (Tier-1 documented + Tier-2 internal,
+# core CS1591 == 0) they are replaced by project-wide WarningsAsErrors=CS1591
+# and removed. Scoped to "WebReaper/" so it never touches the satellites
+# (they NoWarn CS1591 by their own recorded rationale) or non-shipped code.
+
+# Slice 1 — the pluggable seam interfaces (an extension author's entire
+# surface; the offline test surface).
+[WebReaper/**/Abstract/*.cs]
+dotnet_diagnostic.CS1591.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,32 @@ dotnet_diagnostic.CS1591.severity = error
 # SpiderBuilder is internal, off-surface).
 [WebReaper/Builders/*.cs]
 dotnet_diagnostic.CS1591.severity = error
+
+# Slice 3 — the public Domain model + the two payload-shell bases satellites
+# inherit + the in-memory default adapters the ADR-0009 DIY pattern wires.
+# Directory-scoped where the whole dir is Tier-1; file-scoped for the bases /
+# in-memory defaults whose */Concrete dirs still hold Tier-2 leaves
+# (File* / InMemoryCookieStorage) until Slice 5 internalises them.
+[WebReaper/Domain/**.cs]
+dotnet_diagnostic.CS1591.severity = error
+
+[WebReaper/Core/Crawling/*.cs]
+dotnet_diagnostic.CS1591.severity = error
+
+[WebReaper/Sinks/Models/*.cs]
+dotnet_diagnostic.CS1591.severity = error
+
+[WebReaper/Core/CookieStorage/Concrete/CookieStore.cs]
+dotnet_diagnostic.CS1591.severity = error
+
+[WebReaper/ConfigStorage/Concrete/ScraperConfigStore.cs]
+dotnet_diagnostic.CS1591.severity = error
+
+[WebReaper/ConfigStorage/Concrete/InMemoryScraperConfigStorage.cs]
+dotnet_diagnostic.CS1591.severity = error
+
+[WebReaper/Core/Scheduler/Concrete/InMemoryScheduler.cs]
+dotnet_diagnostic.CS1591.severity = error
+
+[WebReaper/Core/LinkTracker/Concrete/InMemoryVisitedLinkTracker.cs]
+dotnet_diagnostic.CS1591.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,77 +1,13 @@
 root = true
 
-# ADR-0023: the core public surface is a documented contract, ratcheted
-# closed area-by-area. CS1591 (missing XML doc) is promoted to a build
-# ERROR for each core Tier-1 area as that area reaches zero — the documented
-# surface is monotone (a new undocumented public member there fails the
-# build, the way the ~552 backlog accumulated). These path-scoped sections
-# grow one per slice; at the end state (Tier-1 documented + Tier-2 internal,
-# core CS1591 == 0) they are replaced by project-wide WarningsAsErrors=CS1591
-# and removed. Scoped to "WebReaper/" so it never touches the satellites
-# (they NoWarn CS1591 by their own recorded rationale) or non-shipped code.
-
-# Slice 1 — the pluggable seam interfaces (an extension author's entire
-# surface; the offline test surface).
-[WebReaper/**/Abstract/*.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-# Slice 2 — the fluent builder API (the README's front door:
-# ScraperEngineBuilder facade + ConfigBuilder + PageActionBuilder;
-# SpiderBuilder is internal, off-surface).
-[WebReaper/Builders/*.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-# Slice 3 — the public Domain model + the two payload-shell bases satellites
-# inherit + the in-memory default adapters the ADR-0009 DIY pattern wires.
-# Directory-scoped where the whole dir is Tier-1; file-scoped for the bases /
-# in-memory defaults whose */Concrete dirs still hold Tier-2 leaves
-# (File* / InMemoryCookieStorage) until Slice 5 internalises them.
-[WebReaper/Domain/**.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-[WebReaper/Core/Crawling/*.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-[WebReaper/Sinks/Models/*.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-[WebReaper/Core/CookieStorage/Concrete/CookieStore.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-[WebReaper/ConfigStorage/Concrete/ScraperConfigStore.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-[WebReaper/ConfigStorage/Concrete/InMemoryScraperConfigStorage.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-[WebReaper/Core/Scheduler/Concrete/InMemoryScheduler.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-[WebReaper/Core/LinkTracker/Concrete/InMemoryVisitedLinkTracker.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-# Slice 4 — the cross-assembly Job/Config grammar + public exceptions.
-# WebReaperJson is file-scoped (the Serialization/ converters + source-gen
-# context are Tier-2, internalised in Slice 5). Extensions/ is deliberately
-# NOT ratcheted here: LoggerExtensions is Tier-1 and documented, but its
-# file-siblings Timer/Counter are Tier-2 (incidental-public, returned as
-# IDisposable / named by nobody) and keep that path non-zero until Slice 5
-# internalises them — a path ratchets only once it reaches zero.
-[WebReaper/Serialization/WebReaperJson.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-[WebReaper/Exceptions/*.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-# Slice 5a — the last Tier-1 the deletion test pulled back from "looks like
-# Tier-2": ScraperEngine (the runtime object BuildAsync returns) and the only
-# built-in IProxySource / IProxyValidator the public WithValidatedProxies seam
-# takes. File-scoped — their dirs still hold Tier-2 until Slice 5b.
-[WebReaper/Core/ScraperEngine.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-[WebReaper/Proxy/Concrete/StaticProxySource.cs]
-dotnet_diagnostic.CS1591.severity = error
-
-[WebReaper/Proxy/Concrete/HttpProxyValidator.cs]
-dotnet_diagnostic.CS1591.severity = error
+# ADR-0023: the core public surface is the documented contract.
+#
+# This file once carried a per-slice CS1591 ratchet (one path-scoped
+# `dotnet_diagnostic.CS1591.severity = error` section flipped as each Tier-1
+# area reached zero). At the end state — every Tier-1 type documented, every
+# Tier-2 implementation type internal — core CS1591 is zero and enforcement
+# moved to a single project-wide `<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>`
+# in WebReaper/WebReaper.csproj. The scaffolding sections are intentionally
+# removed (the ADR's planned terminal step), not lost. Satellites keep their
+# own NoWarn CS1591 by their own recorded rationale; this file is core-only by
+# never having been anything else.

--- a/.editorconfig
+++ b/.editorconfig
@@ -49,3 +49,16 @@ dotnet_diagnostic.CS1591.severity = error
 
 [WebReaper/Core/LinkTracker/Concrete/InMemoryVisitedLinkTracker.cs]
 dotnet_diagnostic.CS1591.severity = error
+
+# Slice 4 — the cross-assembly Job/Config grammar + public exceptions.
+# WebReaperJson is file-scoped (the Serialization/ converters + source-gen
+# context are Tier-2, internalised in Slice 5). Extensions/ is deliberately
+# NOT ratcheted here: LoggerExtensions is Tier-1 and documented, but its
+# file-siblings Timer/Counter are Tier-2 (incidental-public, returned as
+# IDisposable / named by nobody) and keep that path non-zero until Slice 5
+# internalises them — a path ratchets only once it reaches zero.
+[WebReaper/Serialization/WebReaperJson.cs]
+dotnet_diagnostic.CS1591.severity = error
+
+[WebReaper/Exceptions/*.cs]
+dotnet_diagnostic.CS1591.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,9 @@ root = true
 # surface; the offline test surface).
 [WebReaper/**/Abstract/*.cs]
 dotnet_diagnostic.CS1591.severity = error
+
+# Slice 2 — the fluent builder API (the README's front door:
+# ScraperEngineBuilder facade + ConfigBuilder + PageActionBuilder;
+# SpiderBuilder is internal, off-surface).
+[WebReaper/Builders/*.cs]
+dotnet_diagnostic.CS1591.severity = error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## 9.0.0 — The public surface is the documented contract (breaking)
+
+The core public API is now exactly the contract — no wider, no narrower —
+documented to the bar the codebase already set, and enforced. ADR-0023 drew
+the line with the deletion test (named by a documented consumer / inherited by
+a satellite / part of the taught fluent API ⇒ public; reached only through a
+builder method and named by nobody ⇒ implementation). The ~552-warning CS1591
+backlog the satellite csprojs deliberately kept *visible* is closed: every
+Tier-1 type carries real intent-revealing XML doc, every Tier-2 implementation
+type is now `internal`, and `<WarningsAsErrors>CS1591</WarningsAsErrors>` makes
+the documented surface non-regressing (a new undocumented public member fails
+the build). Rationale, the deletion-test line, the rejected alternatives (the
+shallow factory; document-everything; the non-breaking 8.1.0/9.0.0 split) and
+the staged burndown:
+[`docs/adr/0023-core-doc-contract.md`](docs/adr/0023-core-doc-contract.md).
+
+The satellite csprojs' "core keeps CS1591 visible — a live doc backlog"
+rationale is updated in place to point here: core CS1591 is now a
+contract-enforced zero, not an open backlog.
+
+### Breaking changes
+
+- **The Tier-2 implementation adapters are now `internal`.** The concrete
+  types reached only via the fluent builder (or core-internally) are no longer
+  public: the `File*` / `InMemory*` storage·scheduler·tracker·blob leaves
+  (`FileScheduler`, `FileScraperConfigStorage`, `FileCookieStorage`,
+  `FileVisitedLinkedTracker`, `FileBlobStore`, `InMemoryBlobStore`,
+  `InMemoryCookieStorage`), the sinks (`ConsoleSink`, `CsvFileSink`,
+  `JsonLinesFileSink`, `BufferedFileSink`, `CsvFormat`, `JsonLinesFormat`),
+  the parsers/loaders (`AngleSharpContentParser`, `JsonContentParser`,
+  `XPathContentParser`, `LinkParserByCssSelector`, `PageLoader`,
+  `HttpPageLoadTransport`, `BrowserNotConfiguredPageLoadTransport`), the
+  crawl internals (`Spider`, `CrawlStep`, `InMemoryOutstandingWorkLatch`),
+  `ValidatedProxyProvider`, `Executor`, `ColorConsoleLogger`, and the
+  `LogMethodDuration` / `LogInvocationCount` helpers `Timer` / `Counter`.
+- **`ScraperEngine`'s constructor is `internal`.** The class stays public (you
+  hold it and call `RunAsync`); only `new ScraperEngine(...)` is gone —
+  `ScraperEngineBuilder.BuildAsync()` is the construction contract (the
+  `internal SpiderBuilder` / `BuildSpider()` precedent).
+- **No shipped package is affected.** A repo-wide sweep confirmed no
+  satellite-prod / Example / Misc code names a Tier-2 type; satellites bind
+  the Tier-1 interfaces and inherit the Tier-1 payload-shell bases
+  (`CookieStore` / `ScraperConfigStore`). `[InternalsVisibleTo]` targets the
+  test assemblies only — never a NuGet package.
+- **Kept public on purpose:** the fluent builders, every `*/Abstract` seam
+  interface, the `Domain` model, `WebReaperJson`, `LoggerExtensions`,
+  `ScraperEngine` (the type), the in-memory default adapters the
+  distributed-worker pattern wires by hand, the `CookieStore` /
+  `ScraperConfigStore` satellite-inheritance bases, `StaticProxySource` /
+  `HttpProxyValidator` (the only built-in `WithValidatedProxies` inputs), and
+  **`SchemaContentParser<TNode>`** — the ADR-0002 custom-backend reuse vehicle.
+
+### Migration
+
+A fluent-API consumer (`new ScraperEngineBuilder()…BuildAsync()` /
+`.RunAsync()`), a custom seam implementer (`IScraperSink`, `IScheduler`,
+`ISchemaBackend<TNode>` + `SchemaContentParser<TNode>`, …), and the
+distributed-worker pattern all need **no changes** — every type they touch
+stayed public. The only break is code that constructed a core *implementation*
+adapter by name (e.g. `new ConsoleSink()`, `new FileScheduler(...)`): switch
+to the builder method that wired it (`.WriteToConsole()`,
+`.WithTextFileScheduler(...)`) or to the interface. No behavioural change —
+this is visibility + documentation only (zero IL delta in the documented
+paths; `WebReaper.AotSmokeTest` still publishes Native-AOT zero-warning).
+
 ## 8.0.0 — Crawl driver + Outstanding-work latch; the per-Job shell is a value, not a thrower (breaking)
 
 The per-Job `Spider` shell stops leaking its result through side channels and

--- a/WebReaper.AzureServiceBus/WebReaper.AzureServiceBus.csproj
+++ b/WebReaper.AzureServiceBus/WebReaper.AzureServiceBus.csproj
@@ -10,8 +10,7 @@
          moved adapter classes (*Sink / *Scheduler / *Storage) are public only
          because the extension and tests bind to them; they are not part of the
          satellite's documented contract, so CS1591 for them is noise, not a
-         backlog signal. Core keeps CS1591 visible by contrast — there it IS a
-         live doc backlog. -->
+         backlog signal. Core CS1591 is now a contract-enforced zero (ADR-0023): every Tier-1 type documented, every Tier-2 type internal, WarningsAsErrors=CS1591 project-wide - no longer an open backlog. -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <PackageId>WebReaper.AzureServiceBus</PackageId>

--- a/WebReaper.Cosmos/WebReaper.Cosmos.csproj
+++ b/WebReaper.Cosmos/WebReaper.Cosmos.csproj
@@ -10,8 +10,7 @@
          moved adapter classes (*Sink / *Scheduler / *Storage) are public only
          because the extension and tests bind to them; they are not part of the
          satellite's documented contract, so CS1591 for them is noise, not a
-         backlog signal. Core keeps CS1591 visible by contrast — there it IS a
-         live doc backlog. -->
+         backlog signal. Core CS1591 is now a contract-enforced zero (ADR-0023): every Tier-1 type documented, every Tier-2 type internal, WarningsAsErrors=CS1591 project-wide - no longer an open backlog. -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <PackageId>WebReaper.Cosmos</PackageId>

--- a/WebReaper.Mongo/WebReaper.Mongo.csproj
+++ b/WebReaper.Mongo/WebReaper.Mongo.csproj
@@ -10,8 +10,7 @@
          moved adapter classes (*Sink / *Scheduler / *Storage) are public only
          because the extension and tests bind to them; they are not part of the
          satellite's documented contract, so CS1591 for them is noise, not a
-         backlog signal. Core keeps CS1591 visible by contrast — there it IS a
-         live doc backlog. -->
+         backlog signal. Core CS1591 is now a contract-enforced zero (ADR-0023): every Tier-1 type documented, every Tier-2 type internal, WarningsAsErrors=CS1591 project-wide - no longer an open backlog. -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <PackageId>WebReaper.Mongo</PackageId>

--- a/WebReaper.Puppeteer/WebReaper.Puppeteer.csproj
+++ b/WebReaper.Puppeteer/WebReaper.Puppeteer.csproj
@@ -10,8 +10,7 @@
          moved adapter classes (BrowserPageLoadTransport etc.) are public only
          because the extension and tests bind to them; they are not part of the
          satellite's documented contract, so CS1591 for them is noise, not a
-         backlog signal. Core keeps CS1591 visible by contrast — there it IS a
-         live doc backlog. -->
+         backlog signal. Core CS1591 is now a contract-enforced zero (ADR-0023): every Tier-1 type documented, every Tier-2 type internal, WarningsAsErrors=CS1591 project-wide - no longer an open backlog. -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <PackageId>WebReaper.Puppeteer</PackageId>

--- a/WebReaper.Redis/WebReaper.Redis.csproj
+++ b/WebReaper.Redis/WebReaper.Redis.csproj
@@ -10,8 +10,7 @@
          moved adapter classes (*Sink / *Scheduler / *Storage) are public only
          because the extension and tests bind to them; they are not part of the
          satellite's documented contract, so CS1591 for them is noise, not a
-         backlog signal. Core keeps CS1591 visible by contrast — there it IS a
-         live doc backlog. -->
+         backlog signal. Core CS1591 is now a contract-enforced zero (ADR-0023): every Tier-1 type documented, every Tier-2 type internal, WarningsAsErrors=CS1591 project-wide - no longer an open backlog. -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <PackageId>WebReaper.Redis</PackageId>

--- a/WebReaper.Sqlite/WebReaper.Sqlite.csproj
+++ b/WebReaper.Sqlite/WebReaper.Sqlite.csproj
@@ -10,8 +10,7 @@
          adapter classes (SqliteScheduler / future SqliteVisitedLinkTracker)
          are public only because the extension and tests bind to them; they
          are not part of the satellite's documented contract, so CS1591 for
-         them is noise, not a backlog signal. Core keeps CS1591 visible by
-         contrast — there it IS a live doc backlog. -->
+         them is noise, not a backlog signal. Core CS1591 is now a contract-enforced zero (ADR-0023): every Tier-1 type documented, every Tier-2 type internal, WarningsAsErrors=CS1591 project-wide - no longer an open backlog. -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <PackageId>WebReaper.Sqlite</PackageId>

--- a/WebReaper/Builders/ConfigBuilder.cs
+++ b/WebReaper/Builders/ConfigBuilder.cs
@@ -6,6 +6,19 @@ using WebReaper.Domain.Selectors;
 
 namespace WebReaper.Builders;
 
+/// <summary>
+/// Accumulates the crawl definition and produces the immutable
+/// <see cref="ScraperConfig"/> (the build path: <see cref="ScraperEngineBuilder"/>
+/// is a façade over this plus the runtime <c>SpiderBuilder</c>). The
+/// <see cref="Follow"/> / <see cref="Paginate"/> calls build the
+/// <see cref="LinkPathSelector"/> chain that is the crawl's state machine
+/// (ADR-0001): chain length decides parse-vs-follow-vs-paginate. Use this
+/// directly only when you need a <see cref="ScraperConfig"/> without the
+/// engine (e.g. persisting it for the distributed-worker pattern, ADR-0009);
+/// most consumers use the <see cref="ScraperEngineBuilder"/> façade. Fluent —
+/// every method returns the same instance; <see cref="Build"/> validates and
+/// freezes.
+/// </summary>
 public class ConfigBuilder
 {
     private readonly List<LinkPathSelector> _linkPathSelectors = new();
@@ -27,10 +40,13 @@ public class ConfigBuilder
     private IEnumerable<string> _startUrls;
 
     /// <summary>
-    ///     This method can be called only one time to specify urls to start crawling with.
+    /// The crawl's start URLs, loaded as static HTTP pages. Defines the seed
+    /// set and the start <see cref="PageType"/>; call once — a later
+    /// <see cref="Get"/> / <see cref="GetWithBrowser"/> replaces the set.
+    /// Required: <see cref="Build"/> throws if neither was called (or the set
+    /// is empty).
     /// </summary>
-    /// <param name="startUrls">Initial urls for crawling</param>
-    /// <returns>instance of ConfigBuilder</returns>
+    /// <param name="startUrls">Initial URLs for crawling.</param>
     public ConfigBuilder Get(params string[] startUrls)
     {
         _startUrls = startUrls;
@@ -40,11 +56,14 @@ public class ConfigBuilder
     }
 
     /// <summary>
-    ///     This method can be called only one time to specify urls to start crawling with.
+    /// Like <see cref="Get"/>, but the start pages load through the
+    /// headless-browser transport (JavaScript-rendered), optionally running
+    /// <paramref name="pageActions"/> on each. Requires the WebReaper.Puppeteer
+    /// satellite at run time — core is HTTP-only (ADR-0009).
     /// </summary>
-    /// <param name="startUrls">Initial urls for crawling</param>
-    /// <param name="pageActions">Actions to perform on the page via a browser</param>
-    /// <returns>instance of ConfigBuilder</returns>
+    /// <param name="startUrls">Initial URLs for crawling.</param>
+    /// <param name="pageActions">Browser actions to perform on each start page
+    /// before scraping (see <see cref="PageActionBuilder"/>).</param>
     public ConfigBuilder GetWithBrowser(
         IEnumerable<string> startUrls,
         List<PageAction>? pageActions = null)
@@ -56,6 +75,14 @@ public class ConfigBuilder
         return this;
     }
 
+    /// <summary>
+    /// Append a follow step: from the current page, enqueue child Jobs for the
+    /// links matching <paramref name="linkSelector"/>. Each
+    /// <see cref="Follow"/> / <see cref="Paginate"/> adds one selector to the
+    /// chain that drives the crawl state machine (ADR-0001).
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="linkSelector"/> is
+    /// null/empty/whitespace (fail-fast, 8.0.0).</exception>
     public ConfigBuilder Follow(string linkSelector)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(linkSelector);
@@ -63,6 +90,13 @@ public class ConfigBuilder
         return this;
     }
 
+    /// <summary>
+    /// <see cref="Follow"/> where the followed pages load via the headless
+    /// browser (optionally running <paramref name="pageActions"/>). Requires
+    /// the WebReaper.Puppeteer satellite (ADR-0009).
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="linkSelector"/> is
+    /// null/empty/whitespace.</exception>
     public ConfigBuilder FollowWithBrowser(
         string linkSelector,
         List<PageAction>? pageActions = null)
@@ -72,18 +106,32 @@ public class ConfigBuilder
         return this;
     }
 
+    /// <summary>
+    /// Run the browser headed (<c>false</c>) or headless (<c>true</c>, the
+    /// default) for dynamic pages — headed is useful for debugging a crawl.
+    /// </summary>
     public ConfigBuilder HeadlessMode(bool headless)
     {
         _headless = headless;
         return this;
     }
-    
+
+    /// <summary>
+    /// URLs the crawl must never enqueue — a blocklist applied during link
+    /// discovery.
+    /// </summary>
     public ConfigBuilder IgnoreUrls(IEnumerable<string> urls)
     {
         _blockedUrls = urls;
         return this;
     }
 
+    /// <summary>
+    /// Soft cap on pages crawled. ADR-0022: the Crawl driver stops once the
+    /// visited count reaches <paramref name="limit"/>, but in-flight pages
+    /// still finish — the crawl can overshoot by roughly the parallelism
+    /// degree. Default: unbounded.
+    /// </summary>
     public ConfigBuilder WithPageCrawlLimit(int limit)
     {
         _pageCrawlLimit = limit;
@@ -91,9 +139,10 @@ public class ConfigBuilder
     }
 
     /// <summary>
-    /// Stop the engine once every discovered link has been crawled,
-    /// instead of running forever waiting for new jobs (issue #20).
-    /// Works with the in-memory scheduler.
+    /// Stop the engine once every discovered link has been crawled, instead of
+    /// running forever waiting for new jobs (issue #20). ADR-0022: this is the
+    /// Outstanding-work latch's in-memory adapter — it applies to the
+    /// in-memory scheduler.
     /// </summary>
     public ConfigBuilder StopWhenAllLinksProcessed()
     {
@@ -101,6 +150,14 @@ public class ConfigBuilder
         return this;
     }
 
+    /// <summary>
+    /// Append a paginate step: apply <paramref name="linkSelector"/> on every
+    /// page reached by walking <paramref name="paginationSelector"/> (the
+    /// next-page links). A single selector carrying a pagination selector
+    /// yields the <c>Paginated</c> outcome (ADR-0001).
+    /// </summary>
+    /// <exception cref="ArgumentException">either selector is
+    /// null/empty/whitespace.</exception>
     public ConfigBuilder Paginate(
         string linkSelector,
         string paginationSelector)
@@ -111,6 +168,13 @@ public class ConfigBuilder
         return this;
     }
 
+    /// <summary>
+    /// <see cref="Paginate"/> where the paginated pages load via the headless
+    /// browser (optionally running <paramref name="pageActions"/>). Requires
+    /// the WebReaper.Puppeteer satellite (ADR-0009).
+    /// </summary>
+    /// <exception cref="ArgumentException">either selector is
+    /// null/empty/whitespace.</exception>
     public ConfigBuilder PaginateWithBrowser(
         string linkSelector,
         string paginationSelector,
@@ -122,12 +186,25 @@ public class ConfigBuilder
         return this;
     }
 
+    /// <summary>
+    /// The extraction <see cref="Schema"/> applied to target pages (the
+    /// shared fold grammar, ADR-0002). Required: <see cref="Build"/> throws if
+    /// it was never set. (Exposed on the façade as
+    /// <see cref="ScraperEngineBuilder.Parse"/>.)
+    /// </summary>
     public ConfigBuilder WithScheme(Schema schema)
     {
         _schema = schema;
         return this;
     }
 
+    /// <summary>
+    /// Validate and produce the immutable <see cref="ScraperConfig"/>. Builder
+    /// order matters — configure before calling this.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">no start URLs (neither
+    /// <see cref="Get"/> nor <see cref="GetWithBrowser"/>, or an empty set) or
+    /// no <see cref="Schema"/> (<see cref="WithScheme"/>) was set.</exception>
     public ScraperConfig Build()
     {
         if (_startUrls is null || !_startUrls.Any())

--- a/WebReaper/Builders/PageActionBuilder.cs
+++ b/WebReaper/Builders/PageActionBuilder.cs
@@ -1,23 +1,40 @@
-﻿using WebReaper.Domain.PageActions;
+using WebReaper.Domain.PageActions;
 
 namespace WebReaper.Builders;
 
+/// <summary>
+/// Fluent builder for the ordered list of browser interactions performed on a
+/// dynamic page before it is scraped — click, wait, scroll, evaluate JS,
+/// wait-for-selector / network-idle — plus <c>Repeat*</c> combinators that
+/// replay the previously-added action. Passed to
+/// <see cref="ConfigBuilder.GetWithBrowser"/> /
+/// <c>FollowWithBrowser</c> / <c>PaginateWithBrowser</c>;
+/// <see cref="Build"/> returns the accumulated list. The actions run in the
+/// WebReaper.Puppeteer satellite at run time (core is HTTP-only, ADR-0009).
+/// Every method returns the same instance for chaining.
+/// </summary>
 public class PageActionBuilder
 {
     private readonly List<PageAction> _pageActions = new();
 
+    /// <summary>Click the element matching the CSS <paramref name="selector"/>.</summary>
     public PageActionBuilder Click(string selector)
     {
         _pageActions.Add(new PageAction(PageActionType.Click, selector));
         return this;
     }
 
+    /// <summary>Wait a fixed <paramref name="milliseconds"/> (e.g. to let
+    /// scripted content settle).</summary>
     public PageActionBuilder Wait(int milliseconds)
     {
         _pageActions.Add(new PageAction(PageActionType.Wait, milliseconds));
         return this;
     }
 
+    /// <summary>Scroll to the bottom of the page once — typically to trigger
+    /// infinite-scroll loading (combine with <see cref="Repeat"/> /
+    /// <see cref="RepeatAndWaitForNetworkIdle"/> for multiple loads).</summary>
     public PageActionBuilder ScrollToEnd()
     {
         _pageActions.Add(new PageAction(PageActionType.ScrollToEnd));
@@ -33,6 +50,13 @@ public class PageActionBuilder
             : throw new InvalidOperationException(
                 $"{method} can only be called after at least one page action has been added — there is no action to repeat.");
 
+    /// <summary>
+    /// Replay the previously-added action <paramref name="times"/> more times,
+    /// each followed by a <paramref name="milliseconds"/> wait (e.g.
+    /// scroll-then-pause for paged infinite scroll).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">called before any action
+    /// was added (8.0.0 fail-fast).</exception>
     public PageActionBuilder RepeatWithDelay(int times, int milliseconds)
     {
         var lastEl = LastActionToRepeat(nameof(RepeatWithDelay));
@@ -49,6 +73,14 @@ public class PageActionBuilder
         return this;
     }
 
+    /// <summary>
+    /// Replay the previously-added action <paramref name="times"/> more times,
+    /// each followed by a wait-for-network-idle (the load-driven analogue of
+    /// <see cref="RepeatWithDelay"/> — wait for fetches to settle, not a fixed
+    /// delay).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">called before any action
+    /// was added.</exception>
     public PageActionBuilder RepeatAndWaitForNetworkIdle(int times)
     {
         var lastEl = LastActionToRepeat(nameof(RepeatAndWaitForNetworkIdle));
@@ -65,6 +97,12 @@ public class PageActionBuilder
         return this;
     }
 
+    /// <summary>
+    /// Replay the previously-added action <paramref name="times"/> more times
+    /// back-to-back, with nothing interleaved.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">called before any action
+    /// was added.</exception>
     public PageActionBuilder Repeat(int times)
     {
         var lastEl = LastActionToRepeat(nameof(Repeat));
@@ -72,24 +110,31 @@ public class PageActionBuilder
         return this;
     }
 
+    /// <summary>Evaluate a JavaScript <paramref name="expression"/> in the
+    /// page context.</summary>
     public PageActionBuilder EvaluateExpression(string expression)
     {
         _pageActions.Add(new PageAction(PageActionType.EvaluateExpression, expression));
         return this;
     }
 
+    /// <summary>Wait until an element matching <paramref name="selector"/>
+    /// appears, up to <paramref name="timeout"/> ms.</summary>
     public PageActionBuilder WaitForSelector(string selector, int timeout)
     {
         _pageActions.Add(new PageAction(PageActionType.WaitForSelector, selector, timeout));
         return this;
     }
 
+    /// <summary>Wait until the page's network activity goes idle (no
+    /// fixed duration).</summary>
     public PageActionBuilder WaitForNetworkIdle()
     {
         _pageActions.Add(new PageAction(PageActionType.WaitForNetworkIdle));
         return this;
     }
 
+    /// <summary>The accumulated actions, in the order they were added.</summary>
     public List<PageAction> Build()
     {
         return _pageActions;

--- a/WebReaper/Builders/ScraperEngineBuilder.cs
+++ b/WebReaper/Builders/ScraperEngineBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Text.Json.Nodes;
@@ -26,7 +26,18 @@ using WebReaper.Sinks.Models;
 namespace WebReaper.Builders;
 
 /// <summary>
-///     Builds a web scraper engine responsible for creating and receiving crawling jobs and running a spider on them
+/// The public fluent façade for configuring and building a scraper. It
+/// composes a <see cref="ConfigBuilder"/> (the immutable
+/// <see cref="ScraperConfig"/>: start URLs, the selector chain, the crawl
+/// limit) and an internal <c>SpiderBuilder</c> (runtime components — loaders,
+/// parsers, sinks, trackers, cookie storage), all with in-memory defaults.
+/// Terminate the chain with <see cref="BuildAsync"/> (an engine plus its
+/// persisted config) or <see cref="BuildSpider"/> (a bare
+/// <see cref="ISpider"/> for the distributed-worker pattern, ADR-0009). Every
+/// method returns the same builder for chaining; configuration order is free
+/// except that <see cref="BuildAsync"/> requires a start set
+/// (<see cref="Get"/>/<see cref="GetWithBrowser"/>) and a schema
+/// (<see cref="Parse"/>).
 /// </summary>
 public class ScraperEngineBuilder
 {
@@ -39,8 +50,12 @@ public class ScraperEngineBuilder
 
     private IScheduler Scheduler { get; set; } = new InMemoryScheduler();
     private IScraperConfigStorage? ConfigStorage { get; set; } = new InMemoryScraperConfigStorage();
+    /// <summary>The proxy provider, once configured via
+    /// <see cref="WithProxies"/> / <see cref="WithValidatedProxies(IProxySource, IEnumerable{IProxyValidator}, ValidatedProxyProviderOptions)"/>.</summary>
     protected IProxyProvider? ProxyProvider { get; set; }
 
+    /// <summary>Use a custom content parser (the Schema-fold backend, ADR-0002)
+    /// instead of the default AngleSharp/CSS one.</summary>
     public ScraperEngineBuilder WithContentParser(IJsonContentParser contentParser)
     {
         SpiderBuilder.WithContentParser(contentParser);
@@ -68,24 +83,32 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>Add a custom <see cref="IScraperSink"/>. Sinks compose — every
+    /// registered sink receives every scraped record.</summary>
     public ScraperEngineBuilder AddSink(IScraperSink sink)
     {
         SpiderBuilder.AddSink(sink);
         return this;
     }
 
+    /// <summary>Seed the crawl's cookie container (e.g. an authenticated
+    /// session) before any page loads — see <see cref="ICookiesStorage"/>.</summary>
     public ScraperEngineBuilder SetCookies(Action<CookieContainer> authorize)
     {
         SpiderBuilder.SetCookies(authorize);
         return this;
     }
 
+    /// <summary>URLs the crawl must never enqueue (a discovery-time
+    /// blocklist).</summary>
     public ScraperEngineBuilder IgnoreUrls(params string[] urls)
     {
         ConfigBuilder.IgnoreUrls(urls);
         return this;
     }
 
+    /// <summary>Soft cap on pages crawled (ADR-0022: best-effort — in-flight
+    /// pages still finish, so it can overshoot by ~the parallelism degree).</summary>
     public ScraperEngineBuilder PageCrawlLimit(int limit)
     {
         ConfigBuilder.WithPageCrawlLimit(limit);
@@ -103,18 +126,29 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>Run the browser headed (<c>false</c>) or headless
+    /// (<c>true</c>, default) for dynamic pages.</summary>
     public ScraperEngineBuilder HeadlessMode(bool headless)
     {
         ConfigBuilder.HeadlessMode(headless);
         return this;
     }
 
+    /// <summary>Use a custom <see cref="IVisitedLinkTracker"/> (the
+    /// idempotency authority, ADR-0022) instead of the in-memory default.</summary>
     public ScraperEngineBuilder WithLinkTracker(IVisitedLinkTracker linkTracker)
     {
         SpiderBuilder.WithLinkTracker(linkTracker);
         return this;
     }
 
+    /// <summary>
+    /// Track visited links in a file so a crawl resumes across restarts.
+    /// </summary>
+    /// <param name="dataCleanupOnStart">Wipe the file on start (fresh run)
+    /// rather than resume; defaults to <c>false</c> (resume).</param>
+    /// <exception cref="ArgumentException"><paramref name="fileName"/> is
+    /// null/empty/whitespace (8.0.0 fail-fast).</exception>
     public ScraperEngineBuilder TrackVisitedLinksInFile(string fileName, bool dataCleanupOnStart = false)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
@@ -123,6 +157,7 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>Route library logging to your <see cref="ILogger"/>.</summary>
     public ScraperEngineBuilder WithLogger(ILogger logger)
     {
         SpiderBuilder.WithLogger(logger);
@@ -132,6 +167,7 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>Log to the console with the built-in colour logger.</summary>
     public ScraperEngineBuilder LogToConsole()
     {
         SpiderBuilder.WithLogger(new ColorConsoleLogger());
@@ -139,6 +175,8 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>Write every scraped record to the console (a built-in
+    /// <see cref="IScraperSink"/>).</summary>
     public ScraperEngineBuilder WriteToConsole()
     {
         SpiderBuilder.WriteToConsole();
@@ -146,12 +184,25 @@ public class ScraperEngineBuilder
     }
 
 
+    /// <summary>
+    /// Invoke <paramref name="scrapingResultHandler"/> for every scraped
+    /// record. ADR-0022: the callback is wired onto the Crawl driver; this
+    /// builder surface is unchanged.
+    /// </summary>
     public ScraperEngineBuilder Subscribe(Action<ParsedData> scrapingResultHandler)
     {
         SpiderBuilder.AddSubscription(scrapingResultHandler);
         return this;
     }
 
+    /// <summary>
+    /// Write scraped records to a CSV file.
+    /// </summary>
+    /// <param name="dataCleanupOnStart">Wipe the file on start vs append.
+    /// Required — no default (contrast <see cref="WriteToJsonFile"/>, whose
+    /// default is <c>true</c>).</param>
+    /// <exception cref="ArgumentException"><paramref name="filePath"/> is
+    /// null/empty/whitespace.</exception>
     public ScraperEngineBuilder WriteToCsvFile(string filePath, bool dataCleanupOnStart)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
@@ -159,6 +210,15 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>
+    /// Write scraped records to a file as <b>JSON Lines</b> — one JSON object
+    /// per line, not a JSON array.
+    /// </summary>
+    /// <param name="dataCleanupOnStart">Wipe the file on start. Defaults to
+    /// <c>true</c> (fresh file each run) — the opposite of the other file
+    /// sinks; pass <c>false</c> to append across runs.</param>
+    /// <exception cref="ArgumentException"><paramref name="filePath"/> is
+    /// null/empty/whitespace.</exception>
     public ScraperEngineBuilder WriteToJsonFile(string filePath, bool dataCleanupOnStart = true)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
@@ -166,6 +226,8 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>Route page loads through a rotating proxy
+    /// (<see cref="IProxyProvider"/>).</summary>
     public ScraperEngineBuilder WithProxies(IProxyProvider proxyProvider)
     {
         SpiderBuilder.WithProxies(proxyProvider);
@@ -190,6 +252,8 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>Rotate over proxies from <paramref name="source"/>, keeping
+    /// only those every <paramref name="validators"/> approves.</summary>
     public ScraperEngineBuilder WithValidatedProxies(
         IProxySource source,
         IEnumerable<IProxyValidator> validators,
@@ -199,24 +263,35 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary><see cref="WithValidatedProxies(IProxySource, IEnumerable{IProxyValidator}, ValidatedProxyProviderOptions)"/>
+    /// with the validators as params and default options.</summary>
     public ScraperEngineBuilder WithValidatedProxies(IProxySource source, params IProxyValidator[] validators)
     {
         SpiderBuilder.WithValidatedProxies(source, validators);
         return this;
     }
 
+    /// <summary>The extraction <see cref="Schema"/> for target pages (the
+    /// fold grammar, ADR-0002). Required by <see cref="BuildAsync"/>.</summary>
     public ScraperEngineBuilder Parse(Schema schema)
     {
         ConfigBuilder.WithScheme(schema);
         return this;
     }
 
+    /// <summary>The crawl's start URLs, loaded as static HTTP pages. Required
+    /// by <see cref="BuildAsync"/> (or use <see cref="GetWithBrowser(string[])"/>).</summary>
     public ScraperEngineBuilder Get(params string[] startUrls)
     {
         ConfigBuilder.Get(startUrls);
         return this;
     }
 
+    /// <summary>
+    /// Start URLs loaded through the headless browser, with an optional
+    /// <see cref="PageActionBuilder"/> per page. Requires the
+    /// WebReaper.Puppeteer satellite (ADR-0009).
+    /// </summary>
     public ScraperEngineBuilder GetWithBrowser(
         IEnumerable<string> startUrls,
         Func<PageActionBuilder, List<PageAction>>? actionBuilder = null)
@@ -224,18 +299,28 @@ public class ScraperEngineBuilder
         ConfigBuilder.GetWithBrowser(startUrls, actionBuilder?.Invoke(new PageActionBuilder()));
         return this;
     }
+
+    /// <summary>Start URLs loaded through the headless browser, no page
+    /// actions. Requires the WebReaper.Puppeteer satellite.</summary>
     public ScraperEngineBuilder GetWithBrowser(params string[] startUrls)
     {
         ConfigBuilder.GetWithBrowser(startUrls);
         return this;
     }
 
+    /// <summary>Append a follow step over <paramref name="linkSelector"/> (one
+    /// link in the crawl's selector chain, ADR-0001).</summary>
     public ScraperEngineBuilder Follow(string linkSelector)
     {
         ConfigBuilder.Follow(linkSelector);
         return this;
     }
 
+    /// <summary>
+    /// <see cref="Follow"/> where the followed pages load via the headless
+    /// browser, with optional page actions. Requires the WebReaper.Puppeteer
+    /// satellite.
+    /// </summary>
     public ScraperEngineBuilder FollowWithBrowser(
         string linkSelector,
         Func<PageActionBuilder,
@@ -245,6 +330,9 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>Append a paginate step: <paramref name="linkSelector"/> applied
+    /// across pages walked via <paramref name="paginationSelector"/>
+    /// (ADR-0001).</summary>
     public ScraperEngineBuilder Paginate(
         string linkSelector,
         string paginationSelector)
@@ -253,6 +341,10 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>
+    /// <see cref="Paginate"/> where the pages load via the headless browser,
+    /// with optional page actions. Requires the WebReaper.Puppeteer satellite.
+    /// </summary>
     public ScraperEngineBuilder PaginateWithBrowser(
         string linkSelector,
         string paginationSelector,
@@ -263,12 +355,22 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>Use a custom <see cref="IScheduler"/> (e.g. a distributed
+    /// queue) instead of the in-memory default.</summary>
     public ScraperEngineBuilder WithScheduler(IScheduler scheduler)
     {
         Scheduler = scheduler;
         return this;
     }
 
+    /// <summary>
+    /// Persist the job queue and its cursor to files so a crawl resumes across
+    /// restarts (the file scheduler).
+    /// </summary>
+    /// <param name="dataCleanupOnStart">Wipe the files on start vs resume;
+    /// defaults to <c>false</c> (resume).</param>
+    /// <exception cref="ArgumentException">either file name is
+    /// null/empty/whitespace.</exception>
     public ScraperEngineBuilder WithTextFileScheduler(
         string fileName,
         string currentJobPositionFileName,
@@ -280,12 +382,18 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>Use a custom <see cref="ICookiesStorage"/> instead of the
+    /// in-memory default.</summary>
     public ScraperEngineBuilder WithCookieStorage(ICookiesStorage cookiesStorage)
     {
         SpiderBuilder.WithCookieStorage(cookiesStorage);
         return this;
     }
 
+    /// <summary>Persist cookies to a file so an authenticated session
+    /// survives restarts.</summary>
+    /// <exception cref="ArgumentException"><paramref name="fileName"/> is
+    /// null/empty/whitespace.</exception>
     public ScraperEngineBuilder WithFileCookieStorage(string fileName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
@@ -293,12 +401,18 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>Use a custom <see cref="IScraperConfigStorage"/> (e.g. a
+    /// distributed store shared with workers) instead of the in-memory
+    /// default.</summary>
     public ScraperEngineBuilder WithConfigStorage(IScraperConfigStorage configStorage)
     {
         ConfigStorage = configStorage;
         return this;
     }
 
+    /// <summary>Persist the <see cref="ScraperConfig"/> to a file.</summary>
+    /// <exception cref="ArgumentException"><paramref name="fileName"/> is
+    /// null/empty/whitespace.</exception>
     public ScraperEngineBuilder WithFileConfigStorage(string fileName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
@@ -308,12 +422,19 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>
+    /// Post-process every scraped record (e.g. enrich or reshape it) before it
+    /// reaches the sinks. ADR-0022: wired onto the Crawl driver; this surface
+    /// is unchanged.
+    /// </summary>
     public ScraperEngineBuilder PostProcess(Func<Metadata, JsonObject, Task> action)
     {
         SpiderBuilder.PostProcess(action);
         return this;
     }
 
+    /// <summary>Degree of parallelism for the crawl loop (concurrent
+    /// in-flight pages). Default 20.</summary>
     public ScraperEngineBuilder WithParallelismDegree(int parallelismDegree)
     {
         _parallelismDegree = parallelismDegree;
@@ -338,6 +459,15 @@ public class ScraperEngineBuilder
         return SpiderBuilder.Build();
     }
 
+    /// <summary>
+    /// Build the engine: validate and persist the <see cref="ScraperConfig"/>
+    /// to the configured <see cref="IScraperConfigStorage"/>, construct the
+    /// <see cref="ISpider"/>, and return a runnable <see cref="ScraperEngine"/>
+    /// (the in-process Crawl driver, ADR-0022).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">no start URLs
+    /// (<see cref="Get"/>/<see cref="GetWithBrowser(string[])"/>) or no schema
+    /// (<see cref="Parse"/>) was configured.</exception>
     public async Task<ScraperEngine> BuildAsync()
     {
         SpiderBuilder.WithConfigStorage(ConfigStorage);

--- a/WebReaper/Builders/ScraperEngineBuilder.cs
+++ b/WebReaper/Builders/ScraperEngineBuilder.cs
@@ -36,7 +36,7 @@ namespace WebReaper.Builders;
 /// <see cref="ISpider"/> for the distributed-worker pattern, ADR-0009). Every
 /// method returns the same builder for chaining; configuration order is free
 /// except that <see cref="BuildAsync"/> requires a start set
-/// (<see cref="Get"/>/<see cref="GetWithBrowser"/>) and a schema
+/// (<see cref="Get"/> / <c>GetWithBrowser</c>) and a schema
 /// (<see cref="Parse"/>).
 /// </summary>
 public class ScraperEngineBuilder
@@ -145,6 +145,7 @@ public class ScraperEngineBuilder
     /// <summary>
     /// Track visited links in a file so a crawl resumes across restarts.
     /// </summary>
+    /// <param name="fileName">Path of the visited-links file.</param>
     /// <param name="dataCleanupOnStart">Wipe the file on start (fresh run)
     /// rather than resume; defaults to <c>false</c> (resume).</param>
     /// <exception cref="ArgumentException"><paramref name="fileName"/> is
@@ -198,6 +199,7 @@ public class ScraperEngineBuilder
     /// <summary>
     /// Write scraped records to a CSV file.
     /// </summary>
+    /// <param name="filePath">Path of the CSV file.</param>
     /// <param name="dataCleanupOnStart">Wipe the file on start vs append.
     /// Required — no default (contrast <see cref="WriteToJsonFile"/>, whose
     /// default is <c>true</c>).</param>
@@ -214,6 +216,7 @@ public class ScraperEngineBuilder
     /// Write scraped records to a file as <b>JSON Lines</b> — one JSON object
     /// per line, not a JSON array.
     /// </summary>
+    /// <param name="filePath">Path of the JSON Lines file.</param>
     /// <param name="dataCleanupOnStart">Wipe the file on start. Defaults to
     /// <c>true</c> (fresh file each run) — the opposite of the other file
     /// sinks; pass <c>false</c> to append across runs.</param>
@@ -367,6 +370,9 @@ public class ScraperEngineBuilder
     /// Persist the job queue and its cursor to files so a crawl resumes across
     /// restarts (the file scheduler).
     /// </summary>
+    /// <param name="fileName">Path of the job-queue file.</param>
+    /// <param name="currentJobPositionFileName">Path of the cursor file
+    /// tracking how far the queue has been consumed.</param>
     /// <param name="dataCleanupOnStart">Wipe the files on start vs resume;
     /// defaults to <c>false</c> (resume).</param>
     /// <exception cref="ArgumentException">either file name is

--- a/WebReaper/ConfigStorage/Abstract/IScraperConfigStorage.cs
+++ b/WebReaper/ConfigStorage/Abstract/IScraperConfigStorage.cs
@@ -1,10 +1,29 @@
-﻿using WebReaper.Domain;
+using WebReaper.Domain;
 
 namespace WebReaper.ConfigStorage.Abstract;
 
+/// <summary>
+/// Where the immutable <see cref="ScraperConfig"/> lives so the Spider can
+/// read it at crawl time. This is the seam that lets the in-process engine and
+/// a stateless distributed worker share one crawl definition: the engine (or a
+/// start-scraping endpoint) writes it once; every worker reads it back. The
+/// durable adapters extend the <c>ScraperConfigStore</c> payload shell
+/// (ADR-0003); satellites bind here (<c>RedisScraperConfigStorage</c>,
+/// <c>MongoDbScraperConfigStorage</c>). In-memory by default.
+/// </summary>
 public interface IScraperConfigStorage
 {
+    /// <summary>
+    /// Persist the crawl's <see cref="ScraperConfig"/>. Called once when the
+    /// engine is built (<c>BuildAsync</c>), or by the start-scraping endpoint
+    /// in the distributed pattern, before any Job is processed.
+    /// </summary>
     Task CreateConfigAsync(ScraperConfig config);
 
+    /// <summary>
+    /// Read the persisted config. The Spider calls this at crawl time; in the
+    /// distributed pattern it is how a stateless worker recovers the crawl
+    /// definition it was never passed in-process.
+    /// </summary>
     Task<ScraperConfig> GetConfigAsync();
 }

--- a/WebReaper/ConfigStorage/Concrete/FileScraperConfigStorage.cs
+++ b/WebReaper/ConfigStorage/Concrete/FileScraperConfigStorage.cs
@@ -8,7 +8,7 @@ namespace WebReaper.ConfigStorage.Concrete;
 /// <c>fileName</c> is the blob key, so the config is written to
 /// exactly that path — unchanged from before.
 /// </summary>
-public class FileScraperConfigStorage : ScraperConfigStore
+internal class FileScraperConfigStorage : ScraperConfigStore
 {
     public FileScraperConfigStorage(string fileName)
         : base(new FileBlobStore(), fileName)

--- a/WebReaper/ConfigStorage/Concrete/InMemoryScraperConfigStorage.cs
+++ b/WebReaper/ConfigStorage/Concrete/InMemoryScraperConfigStorage.cs
@@ -8,6 +8,8 @@ namespace WebReaper.ConfigStorage.Concrete;
 /// </summary>
 public class InMemoryScraperConfigStorage : ScraperConfigStore
 {
+    /// <summary>An in-process config store (the default; also the in-memory
+    /// building block the ADR-0009 DIY-distributed pattern wires by hand).</summary>
     public InMemoryScraperConfigStorage()
         : base(new InMemoryBlobStore(), "config")
     {

--- a/WebReaper/ConfigStorage/Concrete/ScraperConfigStore.cs
+++ b/WebReaper/ConfigStorage/Concrete/ScraperConfigStore.cs
@@ -23,15 +23,25 @@ public class ScraperConfigStore : IScraperConfigStorage
     private readonly IKeyedBlobStore _store;
     private readonly string _key;
 
+    /// <summary>
+    /// Back this config store with <paramref name="store"/> at
+    /// <paramref name="key"/> (the blob key). This is the constructor the
+    /// satellite config stores (<c>RedisScraperConfigStorage</c>,
+    /// <c>MongoDbScraperConfigStorage</c>) chain to.
+    /// </summary>
     public ScraperConfigStore(IKeyedBlobStore store, string key)
     {
         _store = store;
         _key = key;
     }
 
+    /// <inheritdoc/>
     public Task CreateConfigAsync(ScraperConfig config)
         => _store.PutAsync(_key, WebReaperJson.SerializeConfig(config));
 
+    /// <inheritdoc/>
+    /// <exception cref="ConfigNotFoundException">no config has been persisted
+    /// at this key (the typed "absent" — ADR-0003).</exception>
     public async Task<ScraperConfig> GetConfigAsync()
     {
         var blob = await _store.GetAsync(_key);

--- a/WebReaper/Core/CookieStorage/Abstract/ICookiesStorage.cs
+++ b/WebReaper/Core/CookieStorage/Abstract/ICookiesStorage.cs
@@ -1,9 +1,27 @@
-﻿using System.Net;
+using System.Net;
 
 namespace WebReaper.Core.CookieStorage.Abstract;
 
+/// <summary>
+/// The crawl's cookie jar, so an authenticated session survives across pages
+/// (and, distributed, is shared across workers). The page-load transport
+/// fetches the container and builds its HTTP handler around it, so stored
+/// cookies are actually applied (the ADR-0004 build-after-fetch ordering). The
+/// durable adapters extend the <c>CookieStore</c> payload shell (ADR-0003);
+/// satellites bind here (<c>RedisCookieStorage</c>,
+/// <c>MongoDbCookieStorage</c>). In-memory by default.
+/// </summary>
 public interface ICookiesStorage
 {
+    /// <summary>
+    /// Store (replace) the session cookies — e.g. after a login / cookie-set
+    /// step — so subsequent page loads carry them.
+    /// </summary>
     Task AddAsync(CookieContainer cookieCollection);
+
+    /// <summary>
+    /// The current session cookies. The page-load transport calls this and
+    /// constructs its handler around the returned container.
+    /// </summary>
     Task<CookieContainer> GetAsync();
 }

--- a/WebReaper/Core/CookieStorage/Concrete/CookieStore.cs
+++ b/WebReaper/Core/CookieStorage/Concrete/CookieStore.cs
@@ -21,12 +21,19 @@ public class CookieStore : ICookiesStorage
     private readonly IKeyedBlobStore _store;
     private readonly string _key;
 
+    /// <summary>
+    /// Back this cookie store with <paramref name="store"/> at
+    /// <paramref name="key"/> (the blob key / path). This is the constructor
+    /// the satellite cookie stores (<c>RedisCookieStorage</c>,
+    /// <c>MongoDbCookieStorage</c>) chain to.
+    /// </summary>
     public CookieStore(IKeyedBlobStore store, string key)
     {
         _store = store;
         _key = key;
     }
 
+    /// <inheritdoc/>
     public Task AddAsync(CookieContainer cookieContainer)
     {
         var dtos = cookieContainer.GetAllCookies()
@@ -36,6 +43,7 @@ public class CookieStore : ICookiesStorage
         return _store.PutAsync(_key, WebReaperJson.SerializeCookies(dtos));
     }
 
+    /// <inheritdoc/>
     public async Task<CookieContainer> GetAsync()
     {
         var blob = await _store.GetAsync(_key);

--- a/WebReaper/Core/CookieStorage/Concrete/FileCookieStorage.cs
+++ b/WebReaper/Core/CookieStorage/Concrete/FileCookieStorage.cs
@@ -10,7 +10,7 @@ namespace WebReaper.Core.CookieStorage.Concrete;
 /// <c>logger</c> parameter is retained for binary/source
 /// compatibility; it is no longer used here.
 /// </summary>
-public class FileCookieStorage : CookieStore
+internal class FileCookieStorage : CookieStore
 {
     public FileCookieStorage(string fileName, ILogger logger)
         : base(new FileBlobStore(), fileName)

--- a/WebReaper/Core/CookieStorage/Concrete/InMemoryCookieStorage.cs
+++ b/WebReaper/Core/CookieStorage/Concrete/InMemoryCookieStorage.cs
@@ -6,7 +6,7 @@ namespace WebReaper.Core.CookieStorage.Concrete;
 /// Source-compatible constructor over the <see cref="CookieStore"/> payload
 /// shell backed by an <see cref="InMemoryBlobStore"/> (ADR 0003).
 /// </summary>
-public class InMemoryCookieStorage : CookieStore
+internal class InMemoryCookieStorage : CookieStore
 {
     public InMemoryCookieStorage()
         : base(new InMemoryBlobStore(), "cookies")

--- a/WebReaper/Core/Crawling/Abstract/ICrawlStep.cs
+++ b/WebReaper/Core/Crawling/Abstract/ICrawlStep.cs
@@ -17,6 +17,13 @@ namespace WebReaper.Core.Crawling.Abstract;
 /// </summary>
 public interface ICrawlStep
 {
+    /// <summary>
+    /// Map the loaded Job to exactly one <see cref="CrawlOutcome"/> — parse
+    /// the target page, follow links, or paginate — decided solely by the
+    /// selector chain's shape. Pure and deterministic in
+    /// (<paramref name="job"/>, <paramref name="document"/>,
+    /// <paramref name="schema"/>); performs no I/O.
+    /// </summary>
     /// <param name="job">The Job being crawled. Its selector chain — its
     /// length and whether the single remaining selector paginates — fully
     /// determines which <see cref="CrawlOutcome"/> arm is returned.</param>

--- a/WebReaper/Core/Crawling/Concrete/CrawlStep.cs
+++ b/WebReaper/Core/Crawling/Concrete/CrawlStep.cs
@@ -17,7 +17,7 @@ namespace WebReaper.Core.Crawling.Concrete;
 /// ADR 0008: the content seam is the typed <see cref="IJsonContentParser"/>
 /// (JsonObject); the legacy <c>IContentParser</c> (JObject) was removed at 6.0.0.
 /// </summary>
-public sealed class CrawlStep : ICrawlStep
+internal sealed class CrawlStep : ICrawlStep
 {
     private readonly ILinkParser _linkParser;
     private readonly IJsonContentParser _contentParser;

--- a/WebReaper/Core/Crawling/Concrete/InMemoryOutstandingWorkLatch.cs
+++ b/WebReaper/Core/Crawling/Concrete/InMemoryOutstandingWorkLatch.cs
@@ -8,7 +8,7 @@ namespace WebReaper.Core.Crawling.Concrete;
 /// <see cref="Interlocked.Decrement(ref int)"/> returns 0 to exactly one
 /// thread, so <see cref="SignalProcessedAsync"/> trips for exactly one caller.
 /// </summary>
-public sealed class InMemoryOutstandingWorkLatch : IOutstandingWorkLatch
+internal sealed class InMemoryOutstandingWorkLatch : IOutstandingWorkLatch
 {
     private int _pending;
 

--- a/WebReaper/Core/Crawling/CrawlOutcome.cs
+++ b/WebReaper/Core/Crawling/CrawlOutcome.cs
@@ -19,11 +19,14 @@ public abstract record CrawlOutcome
 
     /// <summary>Target page (empty selector chain): the page was parsed with
     /// the Schema. No further Jobs.</summary>
+    /// <param name="Data">The scraped record for the target page.</param>
     public sealed record Parsed(ParsedData Data) : CrawlOutcome;
 
     /// <summary>Transit page: the head selector was consumed. Every Job carries
     /// the <b>advanced</b> (shortened) selector chain. Empty when no links
     /// matched.</summary>
+    /// <param name="Next">The follow Jobs, each carrying the advanced
+    /// selector chain.</param>
     public sealed record Followed(ImmutableArray<Job> Next) : CrawlOutcome;
 
     /// <summary>Page with pagination. <see cref="Items"/> are item Jobs that
@@ -31,14 +34,23 @@ public abstract record CrawlOutcome
     /// <see cref="NextPages"/> are next-page Jobs that <b>retain</b> the same
     /// one-element paginated chain, because page 2 of a listing is the same
     /// step, not a deeper one. Either list may be empty.</summary>
+    /// <param name="Items">Item Jobs whose chain is emptied (target pages).</param>
+    /// <param name="NextPages">Next-page Jobs that retain the one-element
+    /// paginated chain.</param>
     public sealed record Paginated(
         ImmutableArray<Job> Items,
         ImmutableArray<Job> NextPages) : CrawlOutcome;
 
+    /// <summary>The target-page arm: the page was parsed into
+    /// <paramref name="data"/>.</summary>
     public static CrawlOutcome Target(ParsedData data) => new Parsed(data);
 
+    /// <summary>The transit arm: the head selector was consumed,
+    /// <paramref name="next"/> are the follow Jobs.</summary>
     public static CrawlOutcome Transit(ImmutableArray<Job> next) => new Followed(next);
 
+    /// <summary>The pagination arm: <paramref name="items"/> are the listing's
+    /// item Jobs, <paramref name="nextPages"/> the next-page Jobs.</summary>
     public static CrawlOutcome Pagination(
         ImmutableArray<Job> items,
         ImmutableArray<Job> nextPages) => new Paginated(items, nextPages);

--- a/WebReaper/Core/Crawling/JobReport.cs
+++ b/WebReaper/Core/Crawling/JobReport.cs
@@ -12,4 +12,7 @@ namespace WebReaper.Core.Crawling;
 /// the ADR-0001 closed three-arm sum (that stays the Crawl step's result and
 /// still lives inside the shell). Termination is never a thrown exception.
 /// </summary>
+/// <param name="Outcome">The Crawl step's closed result for this Job.</param>
+/// <param name="Document">The loaded page body, so the driver can build the
+/// PostProcessor <see cref="WebReaper.Domain.Metadata"/>.</param>
 public sealed record JobReport(CrawlOutcome Outcome, string Document);

--- a/WebReaper/Core/LinkTracker/Abstract/IVisitedLinkTracker.cs
+++ b/WebReaper/Core/LinkTracker/Abstract/IVisitedLinkTracker.cs
@@ -1,9 +1,27 @@
 namespace WebReaper.Core.LinkTracker.Abstract;
 
+/// <summary>
+/// Crawl-global "what has this Crawl already visited" state, owned by the
+/// Crawl driver (ADR-0022). It is the single idempotency authority: the atomic
+/// test-and-set <see cref="TryAddVisitedLinkAsync"/> gates discovery dedup,
+/// the crawl-page limit, and Outstanding-work-latch accounting in one
+/// membership check. In-memory by default; the File / Redis adapters share it
+/// across a resumed or distributed crawl.
+/// </summary>
 public interface IVisitedLinkTracker
 {
+    /// <summary>
+    /// Wipe the visited set when the crawl starts (a fresh run) instead of
+    /// resuming from it. No effect in-memory; the durable adapters read it.
+    /// </summary>
     public bool DataCleanupOnStart { get; set; }
-    
+
+    /// <summary>
+    /// Unconditionally record a visited link. Prefer
+    /// <see cref="TryAddVisitedLinkAsync"/> for the dedup / accounting gate —
+    /// that is the atomic test-and-set; this is the plain mark with no race
+    /// verdict.
+    /// </summary>
     Task AddVisitedLinkAsync(string visitedLink);
 
     /// <summary>
@@ -27,9 +45,28 @@ public interface IVisitedLinkTracker
         return true;
     }
 
+    /// <summary>
+    /// A snapshot of the visited set. Backs the non-atomic default
+    /// <see cref="TryAddVisitedLinkAsync"/>; an adapter with a native atomic
+    /// add does not need it on the hot path.
+    /// </summary>
     Task<List<string>> GetVisitedLinksAsync();
+
+    /// <summary>
+    /// The subset of <paramref name="links"/> not yet visited — a
+    /// discovery-filtering helper.
+    /// </summary>
     Task<List<string>> GetNotVisitedLinks(IEnumerable<string> links);
+
+    /// <summary>
+    /// The visited count the soft crawl-page-limit stop reads (ADR-0022: the
+    /// limit is a value the driver checks, not a thrown exception).
+    /// </summary>
     Task<long> GetVisitedLinksCount();
-    
+
+    /// <summary>
+    /// Awaited once before use; durable / distributed adapters connect /
+    /// restore here.
+    /// </summary>
     Task Initialization { get; }
 }

--- a/WebReaper/Core/LinkTracker/Concrete/FileVisitedLinkedTracker.cs
+++ b/WebReaper/Core/LinkTracker/Concrete/FileVisitedLinkedTracker.cs
@@ -4,7 +4,7 @@ using WebReaper.DataAccess;
 
 namespace WebReaper.Core.LinkTracker.Concrete;
 
-public class FileVisitedLinkedTracker : IVisitedLinkTracker
+internal class FileVisitedLinkedTracker : IVisitedLinkTracker
 {
     public bool DataCleanupOnStart { get; set; }
     public Task Initialization { get; }

--- a/WebReaper/Core/LinkTracker/Concrete/InMemoryVisitedLinkTracker.cs
+++ b/WebReaper/Core/LinkTracker/Concrete/InMemoryVisitedLinkTracker.cs
@@ -1,14 +1,24 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using WebReaper.Core.LinkTracker.Abstract;
 
 namespace WebReaper.Core.LinkTracker.Concrete;
 
+/// <summary>
+/// The default <see cref="IVisitedLinkTracker"/>: an in-process
+/// <see cref="ImmutableHashSet{T}"/> behind a lock-free CAS. It overrides the
+/// seam's non-atomic default with a genuine atomic test-and-set, so it is the
+/// in-process idempotency authority (ADR-0022). Single-process only (state is
+/// not shared or persisted — use the File / Redis tracker for that). Also an
+/// in-memory building block for the ADR-0009 DIY-distributed pattern.
+/// </summary>
 public class InMemoryVisitedLinkTracker : IVisitedLinkTracker
 {
+    /// <inheritdoc/>
     public bool DataCleanupOnStart { get; set; }
-    
+
     private ImmutableHashSet<string> visitedUrls = ImmutableHashSet.Create<string>();
 
+    /// <inheritdoc/>
     public Task AddVisitedLinkAsync(string visitedLink)
     {
         ImmutableInterlocked.Update(ref visitedUrls, set => set.Add(visitedLink));
@@ -22,6 +32,7 @@ public class InMemoryVisitedLinkTracker : IVisitedLinkTracker
     // (and, distributed-side later, redeliveries) observe it present and
     // return false. Replaces the seam's check-then-add default with no race
     // window.
+    /// <inheritdoc/>
     public Task<bool> TryAddVisitedLinkAsync(string visitedLink)
     {
         var spin = new SpinWait();
@@ -37,21 +48,25 @@ public class InMemoryVisitedLinkTracker : IVisitedLinkTracker
             spin.SpinOnce();
         }
     }
-    
+
+    /// <inheritdoc/>
     public Task<List<string>> GetVisitedLinksAsync()
     {
         return Task.FromResult(visitedUrls.ToList());
     }
 
+    /// <inheritdoc/>
     public Task<List<string>> GetNotVisitedLinks(IEnumerable<string> links)
     {
         return Task.FromResult(links.Except(visitedUrls).ToList());
     }
 
+    /// <inheritdoc/>
     public Task<long> GetVisitedLinksCount()
     {
         return Task.FromResult((long)visitedUrls.Count);
     }
 
+    /// <inheritdoc/>
     public Task Initialization => Task.CompletedTask;
 }

--- a/WebReaper/Core/Loaders/Abstract/IPageLoadTransport.cs
+++ b/WebReaper/Core/Loaders/Abstract/IPageLoadTransport.cs
@@ -9,5 +9,12 @@ namespace WebReaper.Core.Loaders.Abstract;
 /// </summary>
 public interface IPageLoadTransport
 {
+    /// <summary>
+    /// Perform the actual fetch for <paramref name="request"/> via this
+    /// mechanism (HTTP or headless browser) and return the page body. Applies
+    /// the optional proxy and this mechanism's client / launch quirks. A page
+    /// that cannot be retrieved is surfaced as an exception, not an empty
+    /// string.
+    /// </summary>
     Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default);
 }

--- a/WebReaper/Core/Loaders/Abstract/IPageLoader.cs
+++ b/WebReaper/Core/Loaders/Abstract/IPageLoader.cs
@@ -9,5 +9,12 @@ namespace WebReaper.Core.Loaders.Abstract;
 /// </summary>
 public interface IPageLoader
 {
+    /// <summary>
+    /// Fetch the page for <paramref name="request"/> and return its body,
+    /// dispatching on <see cref="PageRequest.PageType"/> to the matching
+    /// <see cref="IPageLoadTransport"/>. A page that cannot be retrieved is
+    /// surfaced as an exception (the transport decides the type), not an empty
+    /// string.
+    /// </summary>
     Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default);
 }

--- a/WebReaper/Core/Loaders/Abstract/PageRequest.cs
+++ b/WebReaper/Core/Loaders/Abstract/PageRequest.cs
@@ -12,6 +12,13 @@ namespace WebReaper.Core.Loaders.Abstract;
 /// <see cref="Headless"/>; that is the accepted fat-field cost of having one
 /// loading seam instead of two.
 /// </summary>
+/// <param name="Url">Absolute URL of the page to fetch.</param>
+/// <param name="PageType">Load mode — static HTTP or dynamic headless
+/// browser; selects the <c>IPageLoadTransport</c>.</param>
+/// <param name="PageActions">Optional browser interactions (click, scroll,
+/// wait) for a dynamic page; ignored by the HTTP transport.</param>
+/// <param name="Headless">Run the browser headless for a dynamic page;
+/// ignored by the HTTP transport.</param>
 public record PageRequest(
     string Url,
     PageType PageType,

--- a/WebReaper/Core/Loaders/Concrete/BrowserNotConfiguredPageLoadTransport.cs
+++ b/WebReaper/Core/Loaders/Concrete/BrowserNotConfiguredPageLoadTransport.cs
@@ -12,7 +12,7 @@ namespace WebReaper.Core.Loaders.Concrete;
 /// / two-<see cref="IPageLoadTransport"/> dispatcher is unchanged — only the
 /// default composition of the dynamic slot moved out of core.
 /// </summary>
-public sealed class BrowserNotConfiguredPageLoadTransport : IPageLoadTransport
+internal sealed class BrowserNotConfiguredPageLoadTransport : IPageLoadTransport
 {
     public Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default) =>
         throw new InvalidOperationException(

--- a/WebReaper/Core/Loaders/Concrete/HttpPageLoadTransport.cs
+++ b/WebReaper/Core/Loaders/Concrete/HttpPageLoadTransport.cs
@@ -22,7 +22,7 @@ namespace WebReaper.Core.Loaders.Concrete;
 /// for correct per-request cookie/proxy application — connection-pool tuning
 /// is a separate concern, out of scope for this deepening.
 /// </summary>
-public class HttpPageLoadTransport : IPageLoadTransport
+internal class HttpPageLoadTransport : IPageLoadTransport
 {
     private const string UserAgent =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36";

--- a/WebReaper/Core/Loaders/Concrete/PageLoader.cs
+++ b/WebReaper/Core/Loaders/Concrete/PageLoader.cs
@@ -10,7 +10,7 @@ namespace WebReaper.Core.Loaders.Concrete;
 /// <see cref="PageRequest.PageType"/> to the HTTP or browser
 /// <see cref="IPageLoadTransport"/> (ADR 0004).
 /// </summary>
-public class PageLoader : IPageLoader
+internal class PageLoader : IPageLoader
 {
     private readonly IPageLoadTransport _httpTransport;
     private readonly IPageLoadTransport _browserTransport;

--- a/WebReaper/Core/Parser/Abstract/IJsonContentParser.cs
+++ b/WebReaper/Core/Parser/Abstract/IJsonContentParser.cs
@@ -14,5 +14,12 @@ namespace WebReaper.Core.Parser.Abstract;
 /// </summary>
 public interface IJsonContentParser
 {
+    /// <summary>
+    /// Run the ADR-0002 Schema fold over <paramref name="content"/> and
+    /// project the result to a <see cref="JsonObject"/> (the AOT-clean
+    /// terminal, ADR-0008) — the content half of crawling a target page (link
+    /// discovery is <see cref="ILinkParser"/>). A <c>null</c>
+    /// <paramref name="schema"/> means no extraction (an empty object).
+    /// </summary>
     Task<JsonObject> ParseToJsonAsync(string content, Schema? schema);
 }

--- a/WebReaper/Core/Parser/Abstract/ILinkParser.cs
+++ b/WebReaper/Core/Parser/Abstract/ILinkParser.cs
@@ -1,6 +1,19 @@
 namespace WebReaper.Core.Parser.Abstract;
 
+/// <summary>
+/// The link-discovery half of crawling one page: extract the follow /
+/// paginate URLs a selector points at. (The content half — turning a target
+/// page into data — is the Schema fold, <see cref="IJsonContentParser"/> /
+/// ADR-0002.) The Crawl step turns the returned URLs into candidate child
+/// Jobs; visited-link filtering is the Crawl driver's job, not this seam's.
+/// </summary>
 public interface ILinkParser
 {
+    /// <summary>
+    /// The absolute URLs in <paramref name="html"/> matching
+    /// <paramref name="selector"/>, with relative hrefs resolved against
+    /// <paramref name="baseUrl"/>. Returns the raw discovered set — not
+    /// deduplicated and not visited-filtered (the driver owns that).
+    /// </summary>
     Task<List<string>> GetLinksAsync(Uri baseUrl, string html, string selector);
 }

--- a/WebReaper/Core/Parser/Concrete/AngleSharpContentParser.cs
+++ b/WebReaper/Core/Parser/Concrete/AngleSharpContentParser.cs
@@ -11,7 +11,7 @@ namespace WebReaper.Core.Parser.Concrete;
 /// type with its original <c>(ILogger)</c> constructor so it stays the
 /// default and a drop-in for existing callers.
 /// </summary>
-public class AngleSharpContentParser : IJsonContentParser
+internal class AngleSharpContentParser : IJsonContentParser
 {
     private readonly SchemaContentParser<AngleSharp.Dom.IParentNode> _inner;
 

--- a/WebReaper/Core/Parser/Concrete/JsonContentParser.cs
+++ b/WebReaper/Core/Parser/Concrete/JsonContentParser.cs
@@ -22,7 +22,7 @@ namespace WebReaper.Core.Parser.Concrete;
 /// <c>CookieStore</c> payload-shell sibling.
 /// </para>
 /// </summary>
-public class JsonContentParser : IJsonContentParser
+internal class JsonContentParser : IJsonContentParser
 {
     private readonly SchemaContentParser<JsonNode> _inner;
 

--- a/WebReaper/Core/Parser/Concrete/LinkParserByCssSelector.cs
+++ b/WebReaper/Core/Parser/Concrete/LinkParserByCssSelector.cs
@@ -3,7 +3,7 @@ using WebReaper.Core.Parser.Abstract;
 
 namespace WebReaper.Core.Parser.Concrete;
 
-public class LinkParserByCssSelector : ILinkParser
+internal class LinkParserByCssSelector : ILinkParser
 {
     public async Task<List<string>> GetLinksAsync(Uri baseUrl, string html, string cssSelector)
     {

--- a/WebReaper/Core/Parser/Concrete/SchemaContentParser.cs
+++ b/WebReaper/Core/Parser/Concrete/SchemaContentParser.cs
@@ -36,12 +36,17 @@ public class SchemaContentParser<TNode> : IJsonContentParser where TNode : class
     private readonly ISchemaBackend<TNode> _backend;
     private readonly ILogger _logger;
 
+    /// <summary>Reuse the proven fold with a custom
+    /// <paramref name="backend"/> — the ADR-0002 extension point:
+    /// <c>new SchemaContentParser&lt;TNode&gt;(myBackend, logger)</c> passed to
+    /// <c>WithContentParser</c>.</summary>
     public SchemaContentParser(ISchemaBackend<TNode> backend, ILogger logger)
     {
         _backend = backend;
         _logger = logger;
     }
 
+    /// <inheritdoc/>
     public async Task<JsonObject> ParseToJsonAsync(string content, Schema? schema)
     {
         ArgumentNullException.ThrowIfNull(schema);

--- a/WebReaper/Core/Parser/Concrete/XPathContentParser.cs
+++ b/WebReaper/Core/Parser/Concrete/XPathContentParser.cs
@@ -15,7 +15,7 @@ namespace WebReaper.Core.Parser.Concrete;
 /// constructor so <c>WithXPathContentParser</c> mirrors
 /// <c>WithJsonContentParser</c>.
 /// </summary>
-public class XPathContentParser : IJsonContentParser
+internal class XPathContentParser : IJsonContentParser
 {
     private readonly SchemaContentParser<AngleSharp.Dom.IParentNode> _inner;
 

--- a/WebReaper/Core/Scheduler/Abstract/IScheduler.cs
+++ b/WebReaper/Core/Scheduler/Abstract/IScheduler.cs
@@ -1,14 +1,49 @@
-﻿using WebReaper.Domain;
+using WebReaper.Domain;
 
 namespace WebReaper.Core.Scheduler.Abstract;
 
+/// <summary>
+/// The job-queue seam: what holds <see cref="Job"/>s waiting to be crawled and
+/// streams them to the Crawl driver (ADR-0022). Swapping this is how a crawl
+/// moves from in-process (the in-memory default) to durable / distributed
+/// state shared across workers (File, Redis, Azure Service Bus). The driver
+/// pushes surviving child Jobs back through <see cref="AddAsync(Job, CancellationToken)"/>
+/// and consumes <see cref="GetAllAsync"/> with <c>Parallel.ForEachAsync</c>.
+/// </summary>
 public interface IScheduler
 {
+    /// <summary>
+    /// Wipe the backing store when the crawl starts (a fresh run) instead of
+    /// resuming from it. No effect on the in-memory adapter; the durable
+    /// adapters read it to decide fresh-vs-resume.
+    /// </summary>
     public bool DataCleanupOnStart { get; set; }
+
+    /// <summary>
+    /// Awaited once before the queue is used. A durable / distributed adapter
+    /// performs its async connect / restore here; the in-memory adapter
+    /// completes synchronously.
+    /// </summary>
     public Task Initialization { get; }
-    
+
+    /// <summary>
+    /// Enqueue one discovered Job. The Crawl driver calls this to push a
+    /// surviving child Job back onto the queue.
+    /// </summary>
     Task AddAsync(Job job, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Enqueue a batch of Jobs in one call — the start URLs at seed time, or a
+    /// page's discovered children together.
+    /// </summary>
     Task AddAsync(IEnumerable<Job> jobs, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// The async stream the Crawl driver drives. Yields Jobs as they arrive;
+    /// it ends only once <see cref="Complete"/> has been signalled (the
+    /// in-memory adapter) — a durable / distributed adapter keeps streaming by
+    /// default, since it cannot know that no other worker will ever add more.
+    /// </summary>
     IAsyncEnumerable<Job> GetAllAsync(CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/WebReaper/Core/Scheduler/Concrete/FileScheduler.cs
+++ b/WebReaper/Core/Scheduler/Concrete/FileScheduler.cs
@@ -7,7 +7,7 @@ using WebReaper.Serialization;
 
 namespace WebReaper.Core.Scheduler.Concrete;
 
-public class FileScheduler : IScheduler
+internal class FileScheduler : IScheduler
 {
     private readonly string _currentJobPositionFileName;
     private readonly string _fileName;

--- a/WebReaper/Core/Scheduler/Concrete/InMemoryScheduler.cs
+++ b/WebReaper/Core/Scheduler/Concrete/InMemoryScheduler.cs
@@ -4,27 +4,40 @@ using WebReaper.Domain;
 
 namespace WebReaper.Core.Scheduler.Concrete;
 
+/// <summary>
+/// The default <see cref="IScheduler"/>: an in-process unbounded
+/// <see cref="Channel{T}"/> of Jobs. Single-process only (the queue does not
+/// survive a restart and is not shared across workers — use a durable /
+/// distributed scheduler for that). Also the in-memory building block the
+/// ADR-0009 DIY-distributed pattern can wire by hand.
+/// </summary>
 public class InMemoryScheduler : IScheduler
 {
     private readonly Channel<Job> _jobChannel = Channel.CreateUnbounded<Job>();
 
+    /// <inheritdoc/>
     public IAsyncEnumerable<Job> GetAllAsync(CancellationToken cancellationToken = default)
     {
         return _jobChannel.Reader.ReadAllAsync(cancellationToken);
     }
 
     // TryComplete is idempotent: safe if the engine calls it more than once.
+    /// <inheritdoc/>
     public void Complete() => _jobChannel.Writer.TryComplete();
 
+    /// <inheritdoc/>
     public bool DataCleanupOnStart { get; set; }
 
+    /// <inheritdoc/>
     public Task Initialization { get; } = Task.CompletedTask;
 
+    /// <inheritdoc/>
     public async Task AddAsync(Job job, CancellationToken cancellationToken = default)
     {
         await _jobChannel.Writer.WriteAsync(job, cancellationToken);
     }
 
+    /// <inheritdoc/>
     public async Task AddAsync(IEnumerable<Job> jobs, CancellationToken cancellationToken = default)
     {
         foreach (var job in jobs)

--- a/WebReaper/Core/ScraperEngine.cs
+++ b/WebReaper/Core/ScraperEngine.cs
@@ -40,7 +40,7 @@ public class ScraperEngine
     /// ScrapedData / PostProcessor callbacks, and the Outstanding-work latch
     /// (an in-memory <c>Interlocked</c> latch by default).
     /// </summary>
-    public ScraperEngine(
+    internal ScraperEngine(
         int parallelismDegree,
         IScraperConfigStorage configStorage,
         IScheduler jobScheduler,

--- a/WebReaper/Core/ScraperEngine.cs
+++ b/WebReaper/Core/ScraperEngine.cs
@@ -30,6 +30,16 @@ namespace WebReaper.Core;
 /// </summary>
 public class ScraperEngine
 {
+    /// <summary>
+    /// Constructed by
+    /// <see cref="WebReaper.Builders.ScraperEngineBuilder.BuildAsync"/> —
+    /// consumers obtain an engine from the builder, not by calling this
+    /// directly. Wires the in-process Crawl driver (ADR-0022): the scheduler,
+    /// the persisted config storage, the per-Job <see cref="ISpider"/> shell,
+    /// the visited-link idempotency authority, the Sink fan-out, the optional
+    /// ScrapedData / PostProcessor callbacks, and the Outstanding-work latch
+    /// (an in-memory <c>Interlocked</c> latch by default).
+    /// </summary>
     public ScraperEngine(
         int parallelismDegree,
         IScraperConfigStorage configStorage,
@@ -69,6 +79,13 @@ public class ScraperEngine
 
     private int ParallelismDegree { get; }
 
+    /// <summary>
+    /// Run the crawl to completion: seed the scheduler from the config's start
+    /// URLs and drive <c>Parallel.ForEachAsync</c> over the job stream until
+    /// the Outstanding-work latch trips (all work drained) or the soft
+    /// crawl-page limit is reached (ADR-0022 — termination is a value, never a
+    /// thrown exception). Honours <paramref name="cancellationToken"/>.
+    /// </summary>
     public async Task RunAsync(CancellationToken cancellationToken = default)
     {
         await Scheduler.Initialization;

--- a/WebReaper/Core/Spider/Abstract/ISpider.cs
+++ b/WebReaper/Core/Spider/Abstract/ISpider.cs
@@ -13,5 +13,16 @@ namespace WebReaper.Core.Spider.Abstract;
 /// </summary>
 public interface ISpider
 {
+    /// <summary>
+    /// Load <paramref name="job"/>'s page, run the Crawl step, and return the
+    /// <see cref="JobReport"/> the Crawl driver interprets. Never throws to
+    /// signal termination or the crawl limit (ADR-0022) — those are values on
+    /// the report, not control flow. The report's child Jobs are
+    /// <b>candidates</b>: visited-link dedup is the driver's, not the shell's.
+    /// </summary>
+    /// <param name="job">The Job to crawl; its selector chain decides
+    /// parse-vs-follow-vs-paginate.</param>
+    /// <returns>The closed Job report — the <see cref="CrawlOutcome"/> plus the
+    /// loaded document and the accounting facts the driver needs.</returns>
     Task<JobReport> CrawlAsync(Job job, CancellationToken cancellationToken = default);
 }

--- a/WebReaper/Core/Spider/Abstract/ISpider.cs
+++ b/WebReaper/Core/Spider/Abstract/ISpider.cs
@@ -22,6 +22,8 @@ public interface ISpider
     /// </summary>
     /// <param name="job">The Job to crawl; its selector chain decides
     /// parse-vs-follow-vs-paginate.</param>
+    /// <param name="cancellationToken">Cancels the page load / crawl
+    /// step.</param>
     /// <returns>The closed Job report — the <see cref="CrawlOutcome"/> plus the
     /// loaded document and the accounting facts the driver needs.</returns>
     Task<JobReport> CrawlAsync(Job job, CancellationToken cancellationToken = default);

--- a/WebReaper/Core/Spider/Concrete/Spider.cs
+++ b/WebReaper/Core/Spider/Concrete/Spider.cs
@@ -15,7 +15,7 @@ namespace WebReaper.Core.Spider.Concrete;
 /// driver's — not the shell's. The shell <em>reports</em> what happened; the
 /// driver <em>decides</em> what to do. No termination signal is thrown.
 /// </summary>
-public class Spider : ISpider
+internal class Spider : ISpider
 {
     public Spider(
         ICrawlStep crawlStep,

--- a/WebReaper/DataAccess/FileBlobStore.cs
+++ b/WebReaper/DataAccess/FileBlobStore.cs
@@ -11,7 +11,7 @@ namespace WebReaper.DataAccess;
 /// (last-write-wins) is this adapter's own essence. No lock is taken — the
 /// engine writes a config once at build time.
 /// </summary>
-public class FileBlobStore : IKeyedBlobStore
+internal class FileBlobStore : IKeyedBlobStore
 {
     public Task PutAsync(string key, string value)
     {

--- a/WebReaper/DataAccess/InMemoryBlobStore.cs
+++ b/WebReaper/DataAccess/InMemoryBlobStore.cs
@@ -7,7 +7,7 @@ namespace WebReaper.DataAccess;
 /// the live object — so the in-memory path exercises the same payload-shell
 /// serialization the persistent backends do (ADR 0003).
 /// </summary>
-public class InMemoryBlobStore : IKeyedBlobStore
+internal class InMemoryBlobStore : IKeyedBlobStore
 {
     private readonly ConcurrentDictionary<string, string> _blobs = new();
 

--- a/WebReaper/Domain/Job.cs
+++ b/WebReaper/Domain/Job.cs
@@ -4,6 +4,23 @@ using WebReaper.Domain.Selectors;
 
 namespace WebReaper.Domain;
 
+/// <summary>
+/// One unit of crawl work: a URL plus the remaining
+/// <see cref="LinkPathSelector"/> chain. The chain length is the crawl state
+/// machine (ADR-0001) — the Crawl step dequeues one selector per step, and an
+/// empty chain means "this is a target page, parse it with the Schema". Child
+/// Jobs carry the advanced (shortened) chain. Immutable; created by the engine
+/// from the start URLs and by the Crawl step from discovered links.
+/// </summary>
+/// <param name="Url">The page this Job crawls.</param>
+/// <param name="LinkPathSelectors">The remaining selector chain; empty ⇒ a
+/// target page (parsed with the Schema, no further Jobs).</param>
+/// <param name="ParentBacklinks">The ancestor URLs that led here, oldest
+/// first — surfaced to the PostProcessor as <see cref="Metadata"/>.</param>
+/// <param name="PageType">Load statically (HTTP) or dynamically (headless
+/// browser).</param>
+/// <param name="PageActions">Browser actions to run before scraping a dynamic
+/// page; null for a static page.</param>
 public record Job(
     string Url,
     ImmutableQueue<LinkPathSelector> LinkPathSelectors,

--- a/WebReaper/Domain/Metadata.cs
+++ b/WebReaper/Domain/Metadata.cs
@@ -1,3 +1,12 @@
-﻿namespace WebReaper.Domain;
+namespace WebReaper.Domain;
 
+/// <summary>
+/// The context handed to a <c>PostProcess</c> callback alongside the scraped
+/// JSON: where the data came from and the raw page it came from, so the
+/// callback can enrich or filter using the page itself and its crawl ancestry.
+/// </summary>
+/// <param name="BackLinks">Ancestor URLs that led to this page, oldest
+/// first.</param>
+/// <param name="Url">The page the data was scraped from.</param>
+/// <param name="Html">The raw page body as loaded.</param>
 public record Metadata(List<string> BackLinks, string Url, string Html);

--- a/WebReaper/Domain/PageActions/PageAction.cs
+++ b/WebReaper/Domain/PageActions/PageAction.cs
@@ -1,3 +1,14 @@
-﻿namespace WebReaper.Domain.PageActions;
+namespace WebReaper.Domain.PageActions;
 
+/// <summary>
+/// One browser interaction performed on a dynamic page before scraping (built
+/// via <see cref="WebReaper.Builders.PageActionBuilder"/>). The
+/// <see cref="Parameters"/> shape depends on <see cref="Type"/> — e.g. a CSS
+/// selector for <see cref="PageActionType.Click"/>, a millisecond count for
+/// <see cref="PageActionType.Wait"/>. Interpreted by the WebReaper.Puppeteer
+/// satellite (ADR-0009).
+/// </summary>
+/// <param name="Type">Which interaction to perform.</param>
+/// <param name="Parameters">The interaction's arguments, positional per
+/// <paramref name="Type"/>.</param>
 public record PageAction(PageActionType Type, params object[] Parameters);

--- a/WebReaper/Domain/PageActions/PageActionType.cs
+++ b/WebReaper/Domain/PageActions/PageActionType.cs
@@ -4,12 +4,29 @@ namespace WebReaper.Domain.PageActions;
 // removed — string-enum serialisation is now the AOT-safe
 // JsonStringEnumConverter<PageActionType> registered on WebReaperJson. The
 // Domain enum no longer references Newtonsoft.
+/// <summary>
+/// The browser interactions a <see cref="PageAction"/> can perform on a
+/// dynamic page before it is scraped (executed by the WebReaper.Puppeteer
+/// satellite, ADR-0009).
+/// </summary>
 public enum PageActionType
 {
+    /// <summary>Click the element matching a CSS selector.</summary>
     Click,
+
+    /// <summary>Wait a fixed number of milliseconds.</summary>
     Wait,
+
+    /// <summary>Scroll to the bottom of the page (e.g. to trigger
+    /// infinite-scroll loading).</summary>
     ScrollToEnd,
+
+    /// <summary>Evaluate a JavaScript expression in the page context.</summary>
     EvaluateExpression,
+
+    /// <summary>Wait until an element matching a CSS selector appears.</summary>
     WaitForSelector,
+
+    /// <summary>Wait until the page's network activity goes idle.</summary>
     WaitForNetworkIdle
 }

--- a/WebReaper/Domain/Parsing/DataType.cs
+++ b/WebReaper/Domain/Parsing/DataType.cs
@@ -1,12 +1,30 @@
 namespace WebReaper.Domain.Parsing;
 
+/// <summary>
+/// The type a <see cref="SchemaElement"/>'s extracted text is coerced to in
+/// the output JSON. <see cref="None"/> (the default) keeps the raw string.
+/// </summary>
 public enum DataType
 {
+    /// <summary>No coercion — keep the extracted string verbatim.</summary>
     None = 0,
+
+    /// <summary>Parse the extracted text as an integer.</summary>
     Integer = 1,
+
+    /// <summary>Parse the extracted text as a floating-point number.</summary>
     Float = 2,
+
+    /// <summary>Parse the extracted text as a boolean.</summary>
     Boolean = 3,
+
+    /// <summary>Keep the value as a string (explicit).</summary>
     String = 4,
+
+    /// <summary>Parse the extracted text as a date/time.</summary>
     DataTime = 5,
+
+    /// <summary>Treat the element as a nested object — its child selectors
+    /// produce a sub-object rather than a scalar.</summary>
     Object = 6
 }

--- a/WebReaper/Domain/Parsing/Schema.cs
+++ b/WebReaper/Domain/Parsing/Schema.cs
@@ -1,45 +1,66 @@
-﻿using System.Collections;
+using System.Collections;
 
 namespace WebReaper.Domain.Parsing;
 
+/// <summary>
+/// The extraction grammar for a target page: a <see cref="SchemaElement"/>
+/// that also holds <see cref="Children"/>, so a schema is a tree of fields.
+/// Implements <see cref="ICollection{T}"/> purely to enable collection-
+/// initialiser syntax — <c>new Schema { new SchemaElement("title", "h1") }</c>
+/// — over <see cref="Children"/>. The shared fold (ADR-0002) walks this tree;
+/// a nested <see cref="Schema"/> child produces a sub-object.
+/// </summary>
+/// <param name="Field">The output property name when this schema is itself a
+/// nested field; null for the root.</param>
 public record Schema(string? Field = null)
     : SchemaElement(Field), ICollection<SchemaElement>
 {
+    /// <summary>A root schema with no field name.</summary>
     public Schema() : this(Field: null)
     {
     }
 
+    /// <summary>The child fields of this schema, in declaration order.</summary>
     public List<SchemaElement> Children { get; set; } = new();
 
+    /// <summary>The number of direct <see cref="Children"/>.</summary>
     public int Count => Children.Count;
 
+    /// <summary>Always false — a schema is mutable while being built.</summary>
     public bool IsReadOnly => false;
 
+    /// <summary>Add a child field (the collection-initialiser entry point).</summary>
     public virtual void Add(SchemaElement element)
     {
         Children.Add(element);
     }
 
+    /// <summary>Remove all child fields.</summary>
     public void Clear()
     {
         Children.Clear();
     }
 
+    /// <summary>Whether <paramref name="item"/> is a direct child.</summary>
     public bool Contains(SchemaElement item)
     {
         return Children.Contains(item);
     }
 
+    /// <summary>Copy the child fields into <paramref name="array"/> starting
+    /// at <paramref name="arrayIndex"/>.</summary>
     public void CopyTo(SchemaElement[] array, int arrayIndex)
     {
         Children.ToArray().CopyTo(array, arrayIndex);
     }
 
+    /// <summary>Enumerate the child fields.</summary>
     public IEnumerator<SchemaElement> GetEnumerator()
     {
         return Children.GetEnumerator();
     }
 
+    /// <summary>Remove a child field; returns whether it was present.</summary>
     public bool Remove(SchemaElement item)
     {
         return Children.Remove(item);

--- a/WebReaper/Domain/Parsing/SchemaElement.cs
+++ b/WebReaper/Domain/Parsing/SchemaElement.cs
@@ -1,36 +1,64 @@
-﻿namespace WebReaper.Domain.Parsing;
+namespace WebReaper.Domain.Parsing;
 
+/// <summary>
+/// One field in the extraction <see cref="Schema"/>: a named output field, the
+/// selector that locates it on the page, and how to read it (an attribute, the
+/// inner HTML, a type coercion, or a list). The fold (ADR-0002) walks these;
+/// <see cref="Schema"/> is the composite element with <see cref="Schema.Children"/>.
+/// </summary>
 public record SchemaElement()
 {
+    /// <summary>An element that extracts text content for
+    /// <paramref name="field"/> via <c>Selector</c> set later.</summary>
     public SchemaElement(string field) : this()
     {
         Field = field;
     }
 
+    /// <summary>Extract <paramref name="field"/> from the first node matching
+    /// <paramref name="selector"/> (its text content).</summary>
     public SchemaElement(string field, string selector) : this(field)
     {
         Selector = selector;
     }
 
+    /// <summary>As <see cref="SchemaElement(string, string)"/>, but coerce the
+    /// extracted value to <paramref name="type"/>.</summary>
     public SchemaElement(string field, string selector, DataType type) : this(field, selector)
     {
         Type = type;
     }
 
+    /// <summary>As <see cref="SchemaElement(string, string)"/>, but read the
+    /// <paramref name="attr"/> attribute instead of the text content.</summary>
     public SchemaElement(string field, string selector, string attr) : this(field, selector)
     {
         Attr = attr;
     }
 
+    /// <summary>As <see cref="SchemaElement(string, string)"/>, but capture the
+    /// node's inner HTML when <paramref name="getHtml"/> is true.</summary>
     public SchemaElement(string field, string selector, bool getHtml) : this(field, selector)
     {
         GetHtml = getHtml;
     }
 
+    /// <summary>The output JSON property name for this element.</summary>
     public string? Field { get; set; }
+
+    /// <summary>The selector (CSS / XPath / JSONPath, per the configured
+    /// backend) that locates the value on the page.</summary>
     public string? Selector { get; set; }
+
+    /// <summary>An attribute to read instead of the element's text content
+    /// (e.g. <c>href</c>); null reads the text.</summary>
     public string? Attr { get; set; }
+
+    /// <summary>Optional coercion applied to the extracted value (see
+    /// <see cref="DataType"/>); null keeps the raw string.</summary>
     public DataType? Type { get; set; }
+
+    /// <summary>Capture the matched node's inner HTML rather than its text.</summary>
     public bool GetHtml { get; set; }
 
     /// <summary>

--- a/WebReaper/Domain/ScraperConfig.cs
+++ b/WebReaper/Domain/ScraperConfig.cs
@@ -5,6 +5,27 @@ using WebReaper.Domain.Selectors;
 
 namespace WebReaper.Domain;
 
+/// <summary>
+/// The immutable, serialisable crawl definition produced by
+/// <see cref="WebReaper.Builders.ConfigBuilder.Build"/> and persisted to
+/// <see cref="WebReaper.ConfigStorage.Abstract.IScraperConfigStorage"/> so the
+/// Spider (in-process or a distributed worker) reads identical settings at
+/// crawl time. Round-trips through <c>WebReaperJson</c> (ADR-0008).
+/// </summary>
+/// <param name="ParsingScheme">The extraction <see cref="Schema"/> for target
+/// pages; null means no extraction.</param>
+/// <param name="LinkPathSelectors">The selector chain that drives the crawl
+/// state machine (ADR-0001).</param>
+/// <param name="StartUrls">The seed URLs.</param>
+/// <param name="UrlBlackList">URL patterns the crawl must never enqueue.</param>
+/// <param name="PageCrawlLimit">Soft cap on pages crawled (ADR-0022:
+/// best-effort, may overshoot by ~the parallelism degree).</param>
+/// <param name="StartPageType">Whether the start URLs load static or
+/// dynamic.</param>
+/// <param name="PageActions">Browser actions for dynamic start pages.</param>
+/// <param name="Headless">Run the browser headless for dynamic pages.</param>
+/// <param name="StopWhenDrained">Stop once every discovered link is crawled
+/// (issue #20 / ADR-0022 in-memory latch) instead of running forever.</param>
 public record ScraperConfig(
     Schema? ParsingScheme,
     ImmutableQueue<LinkPathSelector> LinkPathSelectors,

--- a/WebReaper/Domain/Selectors/LinkPathSelector.cs
+++ b/WebReaper/Domain/Selectors/LinkPathSelector.cs
@@ -2,11 +2,28 @@ using WebReaper.Domain.PageActions;
 
 namespace WebReaper.Domain.Selectors;
 
+/// <summary>
+/// One step in the crawl's selector chain (ADR-0001): the link selector to
+/// follow from the current page, optionally a pagination selector (walk
+/// next-page links applying <see cref="Selector"/> to each), and how the
+/// reached pages load. The chain is consumed one step per crawl step; its
+/// length is the state machine.
+/// </summary>
+/// <param name="Selector">The selector for the links to follow from the
+/// current page.</param>
+/// <param name="PaginationSelector">The next-page-link selector; null for a
+/// plain follow step (no pagination).</param>
+/// <param name="PageType">Whether the reached pages load static or
+/// dynamic.</param>
+/// <param name="PageActions">Browser actions for the reached dynamic
+/// pages.</param>
 public record LinkPathSelector(
     string Selector,
     string? PaginationSelector = null,
     PageType PageType = PageType.Static,
     List<PageAction>? PageActions = null)
 {
+    /// <summary>True when a <see cref="PaginationSelector"/> is set — this
+    /// step paginates rather than plain-follows.</summary>
     public bool HasPagination => PaginationSelector != null;
 }

--- a/WebReaper/Domain/Selectors/PageType.cs
+++ b/WebReaper/Domain/Selectors/PageType.cs
@@ -4,8 +4,16 @@ namespace WebReaper.Domain.Selectors;
 // removed — string-enum serialisation is now the AOT-safe
 // JsonStringEnumConverter<PageType> registered on WebReaperJson. The Domain
 // enum no longer references Newtonsoft.
+/// <summary>
+/// How a page is loaded: <see cref="Static"/> via HTTP, or
+/// <see cref="Dynamic"/> via the headless-browser transport (the
+/// WebReaper.Puppeteer satellite, ADR-0009) for JavaScript-rendered pages.
+/// </summary>
 public enum PageType
 {
+    /// <summary>Load through the headless browser (JavaScript-rendered).</summary>
     Dynamic,
+
+    /// <summary>Load via a plain HTTP request (the default, core-only).</summary>
     Static
 }

--- a/WebReaper/Exceptions/ConfigNotFoundException.cs
+++ b/WebReaper/Exceptions/ConfigNotFoundException.cs
@@ -10,11 +10,14 @@ namespace WebReaper.Exceptions;
 /// </summary>
 public class ConfigNotFoundException : Exception
 {
+    /// <summary>The config was absent for storage key
+    /// <paramref name="key"/>.</summary>
     public ConfigNotFoundException(string key)
         : base($"No scraper config found for key '{key}'. CreateConfigAsync must run before GetConfigAsync.")
     {
         Key = key;
     }
 
+    /// <summary>The storage key that had no persisted config.</summary>
     public string Key { get; init; }
 }

--- a/WebReaper/Extensions/LoggerExtensions.cs
+++ b/WebReaper/Extensions/LoggerExtensions.cs
@@ -36,7 +36,7 @@ public static class LoggerExtensions
     }
 }
 
-public class Timer : IDisposable
+internal class Timer : IDisposable
 {
     private readonly ILogger _logger;
     private readonly string callerName = "";
@@ -65,7 +65,7 @@ public class Timer : IDisposable
     }
 }
 
-public static class Counter
+internal static class Counter
 {
     private static readonly ConcurrentDictionary<string, int> _methodCounters = new();
 

--- a/WebReaper/Extensions/LoggerExtensions.cs
+++ b/WebReaper/Extensions/LoggerExtensions.cs
@@ -5,8 +5,18 @@ using Microsoft.Extensions.Logging;
 
 namespace WebReaper.Extensions;
 
+/// <summary>
+/// Diagnostic <see cref="ILogger"/> extensions used across WebReaper and the
+/// satellites (e.g. the WebReaper.Puppeteer transport times its page loads
+/// with <see cref="LogMethodDuration"/>).
+/// </summary>
 public static class LoggerExtensions
 {
+    /// <summary>
+    /// Time the calling method: returns an <see cref="IDisposable"/> that, when
+    /// disposed, logs the elapsed milliseconds. Use with
+    /// <c>using var _ = logger.LogMethodDuration();</c>.
+    /// </summary>
     public static IDisposable LogMethodDuration(
         this ILogger logger,
         [CallerMemberName] string callerName = "")
@@ -14,6 +24,10 @@ public static class LoggerExtensions
         return new Timer(logger, callerName);
     }
 
+    /// <summary>
+    /// Log how many times the calling method has been invoked (a process-wide
+    /// counter keyed by caller name) — a lightweight call-frequency probe.
+    /// </summary>
     public static void LogInvocationCount(
         this ILogger logger,
         [CallerMemberName] string callerName = "")

--- a/WebReaper/Infra/Executor.cs
+++ b/WebReaper/Infra/Executor.cs
@@ -3,7 +3,7 @@ using Polly.Retry;
 
 namespace WebReaper.Infra;
 
-public static class Executor
+internal static class Executor
 {
     private static AsyncRetryPolicy AsyncPolicy { get; } = Polly.Policy.Handle<Exception>().RetryAsync(3);
     private static RetryPolicy Policy { get; } = Polly.Policy.Handle<Exception>().Retry(3);

--- a/WebReaper/Logging/ColorConsoleLogger.cs
+++ b/WebReaper/Logging/ColorConsoleLogger.cs
@@ -2,7 +2,7 @@
 
 namespace WebReaper.Logging;
 
-public sealed class ColorConsoleLogger : ILogger
+internal sealed class ColorConsoleLogger : ILogger
 {
     private Dictionary<LogLevel, ConsoleColor> LogLevelToColorMap { get; } = new()
     {

--- a/WebReaper/Proxy/Abstract/IProxyProvider.cs
+++ b/WebReaper/Proxy/Abstract/IProxyProvider.cs
@@ -1,8 +1,20 @@
-﻿using System.Net;
+using System.Net;
 
 namespace WebReaper.Proxy.Abstract;
 
+/// <summary>
+/// Supplies the <see cref="WebProxy"/> the page-load transport applies to a
+/// request — the seam behind proxy rotation. When a provider is configured the
+/// loaders switch to the proxy-applying path. The built-in adapter is
+/// <c>ValidatedProxyProvider</c> (an <see cref="IProxySource"/> filtered by
+/// <see cref="IProxyValidator"/>s).
+/// </summary>
 public interface IProxyProvider
 {
+    /// <summary>
+    /// The proxy to use for the next request. Called per request, so a
+    /// rotating implementation returns different proxies over time; keep it
+    /// cheap (cache / refresh internally rather than fetching per call).
+    /// </summary>
     Task<WebProxy> GetProxyAsync();
 }

--- a/WebReaper/Proxy/Concrete/HttpProxyValidator.cs
+++ b/WebReaper/Proxy/Concrete/HttpProxyValidator.cs
@@ -17,6 +17,8 @@ public sealed class HttpProxyValidator : IProxyValidator
 {
     private readonly Uri _testUrl;
 
+    /// <summary>Validate proxies by fetching <paramref name="testUrl"/>
+    /// through each one.</summary>
     /// <param name="testUrl">
     /// URL fetched through the proxy. Default is Google's connectivity
     /// endpoint, which returns an empty 204 quickly.
@@ -24,6 +26,7 @@ public sealed class HttpProxyValidator : IProxyValidator
     public HttpProxyValidator(string testUrl = "http://www.gstatic.com/generate_204")
         => _testUrl = new Uri(testUrl);
 
+    /// <inheritdoc/>
     public async Task<bool> IsValidAsync(WebProxy proxy, CancellationToken cancellationToken = default)
     {
         try

--- a/WebReaper/Proxy/Concrete/StaticProxySource.cs
+++ b/WebReaper/Proxy/Concrete/StaticProxySource.cs
@@ -11,6 +11,8 @@ public sealed class StaticProxySource : IProxySource
 {
     private readonly IReadOnlyList<WebProxy> _proxies;
 
+    /// <summary>Capture a fixed set of <paramref name="proxies"/> (snapshotted
+    /// at construction).</summary>
     public StaticProxySource(IEnumerable<WebProxy> proxies)
     {
         ArgumentNullException.ThrowIfNull(proxies);
@@ -34,6 +36,7 @@ public sealed class StaticProxySource : IProxySource
         return new StaticProxySource(proxies);
     }
 
+    /// <inheritdoc/>
     public Task<IReadOnlyList<WebProxy>> GetCandidatesAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(_proxies);
 }

--- a/WebReaper/Proxy/Concrete/ValidatedProxyProvider.cs
+++ b/WebReaper/Proxy/Concrete/ValidatedProxyProvider.cs
@@ -16,7 +16,7 @@ namespace WebReaper.Proxy.Concrete;
 /// Puppeteer loader) with no other changes. No background service, no extra
 /// hosting dependency: refresh happens on demand, single-flighted.
 /// </summary>
-public sealed class ValidatedProxyProvider : IProxyProvider, IDisposable
+internal sealed class ValidatedProxyProvider : IProxyProvider, IDisposable
 {
     private readonly IProxySource _source;
     private readonly IReadOnlyList<IProxyValidator> _validators;

--- a/WebReaper/Serialization/WebReaperJson.cs
+++ b/WebReaper/Serialization/WebReaperJson.cs
@@ -47,16 +47,30 @@ public static class WebReaperJson
     // registered converters into the generated metadata (spike-proven).
     private static JsonTypeInfo<T> Info<T>() => (JsonTypeInfo<T>)Options.GetTypeInfo(typeof(T));
 
+    /// <summary>Serialise a <see cref="ScraperConfig"/> to the WebReaper JSON
+    /// grammar — what <c>IScraperConfigStorage</c> persists so an in-process
+    /// or distributed worker reads identical settings.</summary>
     public static string SerializeConfig(ScraperConfig config)
         => JsonSerializer.Serialize(config, Info<ScraperConfig>());
 
+    /// <summary>Parse a <see cref="ScraperConfig"/> from the WebReaper JSON
+    /// grammar.</summary>
+    /// <exception cref="JsonException">the payload deserialised to
+    /// null.</exception>
     public static ScraperConfig DeserializeConfig(string json)
         => JsonSerializer.Deserialize(json, Info<ScraperConfig>())
            ?? throw new JsonException("ScraperConfig deserialised to null");
 
+    /// <summary>Serialise a <see cref="Job"/> to the WebReaper JSON grammar —
+    /// the wire form the distributed schedulers (Redis / Azure Service Bus /
+    /// SQLite) enqueue and replay (ADR-0008).</summary>
     public static string SerializeJob(Job job)
         => JsonSerializer.Serialize(job, Info<Job>());
 
+    /// <summary>Parse a <see cref="Job"/> from the WebReaper JSON
+    /// grammar.</summary>
+    /// <exception cref="JsonException">the payload deserialised to
+    /// null.</exception>
     public static Job DeserializeJob(string json)
         => JsonSerializer.Deserialize(json, Info<Job>())
            ?? throw new JsonException("Job deserialised to null");

--- a/WebReaper/Sinks/Abstract/IScraperSink.cs
+++ b/WebReaper/Sinks/Abstract/IScraperSink.cs
@@ -2,9 +2,28 @@ using WebReaper.Sinks.Models;
 
 namespace WebReaper.Sinks.Abstract;
 
+/// <summary>
+/// A destination for scraped data. The Crawl driver (ADR-0022) fans every
+/// target-page <see cref="ParsedData"/> out to every registered sink, so
+/// sinks compose (console + file + database at once). Built-in adapters are
+/// added via builder methods (<c>.WriteToConsole()</c>,
+/// <c>.WriteToJsonFile()</c>, <c>.WriteToCsvFile()</c>, the satellite db
+/// sinks); implement this to add your own.
+/// </summary>
 public interface IScraperSink
 {
+    /// <summary>
+    /// Wipe the destination when the crawl starts instead of appending to it.
+    /// Note the documented asymmetry: <c>WriteToJsonFile</c> defaults this to
+    /// <c>true</c> (fresh file each run); the other file sinks default it to
+    /// <c>false</c> (append).
+    /// </summary>
     public bool DataCleanupOnStart { get; set; }
 
+    /// <summary>
+    /// Write one parsed record. Called once per target page per sink, and
+    /// concurrently — the driver fans out under <c>Parallel.ForEachAsync</c>,
+    /// so an implementation must be safe under concurrent calls.
+    /// </summary>
     public Task EmitAsync(ParsedData entity, CancellationToken cancellationToken = default);
 }

--- a/WebReaper/Sinks/Concrete/BufferedFileSink.cs
+++ b/WebReaper/Sinks/Concrete/BufferedFileSink.cs
@@ -31,7 +31,7 @@ namespace WebReaper.Sinks.Concrete;
 /// per row opens and closes the file each time, and the consumer has no
 /// flush/dispose — its lifetime is the process or the bound token.
 /// </summary>
-public class BufferedFileSink : IScraperSink
+internal class BufferedFileSink : IScraperSink
 {
     private readonly BlockingCollection<JsonObject> _entries = new();
     private readonly IFileSinkFormat _format;

--- a/WebReaper/Sinks/Concrete/ConsoleSink.cs
+++ b/WebReaper/Sinks/Concrete/ConsoleSink.cs
@@ -3,7 +3,7 @@ using WebReaper.Sinks.Models;
 
 namespace WebReaper.Sinks.Concrete;
 
-public class ConsoleSink : IScraperSink
+internal class ConsoleSink : IScraperSink
 {
     public bool DataCleanupOnStart { get; set; }
 

--- a/WebReaper/Sinks/Concrete/CsvFileSink.cs
+++ b/WebReaper/Sinks/Concrete/CsvFileSink.cs
@@ -7,7 +7,7 @@ namespace WebReaper.Sinks.Concrete;
 /// ctor is preserved, so the builder and consumer code are unchanged
 /// (source-compatible, minor SemVer).
 /// </summary>
-public class CsvFileSink : BufferedFileSink
+internal class CsvFileSink : BufferedFileSink
 {
     public CsvFileSink(string filePath, bool dataCleanupOnStart)
         : base(filePath, dataCleanupOnStart, new CsvFormat())

--- a/WebReaper/Sinks/Concrete/CsvFormat.cs
+++ b/WebReaper/Sinks/Concrete/CsvFormat.cs
@@ -12,7 +12,7 @@ namespace WebReaper.Sinks.Concrete;
 /// (<c>$.name</c>→<c>name</c>, <c>$.a.b</c>→<c>b</c>, <c>$.a[0]</c>→<c>a[0]</c>),
 /// so observable file content is unchanged.
 /// </summary>
-public sealed class CsvFormat : IFileSinkFormat
+internal sealed class CsvFormat : IFileSinkFormat
 {
     public string? Header(JsonObject firstRow)
     {

--- a/WebReaper/Sinks/Concrete/JsonFileSink.cs
+++ b/WebReaper/Sinks/Concrete/JsonFileSink.cs
@@ -7,7 +7,7 @@ namespace WebReaper.Sinks.Concrete;
 /// is preserved, so the builder and consumer code are unchanged
 /// (source-compatible, minor SemVer).
 /// </summary>
-public class JsonLinesFileSink : BufferedFileSink
+internal class JsonLinesFileSink : BufferedFileSink
 {
     public JsonLinesFileSink(string filePath, bool dataCleanupOnStart)
         : base(filePath, dataCleanupOnStart, new JsonLinesFormat())

--- a/WebReaper/Sinks/Concrete/JsonLinesFormat.cs
+++ b/WebReaper/Sinks/Concrete/JsonLinesFormat.cs
@@ -9,7 +9,7 @@ namespace WebReaper.Sinks.Concrete;
 /// Newtonsoft) — observable file content is unchanged (ADR 0006: the format
 /// quirk relocated, not changed).
 /// </summary>
-public sealed class JsonLinesFormat : IFileSinkFormat
+internal sealed class JsonLinesFormat : IFileSinkFormat
 {
     public string? Header(JsonObject firstRow) => null;
 

--- a/WebReaper/Sinks/Models/ParsedData.cs
+++ b/WebReaper/Sinks/Models/ParsedData.cs
@@ -5,4 +5,13 @@ namespace WebReaper.Sinks.Models;
 // ADR 0008: the extracted record's payload is a System.Text.Json JsonObject
 // (the typed terminal of the one Schema fold), not a Newtonsoft JObject.
 // Major SemVer — the JObject public surface changed (precedent ADR 0004).
+/// <summary>
+/// One scraped record: the page it came from and the JSON the
+/// <see cref="WebReaper.Domain.Parsing.Schema"/> fold produced. Emitted to
+/// every <see cref="WebReaper.Sinks.Abstract.IScraperSink"/> and to
+/// <c>Subscribe</c> callbacks by the Crawl driver (ADR-0022) for each target
+/// page.
+/// </summary>
+/// <param name="Url">The page the data was scraped from.</param>
+/// <param name="Data">The extracted fields as a System.Text.Json object.</param>
 public record ParsedData(string Url, JsonObject Data);

--- a/WebReaper/WebReaper.csproj
+++ b/WebReaper/WebReaper.csproj
@@ -25,6 +25,14 @@
          never picked up and wrote a build artifact into the tracked tree
          (hence the historical "revert API.xml before commit" footgun). -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- ADR-0023: the core public surface IS the documented contract. With
+         every Tier-1 type documented and every Tier-2 implementation type
+         internal, core CS1591 is zero; promote it to a build error so the
+         documented surface cannot silently re-accumulate undocumented public
+         members (the way the ~552 backlog did). This replaces the per-area
+         .editorconfig ratchet scaffolding (removed). Satellites keep their
+         own NoWarn CS1591 by their own recorded rationale. -->
+    <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
     <LangVersion>12</LangVersion>
     <Title>WebReaper</Title>
 
@@ -82,11 +90,28 @@
     </None>
   </ItemGroup>
 
-  <!-- ADR-0011: FilePersistencePrep is an internal stateless helper; the unit
-       test assembly asserts its three responsibilities at its own interface
-       (a pure utility has no public facade to test it through, unlike the
-       internal SpiderBuilder which is reached via ScraperEngineBuilder). -->
+  <!-- InternalsVisibleTo targets the test assemblies ONLY — never a shipped
+       package (verified: no satellite-prod / Example / Misc code names a
+       Tier-2 type; satellites bind the Tier-1 interfaces and inherit the
+       Tier-1 payload-shell bases). ADR-0011: the unit suite asserts the
+       internal stateless FilePersistencePrep at its own interface. ADR-0023:
+       the Tier-2 implementation adapters are now internal (the public
+       surface is the documented contract); the suites that construct them
+       directly reach them through this seam, so internalising broke no
+       consumer. -->
   <ItemGroup>
     <InternalsVisibleTo Include="WebReaper.UnitTests" />
+    <InternalsVisibleTo Include="WebReaper.IntegrationTests" />
+    <!-- The Native-AOT publish smoke test deliberately constructs the
+         internal JSON backend / file-format adapters to keep the AOT-sensitive
+         paths (System.Text.Json source-gen, the fold) under regression cover;
+         non-shipped, like the test assemblies. -->
+    <InternalsVisibleTo Include="WebReaper.AotSmokeTest" />
+    <InternalsVisibleTo Include="WebReaper.Redis.Tests" />
+    <InternalsVisibleTo Include="WebReaper.Cosmos.Tests" />
+    <InternalsVisibleTo Include="WebReaper.Mongo.Tests" />
+    <InternalsVisibleTo Include="WebReaper.AzureServiceBus.Tests" />
+    <InternalsVisibleTo Include="WebReaper.Puppeteer.Tests" />
+    <InternalsVisibleTo Include="WebReaper.Sqlite.Tests" />
   </ItemGroup>
 </Project>

--- a/docs/adr/0023-core-doc-contract.md
+++ b/docs/adr/0023-core-doc-contract.md
@@ -1,0 +1,243 @@
+# The core public surface is the contract — drawn by the deletion test, documented to the bar, the rest made internal, CS1591 ratcheted to zero
+
+## Status
+
+**Accepted** (design pass; implementation pending in the staging slices). The
+one fork flagged for grilling — the disposition of the in-memory default
+adapters — was resolved in the grilling loop in favour of the principled line
+below (see *Considered options → the in-memory-defaults sub-decision*).
+
+## Context
+
+Six satellite csprojs carry a verbatim, load-bearing rationale:
+
+> *Ship the XML doc so the documented builder-extension API (the satellite's
+> supported surface) gives consumers IntelliSense. The adapter classes … are
+> public only because the extension and tests bind to them; they are not part
+> of the satellite's documented contract, so CS1591 for them is noise, not a
+> backlog signal. **Core keeps CS1591 visible by contrast — there it IS a live
+> doc backlog.***
+
+That last sentence is a recorded decision: core CS1591 was deliberately left
+*un-suppressed* so the backlog stays a visible signal. It has now been
+measured — **~552 CS1591 across 65 core files** (~2× inflated by the build
+listing each for project and solution; ≈276 declarations). This ADR is what
+that decision was waiting for: it turns the standing backlog into a *closed,
+enforced contract*, and updates the satellite sentence in place to say so.
+
+The public surface is an **interface** in the LANGUAGE.md sense — *everything
+a caller must know to use the module*. Measured against that definition it is
+**under-documented where it is contract** and **accidentally wide where it is
+not**:
+
+- **The fluent front door ships with no IntelliSense.** `ConfigBuilder.Follow`
+  / `.Paginate` / `.Build`, the `ScraperEngineBuilder` façade — the exact API
+  the README *teaches* — have zero XML doc (~56 declarations in `Builders/`).
+  The interface is advertised in prose and absent at the call site.
+- **The surface is accidentally wide.** `SpiderBuilder` is already `internal`
+  (ADR-0009) — precedent that "public" here often meant "a test or satellite
+  binds to it", not "a consumer calls it".
+
+### The line is the deletion test, not the folder
+
+The error to avoid is drawing the Tier line as `Abstract`-public vs
+`Concrete`-internal — optimising for "fewest public concretes". That is the
+wrong target. The right target: **the public surface should *be* the contract
+— no wider, no narrower.** Applied per type via the deletion test (evidence:
+a repo-wide reference sweep, who-names-what across satellites / Examples /
+Misc / tests):
+
+- **`new InMemoryScraperConfigStorage()`** — `Examples/WebReaper.AzureFuncs/
+  Startup.cs:36`. The ADR-0009 "build your own distributed worker" pattern
+  (which deliberately bypasses `ScraperEngineBuilder` via `BuildSpider()`)
+  wires an in-memory store *by hand*. Delete this from the public surface and
+  the complexity reappears in **every** DIY-distributed consumer — each
+  hand-rolls a trivial `IScraperConfigStorage`. It is *earning its keep* as a
+  contract adapter at a real, many-adapter seam. → **public + documented.**
+- **`CookieStore`, `ScraperConfigStore`** — under `*/Concrete/` paths, but
+  shipped satellites *inherit* them (`RedisCookieStorage : CookieStore`,
+  `MongoDbScraperConfigStorage : ScraperConfigStore`, …). They are the
+  ADR-0003 payload-shell extension points: an inheritance contract an
+  extension author subclasses. → **public + documented (the best docs — they
+  are subclassed across assemblies).**
+- **`LoggerExtensions.LogMethodDuration()`** — called by
+  `WebReaper.Puppeteer/BrowserPageLoadTransport.cs:56` (shipped satellite
+  prod). A satellite binds it. → **public + documented.**
+- **`new ConsoleSink()`, `Executor.RetryAsync`, `FileScheduler`,
+  `ColorConsoleLogger`, the `File*`/parser/sink/page-loader leaves** — named
+  by **no** consumer, satellite, or Example; reached only through a fluent
+  builder method (`.WriteToConsole()`, `.WithTextFileScheduler(...)`) or
+  core-internally. Delete them from the *public* surface and nothing reappears
+  anywhere. Zero leverage lost. → **internal.**
+
+A factory introduced solely to vend `new InMemoryX()` (the alternative for
+keeping the surface "concrete-free") is a **shallow module**: its interface is
+as complex as its implementation, behaviourless indirection. Deletion test on
+*that* factory: delete it, complexity vanishes — a pass-through. Rejected (see
+*Considered options*).
+
+### The failure mode this ADR exists to prevent
+
+**Mechanically generating filler comments to zero the counter.** A doc that
+restates the signature is worse than an honest gap — it destroys the very
+signal the visible-backlog decision protected. The codebase already sets the
+bar (the `ScraperEngine` / `HttpPageLoadTransport` summaries: intent,
+invariants, the *why*, ADR-linked). Anything below that bar is not progress.
+Internalising Tier-2 is the *non-filler* way to clear ~half the backlog: CS1591
+does not fire on non-public members, so the warning vanishes with **no NoWarn
+and no comment** when the type stops being contract.
+
+## Decision
+
+- **Draw the surface by the deletion test (the principle above).** Public iff
+  named by a documented consumer / inherited by a satellite / part of the
+  taught fluent API. Everything else is implementation.
+
+- **Tier-1 — the contract: public, documented to the bar.**
+  - `Builders/` — `ScraperEngineBuilder` (façade), `ConfigBuilder`,
+    `PageActionBuilder`.
+  - `*/Abstract/` — every pluggable seam interface (`IScheduler`,
+    `IVisitedLinkTracker`, `IScraperConfigStorage`, `ICookiesStorage`,
+    `IScraperSink`, `IPageLoader`/`IPageLoadTransport`, `ISpider`,
+    `ICrawlStep`, `ILinkParser`, `IContentParser`, `IProxyProvider`,
+    `IKeyedBlobStore`, `IOutstandingWorkLatch`, …).
+  - Public `Domain/` model: `Schema`, `LinkPathSelector`, `PageAction` /
+    `PageActionType`, `PageType`, `Job`, `ScraperConfig`, `ParsedData`,
+    `Metadata`, `CrawlOutcome` (+ `Parsed`/`Followed`/`Paginated`),
+    `JobReport`, `PageRequest`.
+  - The payload-shell extension bases satellites inherit: `CookieStore`,
+    `ScraperConfigStore`.
+  - The in-memory default adapters the DIY-distributed pattern constructs by
+    name: `InMemoryScheduler`, `InMemoryScraperConfigStorage`,
+    `InMemoryVisitedLinkTracker`.
+  - `WebReaperJson` (the ADR-0008 cross-assembly Job/Config grammar; satellite
+    schedulers serialise through it).
+  - `LoggerExtensions` (a shipped satellite binds it).
+  - Public exceptions a consumer catches.
+
+  Bar: purpose + the non-obvious (invariants, ordering, error modes, the
+  *why*), governing ADR linked where one exists, density matching the
+  `ScraperEngine`/`HttpPageLoadTransport` summaries. **A reviewer (human or AI)
+  rejects any comment that only restates the signature.**
+
+- **Tier-2 — implementation: made `internal`.** The `File*` leaves
+  (`FileScheduler`, `FileScraperConfigStorage`, `FileCookieStorage`,
+  `FileVisitedLinkedTracker`, `FileBlobStore`), `InMemoryBlobStore`, the sinks
+  (`ConsoleSink`, `CsvFileSink`, `JsonLinesFileSink`), the parsers
+  (`AngleSharpContentParser`, `JsonContentParser`, `XPathContentParser`), the
+  page loaders, `InMemoryOutstandingWorkLatch`, `Infra/Executor`,
+  `Logging/ColorConsoleLogger`. `[InternalsVisibleTo]` targets the **test
+  assemblies only** — verified: no satellite/Example/Misc names a Tier-2 type;
+  satellites bind core *interfaces* and inherit the *payload-shell bases*
+  (both Tier-1). No shipped package is an `InternalsVisibleTo` target.
+
+- **One release: 9.0.0 (Major).** The maintainer accepts the break. The
+  surface-shrink is done in this initiative, not deferred — internalising
+  Tier-2 is the breaking change and it ships with the docs, as one coherent
+  major.
+
+- **Enforcement: ratchet to zero, then project-wide.** As each Tier-1 area
+  reaches zero CS1591, set `dotnet_diagnostic.CS1591.severity = error` for that
+  path (path-scoped `.editorconfig`), monotone — a new undocumented public
+  member there fails the build. End state (Tier-1 documented + Tier-2 internal
+  ⇒ core CS1591 == 0): promote to project-wide `WarningsAsErrors=CS1591`; the
+  scoped `.editorconfig` sections are then redundant scaffolding and removed.
+  No scoped-NoWarn device is needed at the end state — internalisation, not
+  suppression, clears Tier-2.
+
+- **Close the loop on the recorded decision.** The satellite-csproj sentence
+  *"Core keeps CS1591 visible by contrast — there it IS a live doc backlog"*
+  is updated, in place, to point at this ADR: core CS1591 is now a
+  contract-enforced surface, not an open backlog.
+
+## Staging (slices; guardrail green at each — offline unit suite, whole-solution build incl. Examples/Misc, `WebReaper.AotSmokeTest`)
+
+1. **`*/Abstract` seam interfaces** — highest leverage (an extension author's
+   entire surface; the offline test surface). Document to the bar; ratchet
+   those directories → error.
+2. **`Builders/` fluent API** — the README's front door. Document; ratchet.
+3. **Public `Domain/` model** + the payload-shell bases (`CookieStore`,
+   `ScraperConfigStore`) + the in-memory default adapters. Document; ratchet.
+4. **`WebReaperJson` + `LoggerExtensions` + public exceptions.** Document;
+   ratchet.
+5. **Internalise Tier-2** + `[InternalsVisibleTo]` for the test assemblies.
+   Verify whole-solution build clean; no satellite/Example breaks (none names
+   a Tier-2 type — `InMemoryScraperConfigStorage` stayed Tier-1, so AzureFuncs
+   is untouched). Promote to project-wide `WarningsAsErrors=CS1591`; remove the
+   scaffolding `.editorconfig` sections. Update the satellite-csproj rationale
+   sentence. **Core CS1591 == 0, enforced.**
+
+Each slice is a separate commit; Phase A/B is *not* split — the break
+(internalisation) is slice 5 of the one 9.0.0 initiative.
+
+## Bounded scope — what this does NOT change
+
+- **No behaviour change.** XML doc + visibility modifiers + csproj/
+  `.editorconfig` only. Internalising a type is an IL visibility change, not a
+  logic change; the guardrail (unit suite + whole-solution build + AOT smoke)
+  proves the composition still builds and runs.
+- **No signature change to Tier-1.** The contract a consumer uses is
+  byte-identical; it only gains documentation and enforcement.
+- **Satellite csproj CS1591 NoWarn** — unchanged; only core's posture changes
+  and only its rationale sentence is updated to cross-reference this ADR.
+- **ADR-0009's registration seam / `BuildSpider()` / `internal SpiderBuilder`**
+  — unchanged. This ADR documents and tightens the surface ADR-0009 defined;
+  it does not move the seam. The DIY-distributed pattern keeps its in-memory
+  building blocks (Tier-1 by the deletion test).
+- **The seam interfaces' identity (ADR-0001/0002/0003/0004/0022).** Untouched;
+  they are *documented*, not reshaped.
+
+## SemVer
+
+**Major — 9.0.0.** Tier-2 types leave the public surface (`public` →
+`internal`). Announced via this ADR + the CHANGELOG migration section, never
+silent (project rule). Evidence-backed blast radius: **no in-repo consumer and
+no shipped satellite names a Tier-2 type** (repo-wide sweep); the only
+externally-named concrete, `InMemoryScraperConfigStorage` (AzureFuncs), is
+Tier-1 by the deletion test and stays public. The break is real (the types are
+gone from the API) but affects only code that reached past the contract into
+implementation — exactly what a major is for. Test assemblies retain access via
+`[InternalsVisibleTo]`.
+
+## Considered options
+
+- **The deletion-test line: contract public + documented, implementation
+  internal, one 9.0.0 (chosen).** The surface ends up *being* the contract;
+  ~half the backlog clears by internalisation (no filler), the other half by
+  real docs at the bar; enforcement makes it non-regressing.
+- **Document everything to literal zero, keep it all public (rejected).**
+  Filler on implementation types no one calls — most effort on least leverage,
+  destroys the signal, doesn't shrink the surface.
+- **Bulk `NoWarn CS1591` on core — the one-line "make the number go away"
+  (rejected).** Reinstates exactly the invisible-backlog state the satellite
+  rationale deliberately avoided; silences the front-door gap too.
+- **The in-memory-defaults sub-decision (grilled; chosen = keep public +
+  document).** Alternative B: internalise them and add a public factory seam
+  for the DIY pattern. Rejected — the factory is a shallow module (interface
+  as complex as its one-line implementation, behaviourless indirection; fails
+  the deepening/deletion test). Alternative C: internalise and narrow the DIY
+  pattern to distributed-store-only. Rejected — optimises "zero public
+  concretes" at the cost of a documented capability (in-memory DIY wiring for
+  local/test/single-node), with no architectural gain. A keeps the surface
+  aligned with the real contract without inventing a shallow seam. Recorded so
+  a future review does not re-suggest the factory.
+- **Split into non-breaking 8.1.0 (docs) + breaking 9.0.0 (internalise)
+  (rejected by the maintainer).** Considered to ship the non-breaking value
+  first; the maintainer accepts the break, so the simpler single-major
+  sequencing is taken (one coherent story, no scoped-NoWarn transitional
+  device to carry and later remove).
+- **Burn down, no enforcement (rejected).** The unenforced backlog is *how 552
+  accumulated*; without the ratchet it silently re-accumulates.
+
+## References
+
+- The satellite csproj CS1591 rationale (the recorded decision this ADR
+  revises and updates in place).
+- ADR-0009 — the registration seam, `BuildSpider()`, `internal SpiderBuilder`,
+  and the DIY-distributed pattern that shaped this surface.
+- ADR-0003 — the payload-shell bases (`CookieStore`, `ScraperConfigStore`)
+  satellites inherit; ADR-0008 — the `WebReaperJson` grammar satellites
+  serialise through.
+- LANGUAGE.md — *interface = everything a caller must know*; depth; shallow
+  module; the deletion test (the framing for the Tier line and the
+  factory rejection). CONTEXT.md — the domain vocabulary Tier-1 docs speak in.


### PR DESCRIPTION
The core public API is now exactly the contract — no wider, no narrower —
documented to the bar the codebase already set, and **enforced**. Design pass
+ 6 staged slices, guardrail-green at each.

**The line is the deletion test, not the folder** (ADR-0023): named by a
documented consumer / inherited by a satellite / part of the taught fluent API
⇒ public; reached only through a builder method and named by nobody ⇒
implementation. Core CS1591 **294 → 0**, held there by
`<WarningsAsErrors>CS1591</WarningsAsErrors>` — a new undocumented public
member now fails the build, so the ~552 backlog the satellite csprojs
deliberately kept *visible* cannot re-accumulate.

### Slices
| Commit | Slice |
|---|---|
| `769d7e6` | Design pass (accepted after 3 grilling rounds) |
| `8100480` | 1 · `*/Abstract` seam interfaces + ratchet |
| `a6a1b91` | 2 · `Builders/` fluent API + ratchet |
| `8106dea` | 3 · `Domain` model + payload-shell bases + in-memory defaults + ratchet |
| `bf09243` | 4 · `WebReaperJson` + `LoggerExtensions` + exceptions + ratchet |
| `1621fe1` | 5a · `ScraperEngine`/`StaticProxySource`/`HttpProxyValidator` (Tier-1 the heuristic missed) |
| `395879c` | 5b · internalise the 27 Tier-2 types; project-wide enforcement; the 9.0.0 break |

### Breaking (SemVer major — 9.0.0)
Tier-2 implementation adapters (the `File*`/`InMemory*` leaves, sinks+formats,
parsers/loaders, `Spider`/`CrawlStep`/`InMemoryOutstandingWorkLatch`,
`ValidatedProxyProvider`, `Executor`, `ColorConsoleLogger`, `Timer`/`Counter`)
are now `internal`; `ScraperEngine`'s ctor is `internal` (the class stays
public — `BuildAsync()` is the construction contract). **No shipped package is
affected** — a repo-wide sweep confirms no satellite-prod/Example/Misc names a
Tier-2 type; `[InternalsVisibleTo]` targets the test/AOT-smoke assemblies
only, never a NuGet. Fluent-API consumers, custom-seam implementers, the
distributed-worker pattern, and `SchemaContentParser<TNode>` (the ADR-0002
custom-backend reuse vehicle — kept public) need **no changes**. Full
migration: CHANGELOG `## 9.0.0`.

The deletion test caught **4 Tier-1 types** the mechanical "remaining CS1591"
heuristic would have wrongly internalised (`ScraperEngine`,
`StaticProxySource`, `HttpProxyValidator`, `SchemaContentParser<TNode>` — the
last only on the deep read); each surfaced and kept public + documented.

### Guardrail
Whole-solution build (incl. Examples/Misc + AOT smoke) **0 errors** with
`WarningsAsErrors=CS1591` (core CS1591 == 0, no accessibility leak); **95/95**
unit tests; Native-AOT publish **ALL PASS exit 0** (visibility-only = zero IL
delta). Residual 18 warnings are pre-existing non-shipped/test nits scoped out
earlier. Satellite csprojs' "live doc backlog" rationale updated in place to
cite ADR-0023.

Rationale, rejected alternatives, the staged plan:
[`docs/adr/0023-core-doc-contract.md`](docs/adr/0023-core-doc-contract.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)