### PR TITLE
ADR-0025: a scrape begins with a Crawl seed — staged builder entry (10.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## 10.0.0 — A scrape begins with a Crawl seed (breaking)
+
+The builder front door no longer has a runtime trap. Start URLs and a schema
+were a *runtime* `InvalidOperationException` from `ConfigBuilder.Build()` if you
+forgot them, documented only by a `CLAUDE.md` gotcha — the exact
+runtime/implicit failure the project's signature move (ADR-0001, ADR-0022)
+exists to make structurally impossible. ADR-0025 makes it so: a scrape now
+begins with a **Crawl seed**. `ScraperEngineBuilder.Crawl(urls)` /
+`.CrawlWithBrowser(urls)` are *static* and return `ICrawlSeed`; its only member,
+`.Extract(schema)`, returns the configurable `ScraperEngineBuilder`. That
+builder's constructor is `internal`, so the build terminals are unreachable
+without a seed and a schema — "build with no start URLs or no schema" has no
+representation to construct, not a throw to hit. Rationale, the grilled
+alternatives (type-state phantom generics; the multi-param factory; R-narrow),
+the trilemma surfaced at implementation and the two-seam resolution:
+[`docs/adr/0025-staged-builder-entry.md`](docs/adr/0025-staged-builder-entry.md).
+
+### Breaking changes
+
+- **The entry point moved.** `new ScraperEngineBuilder()` (public ctor) +
+  `.Get(...)` / `.GetWithBrowser(...)` + `.Parse(...)` are replaced by the
+  static `ScraperEngineBuilder.Crawl(...)` / `.CrawlWithBrowser(...)` →
+  `ICrawlSeed.Extract(schema)` → the builder. `ScraperEngineBuilder`'s
+  constructor is `internal` (test-only via `InternalsVisibleTo`); `Get`,
+  `GetWithBrowser`, `Parse` are gone.
+- **`ConfigBuilder` is `internal`.** Its sole external use — the distributed
+  start endpoint's `new ConfigBuilder()….Build()` — is absorbed by the seed's
+  gated `ScraperEngineBuilder.Build()` terminal
+  (`Crawl(...).Extract(...).Build()` → `ScraperConfig`). The two
+  `ConfigBuilder.Build()` throws and the `CLAUDE.md` builder-order gotcha are
+  deleted by construction.
+- **The distributed-worker reduced shell is its own type.**
+  `new ScraperEngineBuilder()….BuildSpider()` becomes
+  `new DistributedSpiderBuilder()….BuildSpider()` (ADR-0009). It has a public
+  constructor and no `BuildAsync` — so the structural guarantee is absolute and
+  the worker stays seedless ("two seams, not one bug"). `BuildSpider()` is
+  removed from `ScraperEngineBuilder`; the worker no longer wires the
+  driver-owned visited-link tracker (ADR-0022).
+- **Zero satellite ripple.** Every `this ScraperEngineBuilder` satellite
+  extension is unchanged and works after `.Extract(...)`. Distributed workers
+  wire shared adapters by direct construction (public satellite concretes), as
+  the canonical `AzureFuncs` example already did.
+
+### Migration
+
+`new ScraperEngineBuilder().Get(url)….Parse(schema)….BuildAsync()` →
+`ScraperEngineBuilder.Crawl(url).Extract(schema)….BuildAsync()` — move the
+schema up to `.Extract`, right after the seed; everything else chains unchanged,
+in order, after it. `.GetWithBrowser` → `.CrawlWithBrowser`. The distributed
+start endpoint's `new ConfigBuilder()….Build()` →
+`ScraperEngineBuilder.Crawl(...).Extract(...)….Build()`. The distributed
+worker's `new ScraperEngineBuilder()….BuildSpider()` →
+`new DistributedSpiderBuilder()….BuildSpider()` (drop the now-unneeded
+`.WithLinkTracker(...)` — the driver owns it, ADR-0022). No behavioural change;
+the guardrail (whole-solution build, 94 unit + 27 satellite tests, Native-AOT
+smoke) is green.
+
 ## 9.0.0 — The public surface is the documented contract (breaking)
 
 The core public API is now exactly the contract — no wider, no narrower —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,11 @@ All projects target **net10.0**; `global.json` pins SDK `10.0.100` (`rollForward
 
 Fluent builder → immutable config + pluggable spider → parallel job loop.
 
-**Build path:** `ScraperEngineBuilder` is a façade over two builders:
-- `ConfigBuilder` → produces immutable `ScraperConfig` (start URLs, the `LinkPathSelector` chain, crawl limit, headless flag).
-- `SpiderBuilder` → wires the runtime components (loaders, parsers, sinks, trackers, cookie storage), all with in-memory defaults.
+**Build path (ADR-0025):** a scrape begins with a **Crawl seed**. `ScraperEngineBuilder.Crawl(urls)` / `.CrawlWithBrowser(urls)` are **static** → return `ICrawlSeed`; `.Extract(schema)` → the `ScraperEngineBuilder`. That builder's constructor is `internal` (test-only via `InternalsVisibleTo`), so it is unreachable without the seed — "build with no start URLs or no schema" is structurally impossible, not a runtime throw. It composes two internal builders:
+- `ConfigBuilder` (internal) → immutable `ScraperConfig` (start URLs, the `LinkPathSelector` chain, crawl limit, headless flag).
+- `SpiderBuilder` (internal) → runtime components (loaders, parsers, sinks, trackers, cookie storage), all with in-memory defaults.
 
-`BuildAsync()` builds the config, persists it to `IScraperConfigStorage`, constructs a `Spider`, and returns a `ScraperEngine`.
+Terminate with `BuildAsync()` (persists the config to `IScraperConfigStorage`, constructs a `Spider`, returns a `ScraperEngine`) or `Build()` (just the `ScraperConfig`, for a distributed start endpoint to persist). The ADR-0009 distributed-worker reduced shell is a **separate public seam**: `DistributedSpiderBuilder` (seedless, no `BuildAsync`; `.BuildSpider()` → `ISpider`) — "two seams, not one bug".
 
 **Run path (ADR-0022):** `ScraperEngine` *is* the in-process **Crawl driver**. `RunAsync` seeds the `IScheduler` with one `Job` per start URL, then drives `Parallel.ForEachAsync` over `Scheduler.GetAllAsync()` (an async stream). Each job → `Spider.CrawlAsync` (wrapped in `Infra.Executor.RetryAsync`, Polly-backed) returns a closed `JobReport`; the driver interprets it — applies the visited-link idempotency authority (atomic test-and-set), fans `ParsedData` to the sinks, fires the `Subscribe`/`PostProcess` callbacks, enqueues child jobs, drives the **Outstanding-work latch**. Termination is a *value*, never an exception: the soft page-limit is a check the driver makes (it calls `Scheduler.Complete()`) — `PageCrawlLimitException` was removed in 8.0.0. Authoritative: `docs/adr/0022-crawl-driver-and-outstanding-work-latch.md`.
 
@@ -63,5 +63,4 @@ Namespace mirrors folder path throughout (`WebReaper.Core.Spider.Concrete` = `We
 
 - `WriteToJsonFile` defaults `dataCleanupOnStart: true` (wipes the file on start) — opposite of the other sinks, which default `false`.
 - The "JSON" sink writes **JSON Lines** (`JsonLinesFileSink`), one object per line, not a JSON array.
-- `ConfigBuilder.Build()` throws if `Get`/`GetWithBrowser` or `Parse` was never called — builder order matters.
 - First dynamic-page run downloads Chromium via Puppeteer.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,6 +10,10 @@ The domain language of WebReaper — a declarative, parallel web crawler. This f
 One end-to-end run of the scraper over a site, seeded from the configured start URLs.
 _Avoid_: scrape, scan, session.
 
+**Crawl seed**:
+The start URL(s) and page mode you hold *before* a builder exists — produced by the static `ScraperEngineBuilder.Crawl(...)` / `CrawlWithBrowser(...)`, awaiting a Schema. Its only operation is `Extract(schema)`, which yields the configurable builder; the build terminals live only there, so "build with no start URLs or no schema" is unrepresentable rather than a runtime throw (see `docs/adr/0025-staged-builder-entry.md`).
+_Avoid_: builder, config, prerequisites, start set.
+
 **Job**:
 A single URL to visit, plus the remaining selector chain and its parent backlinks; the unit the scheduler queues and a worker consumes.
 _Avoid_: task, work item, request.
@@ -53,6 +57,10 @@ _Avoid_: engine, runner, orchestrator, coordinator, master.
 **Spider**:
 The per-Job I/O shell: load one Job's page, run the Crawl step, return a Job report — nothing else. It does NOT own the Visited-link tracker, the crawl-limit stop, Sink fan-out, or the callbacks; those are the Crawl driver's. The ADR 0001 posture one layer up: the shell *reports* what happened, the driver *decides* what to do.
 _Avoid_: crawler, worker, handler, the spider that fans out.
+
+**Distributed spider builder**:
+The ADR-0009 reduced shell — `DistributedSpiderBuilder`, the seedless public seam a distributed worker uses to build its Spider. Config-agnostic by construction: no Crawl seed, no `BuildAsync`, no crawl-shape — the worker's `ScraperConfig` is authored and persisted by the start endpoint and read from shared storage at crawl time. A separate type from the engine builder on purpose ("two seams, not one bug"); shared adapters are wired by hand via public satellite concretes / DI (see `docs/adr/0025-staged-builder-entry.md`).
+_Avoid_: spider builder (unqualified), worker, the engine builder, ScraperEngineBuilder.
 
 **Job report**:
 The closed value `Spider.CrawlAsync` returns: the optional ParsedData to emit (present iff a Target page), the discovered child Jobs (unfiltered — dedup is the driver's), and the accounting facts the Outstanding-work latch needs (this Job's identity, its child count). It *wraps* the Crawl step's Crawl outcome with emission and accounting facts; it does not replace or extend the closed `CrawlOutcome` sum (ADR 0001 stands). Termination is a field here, never a thrown exception.

--- a/Examples/BrownsfashionScraper/Worker.cs
+++ b/Examples/BrownsfashionScraper/Worker.cs
@@ -18,7 +18,18 @@ namespace BrownsfashionScraper
 
         public override async Task StartAsync(CancellationToken cancellationToken)
         {
-             _scraper = await new ScraperEngineBuilder()
+             _scraper = await ScraperEngineBuilder
+                .Crawl("https://www.brownsfashion.com/ua/shopping/man-clothing")
+                .Extract(new()
+                {
+                    new("brand", "a[data-test=\"product-brand\"]"),
+                    new("product", "span[data-test=\"product-name\"]"),
+                    new("price", "span[data-test=\"product-price\"]"),
+                    new("description", "span[data-test=\"product-accordionOption\"]"),
+                    new("category", "#modal-controller-container > main > nav > ol > li:nth-child(1) > a"),
+                    new("subcategory", "#modal-controller-container > main > nav > ol > li:nth-child(2) > a"),
+                    new("subcategory2", "#modal-controller-container > main > nav > ol > li:nth-child(3) > a]"),
+                })
                 .WithLogger(_logger)
                 .WithPuppeteerPageLoader()
                 .SetCookies(cookies =>
@@ -58,19 +69,7 @@ namespace BrownsfashionScraper
                         new Cookie("_clsk", "uhygul|1666602933570|1|1|e.clarity.ms/collect", "/", ".brownsfashion.com")
                     });
                 })
-                .Get("https://www.brownsfashion.com/ua/shopping/man-clothing")
                 .PaginateWithBrowser("._1GX2o>a", ".AlEkI")
-                .Parse(new()
-                {
-                    new("brand", "a[data-test=\"product-brand\"]"),
-                    new("product", "span[data-test=\"product-name\"]"),
-                    new("price", "span[data-test=\"product-price\"]"),
-                    new("description", "span[data-test=\"product-accordionOption\"]"),
-                    new("category", "#modal-controller-container > main > nav > ol > li:nth-child(1) > a"),
-                    new("subcategory", "#modal-controller-container > main > nav > ol > li:nth-child(2) > a"),
-                    new("subcategory2", "#modal-controller-container > main > nav > ol > li:nth-child(3) > a]"),
-
-                })
                 .WriteToCsvFile("result.csv", true)
                 .WithParallelismDegree(10)
                 .BuildAsync();

--- a/Examples/WebReaper.AzureFuncs/StartScraping.cs
+++ b/Examples/WebReaper.AzureFuncs/StartScraping.cs
@@ -52,12 +52,9 @@ namespace WebReaper.AzureFuncs
                 "https://rutracker.org/forum/viewforum.php?f=2321"
             };
             
-            var config = new ConfigBuilder()
-                .Get("https://rutracker.org/forum/index.php?c=33")
-                .Follow("#cf-33 .forumlink>a")
-                .Follow(".forumlink>a")
-                .Paginate("a.torTopic", ".pg")
-                .WithScheme(new()
+            var config = ScraperEngineBuilder
+                .Crawl("https://rutracker.org/forum/index.php?c=33")
+                .Extract(new()
                 {
                         new("name", "#topic-title"),
                         new("category", "td.nav.t-breadcrumb-top.w100.pad_2>a:nth-child(3)"),
@@ -66,6 +63,9 @@ namespace WebReaper.AzureFuncs
                         new("torrentLink", ".magnet-link", "href"),
                         new("coverImageUrl", ".postImg", "src")
                 })
+                .Follow("#cf-33 .forumlink>a")
+                .Follow(".forumlink>a")
+                .Paginate("a.torTopic", ".pg")
                 .IgnoreUrls(blackList)
                 .Build();
 

--- a/Examples/WebReaper.AzureFuncs/WebReaperSpider.cs
+++ b/Examples/WebReaper.AzureFuncs/WebReaperSpider.cs
@@ -47,11 +47,12 @@ namespace WebReaper.AzureFuncs
             });
 
             // ADR-0022 slice 4: this Service Bus function IS the distributed
-            // Crawl driver. ADR-0009: SpiderBuilder is internal; the bare
-            // reduced shell comes from ScraperEngineBuilder.BuildSpider().
-            var spider = new ScraperEngineBuilder()
+            // Crawl driver. ADR-0009/0025: SpiderBuilder is internal; the bare
+            // reduced shell is built by DistributedSpiderBuilder. The link
+            // tracker is the driver's idempotency authority (ADR-0022) — used
+            // directly below, not wired into the spider shell.
+            var spider = new DistributedSpiderBuilder()
                 .WithLogger(log)
-                .WithLinkTracker(LinkTracker)
                 .BuildSpider();
 
             var children = ImmutableArray<Job>.Empty;

--- a/Examples/WebReaper.ConsoleApplication/Program.cs
+++ b/Examples/WebReaper.ConsoleApplication/Program.cs
@@ -1,15 +1,15 @@
 ﻿using WebReaper.Builders;
 using WebReaper.Puppeteer;
 
-var engine = await new ScraperEngineBuilder()
-    .WithPuppeteerPageLoader()
-    .GetWithBrowser("https://www.alexpavlov.dev/blog")
-    .FollowWithBrowser(".text-gray-900.transition")
-    .Parse(new()
+var engine = await ScraperEngineBuilder
+    .CrawlWithBrowser("https://www.alexpavlov.dev/blog")
+    .Extract(new()
     {
         new("title", ".text-3xl.font-bold"),
         new("text", ".max-w-max.prose.prose-dark")
     })
+    .WithPuppeteerPageLoader()
+    .FollowWithBrowser(".text-gray-900.transition")
     .WriteToJsonFile("output.json")
     .PageCrawlLimit(10)
     .WithParallelismDegree(30)

--- a/Examples/WebReaper.DistributedScraperWorkerService/ScrapingWorker.cs
+++ b/Examples/WebReaper.DistributedScraperWorkerService/ScrapingWorker.cs
@@ -30,14 +30,9 @@ public class ScrapingWorker : BackgroundService
         var azureSBConnectionString = "";
         var queue = "jobqueue";
 
-        var engine = await new ScraperEngineBuilder()
-            .WithLogger(_logger)
-            .Get("https://rutracker.org/forum/index.php?c=33")
-            .IgnoreUrls(blackList)
-            .Follow("#cf-33 .forumlink>a")
-            .Follow(".forumlink>a")
-            .Paginate("a.torTopic", ".pg")
-            .Parse(new()
+        var engine = await ScraperEngineBuilder
+            .Crawl("https://rutracker.org/forum/index.php?c=33")
+            .Extract(new()
             {
                 new("name", "#topic-title"),
                 new("category", "td.nav.t-breadcrumb-top.w100.pad_2>a:nth-child(3)"),
@@ -46,6 +41,11 @@ public class ScrapingWorker : BackgroundService
                 new("torrentLink", ".magnet-link", "href"),
                 new("coverImageUrl", ".postImg", "src")
             })
+            .WithLogger(_logger)
+            .IgnoreUrls(blackList)
+            .Follow("#cf-33 .forumlink>a")
+            .Follow(".forumlink>a")
+            .Paginate("a.torTopic", ".pg")
             .TrackVisitedLinksInRedis(redisConnectionString, "rutracker-visited-links")
             .WriteToCosmosDb(
                 "",

--- a/Examples/WebReaper.ScraperWorkerService/ScrapingWorker.cs
+++ b/Examples/WebReaper.ScraperWorkerService/ScrapingWorker.cs
@@ -26,13 +26,9 @@ public class ScrapingWorker : BackgroundService
             "https://rutracker.org/forum/viewforum.php?f=2321"
         };
 
-        var engine = await new ScraperEngineBuilder()
-            .WithLogger(_logger)
-            .Get("https://rutracker.org/forum/index.php?c=33")
-            .Follow("#cf-33 .forumlink>a")
-            .Follow(".forumlink>a")
-            .Paginate("a.torTopic", ".pg")
-            .Parse(new()
+        var engine = await ScraperEngineBuilder
+            .Crawl("https://rutracker.org/forum/index.php?c=33")
+            .Extract(new()
             {
                 new("name", "#topic-title"),
                 new("category", "td.nav.t-breadcrumb-top.w100.pad_2>a:nth-child(3)"),
@@ -41,6 +37,10 @@ public class ScrapingWorker : BackgroundService
                 new("torrentLink", ".magnet-link", "href"),
                 new("coverImageUrl", ".postImg", "src")
             })
+            .WithLogger(_logger)
+            .Follow("#cf-33 .forumlink>a")
+            .Follow(".forumlink>a")
+            .Paginate("a.torTopic", ".pg")
             .IgnoreUrls(blackList)
             .PostProcess(ParseTorrentStats)
             .WithRedisScheduler("localhost:6379", "jobs", true)

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ dotnet add package WebReaper
 ```C#
 using WebReaper.Builders;
 
-var engine = await new ScraperEngineBuilder()
-    .Get("https://www.alexpavlov.dev/blog")
-    .Follow("a.text-gray-900.transition")
-    .Parse(new()
+var engine = await ScraperEngineBuilder
+    .Crawl("https://www.alexpavlov.dev/blog")
+    .Extract(new()
     {
         new("title", ".text-3xl.font-bold"),
         new("text", ".max-w-max.prose.prose-dark")
     })
+    .Follow("a.text-gray-900.transition")
     .WriteToJsonFile("output.json")
     .PageCrawlLimit(10)
     .WithParallelismDegree(30)
@@ -89,22 +89,22 @@ dotnet add package WebReaper.Sqlite           # SQLite local durable scheduler +
 
 ## Packages
 
-All seven packages are versioned in lockstep (currently `9.0.0`) — core and the six satellites move
-together in release waves (ADR-0022 → `8.0.0`, ADR-0023 → `9.0.0`); `WebReaper.Sqlite`, added at
-`7.1.0`, joined the lockstep from `8.0.0`. All packages are GPL-3.0-or-later, and every satellite
+All seven packages are versioned in lockstep (currently `10.0.0`) — core and the six satellites move
+together in release waves (ADR-0022 → `8.0.0`, ADR-0023 → `9.0.0`, ADR-0025 → `10.0.0`);
+`WebReaper.Sqlite`, added at `7.1.0`, joined the lockstep from `8.0.0`. All packages are GPL-3.0-or-later, and every satellite
 wires itself in through the builder's public registration seam.
 
 | Package | Add it for | Key builder calls |
 |---|---|---|
-| **WebReaper** | Core. HTTP crawl/parse, in-memory + file scheduler / visited-link tracker / cookie & config storage, Console / CSV / JSON-Lines sinks. Dependency-light, Native-AOT-ready, Newtonsoft-free. | `Get` `Follow` `Paginate` `Parse` `WriteToJsonFile` `WriteToCsvFile` `WriteToConsole` |
-| **WebReaper.Puppeteer** | Headless-browser loading of SPA / JavaScript pages | `.WithPuppeteerPageLoader()` + `GetWithBrowser` / `FollowWithBrowser` / `PaginateWithBrowser` |
+| **WebReaper** | Core. HTTP crawl/parse, in-memory + file scheduler / visited-link tracker / cookie & config storage, Console / CSV / JSON-Lines sinks. Dependency-light, Native-AOT-ready, Newtonsoft-free. | `Crawl` `Extract` `Follow` `Paginate` `WriteToJsonFile` `WriteToCsvFile` `WriteToConsole` |
+| **WebReaper.Puppeteer** | Headless-browser loading of SPA / JavaScript pages | `.WithPuppeteerPageLoader()` + `CrawlWithBrowser` / `FollowWithBrowser` / `PaginateWithBrowser` |
 | **WebReaper.Mongo** | MongoDB result sink and MongoDB-backed config / cookie storage | `.WriteToMongoDb(...)` `.WithMongoDbConfigStorage(...)` `.WithMongoDbCookieStorage(...)` |
 | **WebReaper.Redis** | Redis scheduler, visited-link tracker, result sink, config / cookie storage | `.WithRedisScheduler(...)` `.TrackVisitedLinksInRedis(...)` `.WriteToRedis(...)` `.WithRedisConfigStorage(...)` `.WithRedisCookieStorage(...)` |
 | **WebReaper.AzureServiceBus** | Distributed scheduler over an Azure Service Bus queue | `.WithAzureServiceBusScheduler(...)` |
 | **WebReaper.Cosmos** | Azure Cosmos DB result sink | `.WriteToCosmosDb(...)` |
 | **WebReaper.Sqlite** | Local **durable** scheduler & visited-link tracker on an embedded SQLite store — resume is a query, no position file. Opt-in robust-local tier (no server, unlike Redis). | `.WithSqliteScheduler(...)` `.TrackVisitedLinksInSqlite(...)` |
 
-> The core default page loader is **HTTP-only**. Crawling a dynamic page (`GetWithBrowser` /
+> The core default page loader is **HTTP-only**. Crawling a dynamic page (`CrawlWithBrowser` /
 > `FollowWithBrowser` / `PaginateWithBrowser`) without `WebReaper.Puppeteer` registered throws an
 > `InvalidOperationException` telling you to add the package and call `.WithPuppeteerPageLoader()`.
 
@@ -138,7 +138,7 @@ design; reference one only when you use it.
 
 ### Parsing dynamic pages (SPA)
 
-Parsing Single Page Applications is simple: use `GetWithBrowser` and/or `FollowWithBrowser`, add the
+Parsing Single Page Applications is simple: use `CrawlWithBrowser` and/or `FollowWithBrowser`, add the
 `WebReaper.Puppeteer` package, and register it with `.WithPuppeteerPageLoader()`. Puppeteer then loads
 those pages in a headless browser.
 
@@ -150,15 +150,15 @@ dotnet add package WebReaper.Puppeteer
 using WebReaper.Builders;
 using WebReaper.Puppeteer;
 
-var engine = await new ScraperEngineBuilder()
-    .GetWithBrowser("https://www.alexpavlov.dev/blog")
-    .FollowWithBrowser("a.text-gray-900.transition")
-    .Parse(new()
+var engine = await ScraperEngineBuilder
+    .CrawlWithBrowser("https://www.alexpavlov.dev/blog")
+    .Extract(new()
     {
         new("title", ".text-3xl.font-bold"),
         new("text", ".max-w-max.prose.prose-dark")
     })
     .WithPuppeteerPageLoader()
+    .FollowWithBrowser("a.text-gray-900.transition")
     .WriteToJsonFile("output.json")
     .PageCrawlLimit(10)
     .WithParallelismDegree(30)
@@ -181,16 +181,16 @@ You can run JavaScript and drive the page as it loads in the headless browser. P
 using WebReaper.Builders;
 using WebReaper.Puppeteer;
 
-var engine = await new ScraperEngineBuilder()
-    .GetWithBrowser("https://www.reddit.com/r/dotnet/", actions => actions
+var engine = await ScraperEngineBuilder
+    .CrawlWithBrowser("https://www.reddit.com/r/dotnet/", actions => actions
         .ScrollToEnd()
         .Build())
-    .Follow("a.SQnoC3ObvgnGjWt90zD9Z._2INHSNB8V5eaWp4P0rY_mE")
-    .Parse(new()
+    .Extract(new()
     {
         new("title", "._eYtD2XCVieq6emjKBH3m"),
         new("text", "._3xX726aBn29LDbsDtzr_6E._1Ap4F5maDtT1E1YuCiaO0r.D3IL3FD0RFy_mkKLPwL4")
     })
+    .Follow("a.SQnoC3ObvgnGjWt90zD9Z._2INHSNB8V5eaWp4P0rY_mE")
     .WithPuppeteerPageLoader()
     .WriteToJsonFile("output.json")
     .LogToConsole()
@@ -212,13 +212,9 @@ To persist the job queue and visited links locally — so you can resume where y
 ```C#
 using WebReaper.Builders;
 
-var engine = await new ScraperEngineBuilder()
-    .WithLogger(logger)
-    .Get("https://rutracker.org/forum/index.php?c=33")
-    .Follow("#cf-33 .forumlink>a")
-    .Follow(".forumlink>a")
-    .Paginate("a.torTopic", ".pg")
-    .Parse(new()
+var engine = await ScraperEngineBuilder
+    .Crawl("https://rutracker.org/forum/index.php?c=33")
+    .Extract(new()
     {
         new("name", "#topic-title"),
         new("category", "td.nav.t-breadcrumb-top.w100.pad_2>a:nth-child(3)"),
@@ -227,6 +223,10 @@ var engine = await new ScraperEngineBuilder()
         new("torrentLink", ".magnet-link", "href"),
         new("coverImageUrl", ".postImg", "src")
     })
+    .WithLogger(logger)
+    .Follow("#cf-33 .forumlink>a")
+    .Follow(".forumlink>a")
+    .Paginate("a.torTopic", ".pg")
     .WriteToJsonFile("result.json")
     .IgnoreUrls(blackList)
     .WithTextFileScheduler("jobs.txt", "currentJob.txt")
@@ -245,11 +245,11 @@ unchanged and stay the default; this is opt-in:
 using WebReaper.Builders;
 using WebReaper.Sqlite;   // dotnet add package WebReaper.Sqlite
 
-var engine = await new ScraperEngineBuilder()
-    .Get("https://rutracker.org/forum/index.php?c=33")
+var engine = await ScraperEngineBuilder
+    .Crawl("https://rutracker.org/forum/index.php?c=33")
+    .Extract(new() { new("name", "#topic-title") })
     .Follow(".forumlink>a")
     .Paginate("a.torTopic", ".pg")
-    .Parse(new() { new("name", "#topic-title") })
     .WriteToJsonFile("result.json")
     .WithSqliteScheduler("crawl/state.db")        // resume is a query, not a position file
     .TrackVisitedLinksInSqlite("crawl/state.db")  // the table is the set
@@ -267,9 +267,10 @@ required. You perform the login yourself; WebReaper only uses the cookies you pr
 using System.Net;
 using WebReaper.Builders;
 
-var engine = await new ScraperEngineBuilder()
+var engine = await ScraperEngineBuilder
+    .Crawl("https://rutracker.org/forum/index.php?c=33")
+    .Extract(new() { new("name", "#topic-title") })
     .WithLogger(logger)
-    .Get("https://rutracker.org/forum/index.php?c=33")
     .SetCookies(cookies =>
     {
         cookies.Add(new Cookie("AuthToken", "123"));
@@ -280,7 +281,7 @@ var engine = await new ScraperEngineBuilder()
 
 ### How to disable headless mode
 
-When scraping with a browser (`GetWithBrowser` / `FollowWithBrowser`, via `WebReaper.Puppeteer`) the
+When scraping with a browser (`CrawlWithBrowser` / `FollowWithBrowser`, via `WebReaper.Puppeteer`) the
 default is headless — you don't see the browser. Seeing it can help with debugging; disable headless mode
 with `.HeadlessMode(false)`:
 
@@ -288,10 +289,11 @@ with `.HeadlessMode(false)`:
 using WebReaper.Builders;
 using WebReaper.Puppeteer;
 
-var engine = await new ScraperEngineBuilder()
-    .GetWithBrowser("https://www.reddit.com/r/dotnet/", actions => actions
+var engine = await ScraperEngineBuilder
+    .CrawlWithBrowser("https://www.reddit.com/r/dotnet/", actions => actions
         .ScrollToEnd()
         .Build())
+    .Extract(new() { new("title", "._eYtD2XCVieq6emjKBH3m") })
     .HeadlessMode(false)
     .WithPuppeteerPageLoader()
     // ...
@@ -327,15 +329,17 @@ shape with two functions:
 * **StartScraping** builds the scraper configuration, seeds the distributed Outstanding-work latch,
   and enqueues the first job (the start URL) onto the queue (e.g. Azure Service Bus).
 * **WebReaperSpider** is the distributed **Crawl driver**, triggered by each queued job. It gets a
-  bare `ISpider` from `new ScraperEngineBuilder()...BuildSpider()` (load → Crawl step → `JobReport`),
-  then interprets the report: an atomic visited-link test-and-set gates duplicates/redeliveries, a
-  parsed page is fanned out to the sink, discovered child jobs are enqueued back onto the queue, and
-  a distributed Outstanding-work latch detects when all work has drained. It never throws to signal
-  the crawl limit, so the queue is never poisoned (ADR-0022).
+  bare `ISpider` from `new DistributedSpiderBuilder()...BuildSpider()` (load → Crawl step →
+  `JobReport`), then interprets the report: an atomic visited-link test-and-set gates
+  duplicates/redeliveries, a parsed page is fanned out to the sink, discovered child jobs are
+  enqueued back onto the queue, and a distributed Outstanding-work latch detects when all work has
+  drained. It never throws to signal the crawl limit, so the queue is never poisoned (ADR-0022).
 
-`BuildSpider()` (the ADR-0009 distributed-worker seam) returns an `ISpider` without building or
-persisting a `ScraperConfig`, so — unlike `BuildAsync()` — it does not require `Get`/`Parse`; the worker's
-config is persisted separately and read from storage at crawl time. See also
+`DistributedSpiderBuilder.BuildSpider()` (the ADR-0009 distributed-worker seam) returns an `ISpider`
+without building or persisting a `ScraperConfig`; it has no Crawl seed and no `BuildAsync` — the
+worker's config is persisted separately by the start endpoint
+(`ScraperEngineBuilder.Crawl(...).Extract(...).Build()`) and read from storage at crawl time. This is
+the "two seams, not one bug" split (ADR-0025). See also
 `Examples/WebReaper.DistributedScraperWorkerService`.
 
 ### Storage and scheduler backends
@@ -393,16 +397,16 @@ Register it with `AddSink`:
 ```C#
 using WebReaper.Builders;
 
-var engine = await new ScraperEngineBuilder()
-    .AddSink(new ConsoleSink())
-    .Get("https://rutracker.org/forum/index.php?c=33")
-    .Follow("#cf-33 .forumlink>a")
-    .Follow(".forumlink>a")
-    .Paginate("a.torTopic", ".pg")
-    .Parse(new()
+var engine = await ScraperEngineBuilder
+    .Crawl("https://rutracker.org/forum/index.php?c=33")
+    .Extract(new()
     {
         new("name", "#topic-title"),
     })
+    .AddSink(new ConsoleSink())
+    .Follow("#cf-33 .forumlink>a")
+    .Follow(".forumlink>a")
+    .Paginate("a.torTopic", ".pg")
     .BuildAsync();
 ```
 
@@ -422,7 +426,7 @@ For result callbacks without a custom sink, use `.Subscribe(Action<ParsedData>)`
 | `ILinkParser` | Takes HTML and returns the page's links. |
 | `IScraperSink` | A destination for scraping results. Receives `ParsedData` (`Url` + `JsonObject`). |
 | `ICrawlStep` | The crawl-step decision: maps a `Job` + loaded page + `Schema` to a `CrawlOutcome` (parse the page, follow links, or paginate). Swap it to customize crawl-vs-parse behavior. |
-| `ISpider` | The per-Job I/O shell around `ICrawlStep`: loads one page, runs the Crawl step, and returns a `JobReport` — nothing else. The Crawl driver (in-process `ScraperEngine` or the distributed worker) owns the visited-link tracker, the crawl-limit stop, sink fan-out and the callbacks. Obtained from `ScraperEngineBuilder.BuildSpider()`. |
+| `ISpider` | The per-Job I/O shell around `ICrawlStep`: loads one page, runs the Crawl step, and returns a `JobReport` — nothing else. The Crawl driver (in-process `ScraperEngine` or the distributed worker) owns the visited-link tracker, the crawl-limit stop, sink fan-out and the callbacks. Obtained from `DistributedSpiderBuilder.BuildSpider()` (the ADR-0009 reduced shell). |
 | `IOutstandingWorkLatch` | The Crawl driver's termination detector (ADR-0022): a unit-credit counter that trips exactly once when all work is drained. In-memory `Interlocked` adapter (in-process) and a distributed-atomic Redis adapter (`WebReaper.Redis`). |
 
 ### Main entities

--- a/WebReaper.AzureServiceBus/README.md
+++ b/WebReaper.AzureServiceBus/README.md
@@ -24,9 +24,9 @@ Adds `WithAzureServiceBusScheduler(...)` to `ScraperEngineBuilder`:
 using WebReaper.Builders;
 using WebReaper.AzureServiceBus;
 
-var engine = await new ScraperEngineBuilder()
-    .Get("https://example.com/catalog")
-    .Parse(new() { new("title", "h1"), new("price", ".price") })
+var engine = await ScraperEngineBuilder
+    .Crawl("https://example.com/catalog")
+    .Extract(new() { new("title", "h1"), new("price", ".price") })
     .WithAzureServiceBusScheduler(
         connectionString: "<service-bus-connection-string>",
         queueName: "scrape-jobs")

--- a/WebReaper.Cosmos/README.md
+++ b/WebReaper.Cosmos/README.md
@@ -23,9 +23,9 @@ Adds `WriteToCosmosDb(...)` to `ScraperEngineBuilder`:
 using WebReaper.Builders;
 using WebReaper.Cosmos;
 
-var engine = await new ScraperEngineBuilder()
-    .Get("https://example.com/catalog")
-    .Parse(new() { new("title", "h1"), new("price", ".price") })
+var engine = await ScraperEngineBuilder
+    .Crawl("https://example.com/catalog")
+    .Extract(new() { new("title", "h1"), new("price", ".price") })
     .WriteToCosmosDb(
         endpointUrl: "https://my-account.documents.azure.com:443/",
         authorizationKey: "<key>",

--- a/WebReaper.Mongo/README.md
+++ b/WebReaper.Mongo/README.md
@@ -25,9 +25,9 @@ Adds `WriteToMongoDb`, `WithMongoDbConfigStorage` and
 using WebReaper.Builders;
 using WebReaper.Mongo;
 
-var engine = await new ScraperEngineBuilder()
-    .Get("https://example.com/catalog")
-    .Parse(new() { new("title", "h1"), new("price", ".price") })
+var engine = await ScraperEngineBuilder
+    .Crawl("https://example.com/catalog")
+    .Extract(new() { new("title", "h1"), new("price", ".price") })
     .WriteToMongoDb(
         connectionString: "mongodb://localhost:27017",
         databaseName: "scrape",

--- a/WebReaper.Puppeteer/README.md
+++ b/WebReaper.Puppeteer/README.md
@@ -7,7 +7,7 @@ JavaScript-rendered pages.
 Satellite package (ADR-0009): the headless-browser transport is kept out of
 the WebReaper core so the core stays dependency-light and Native-AOT-clean.
 The core is HTTP-only by default; **install this package and call
-`.WithPuppeteerPageLoader()` to scrape Dynamic pages** (`GetWithBrowser` /
+`.WithPuppeteerPageLoader()` to scrape Dynamic pages** (`CrawlWithBrowser` /
 `FollowWithBrowser` / `PaginateWithBrowser`) — without it a Dynamic load
 throws an actionable message. The first Dynamic run downloads Chromium.
 
@@ -27,11 +27,11 @@ Adds `WithPuppeteerPageLoader()` to `ScraperEngineBuilder`:
 using WebReaper.Builders;
 using WebReaper.Puppeteer;
 
-var engine = await new ScraperEngineBuilder()
+var engine = await ScraperEngineBuilder
+    .CrawlWithBrowser("https://example.com/blog")
+    .Extract(new() { new("title", "h1"), new("text", "article") })
     .WithPuppeteerPageLoader()
-    .GetWithBrowser("https://example.com/blog")
     .FollowWithBrowser(".post-link")
-    .Parse(new() { new("title", "h1"), new("text", "article") })
     .BuildAsync();
 
 await engine.RunAsync();

--- a/WebReaper.Redis/README.md
+++ b/WebReaper.Redis/README.md
@@ -28,9 +28,9 @@ Adds `WriteToRedis`, `WithRedisScheduler`, `TrackVisitedLinksInRedis`,
 using WebReaper.Builders;
 using WebReaper.Redis;
 
-var engine = await new ScraperEngineBuilder()
-    .Get("https://example.com/catalog")
-    .Parse(new() { new("title", "h1"), new("price", ".price") })
+var engine = await ScraperEngineBuilder
+    .Crawl("https://example.com/catalog")
+    .Extract(new() { new("title", "h1"), new("price", ".price") })
     .WithRedisScheduler("localhost:6379", queueName: "jobs")
     .TrackVisitedLinksInRedis("localhost:6379", redisKey: "visited")
     .WriteToRedis("localhost:6379", redisKey: "results")

--- a/WebReaper.Sqlite/README.md
+++ b/WebReaper.Sqlite/README.md
@@ -39,10 +39,10 @@ Adds `WithSqliteScheduler` to `ScraperEngineBuilder`, over the core's public
 using WebReaper.Builders;
 using WebReaper.Sqlite;
 
-var engine = await new ScraperEngineBuilder()
-    .Get("https://example.com")
+var engine = await ScraperEngineBuilder
+    .Crawl("https://example.com")
+    .Extract(new Schema { /* … */ })
     .WithSqliteScheduler("crawl/state.db")
-    .Parse(new Schema { /* … */ })
     .WriteToJsonFile("output.jsonl")
     .BuildAsync();
 

--- a/WebReaper.Tests/WebReaper.IntegrationTests/ScraperTests.cs
+++ b/WebReaper.Tests/WebReaper.IntegrationTests/ScraperTests.cs
@@ -29,14 +29,14 @@ namespace WebReaper.IntegrationTests
                 "https://www.alexpavlov.dev/blog/tags/web"
             };
             
-            var engine = await new ScraperEngineBuilder()
-                .Get(startUrls)
-                .Follow(".text-gray-900.transition")
-                .Parse(new()
+            var engine = await ScraperEngineBuilder
+                .Crawl(startUrls)
+                .Extract(new()
                 {
                     new("title", ".text-3xl.font-bold"),
                     new("text", ".max-w-max.prose.prose-dark")
                 })
+                .Follow(".text-gray-900.transition")
                 .WithLogger(new TestOutputLogger(this.output))
                 .Subscribe(x => result.Add(x))
                 .BuildAsync();
@@ -54,14 +54,14 @@ namespace WebReaper.IntegrationTests
         {
             var result = new List<ParsedData>();
 
-            var engine = await new ScraperEngineBuilder()
-                .Get("https://www.alexpavlov.dev/blog")
-                .Follow(".text-gray-900.transition")
-                .Parse(new()
+            var engine = await ScraperEngineBuilder
+                .Crawl("https://www.alexpavlov.dev/blog")
+                .Extract(new()
                 {
                     new("title", ".text-3xl.font-bold"),
                     new("text", ".max-w-max.prose.prose-dark")
                 })
+                .Follow(".text-gray-900.transition")
                 .WithLogger(new TestOutputLogger(output))
                 .Subscribe(result.Add)
                 .WithParallelismDegree(1)
@@ -80,14 +80,14 @@ namespace WebReaper.IntegrationTests
         {
             var result = new List<ParsedData>();
 
-            var scraper = await new ScraperEngineBuilder()
-                .Get("https://www.reddit.com/r/dotnet/")
-                .Follow("a.SQnoC3ObvgnGjWt90zD9Z._2INHSNB8V5eaWp4P0rY_mE")
-                .Parse(new()
+            var scraper = await ScraperEngineBuilder
+                .Crawl("https://www.reddit.com/r/dotnet/")
+                .Extract(new()
                 {
                     new("title", "._eYtD2XCVieq6emjKBH3m"),
                     new("text", "._3xX726aBn29LDbsDtzr_6E._1Ap4F5maDtT1E1YuCiaO0r.D3IL3FD0RFy_mkKLPwL4")
                 })
+                .Follow("a.SQnoC3ObvgnGjWt90zD9Z._2INHSNB8V5eaWp4P0rY_mE")
                 .WithLogger(new TestOutputLogger(this.output))
                 .WithProxies(new WebShareProxyProvider())
                 .Subscribe(x => result.Add(x))
@@ -113,15 +113,15 @@ namespace WebReaper.IntegrationTests
 
             var result = new List<ParsedData>();
 
-            var engine = await new ScraperEngineBuilder()
-                .WithPuppeteerPageLoader()
-                .GetWithBrowser(new []{ "https://www.alexpavlov.dev/blog" })
-                .FollowWithBrowser(".text-gray-900.transition")
-                .Parse(new()
+            var engine = await ScraperEngineBuilder
+                .CrawlWithBrowser(new []{ "https://www.alexpavlov.dev/blog" })
+                .Extract(new()
                 {
                     new("title", ".text-3xl.font-bold"),
                     new("text", ".max-w-max.prose.prose-dark")
                 })
+                .WithPuppeteerPageLoader()
+                .FollowWithBrowser(".text-gray-900.transition")
                 .WithLogger(new TestOutputLogger(this.output))
                 .Subscribe(x => result.Add(x))
                 .WithParallelismDegree(10)

--- a/WebReaper.Tests/WebReaper.UnitTests/BuildSpiderTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/BuildSpiderTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using WebReaper.Builders;
 using WebReaper.Core.Spider.Abstract;
 
@@ -5,18 +6,18 @@ namespace WebReaper.UnitTests;
 
 public class BuildSpiderTests
 {
-    // ADR-0009 capstone: the distributed-worker pattern (crawl one queued
-    // Job, re-enqueue its children — Examples/WebReaper.AzureFuncs) needs a
-    // bare ISpider. SpiderBuilder is now internal; the public seam is
-    // ScraperEngineBuilder.BuildSpider(). Unlike BuildAsync() it does NOT
-    // require Get/Parse (the worker's ScraperConfig is persisted separately
-    // and read from storage at crawl time), so configuring then BuildSpider()
-    // succeeds with neither a start URL nor a schema.
+    // ADR-0025: the distributed-worker reduced shell (ADR-0009) is its own
+    // seam, DistributedSpiderBuilder — "two seams, not one bug". Unlike the
+    // engine path it has no Crawl seed and no BuildAsync: the worker's
+    // ScraperConfig is authored/persisted by the start endpoint and read from
+    // shared storage at crawl time, so building a bare ISpider needs neither a
+    // start URL nor a schema. (The structural guarantee that BuildAsync is
+    // unreachable without a seed lives on ScraperEngineBuilder's internal ctor.)
     [Fact]
-    public void BuildSpider_returns_a_configured_ISpider_without_requiring_Get_or_Parse()
+    public void DistributedSpiderBuilder_builds_an_ISpider_without_a_Crawl_seed()
     {
-        var spider = new ScraperEngineBuilder()
-            .WriteToConsole()
+        var spider = new DistributedSpiderBuilder()
+            .WithLogger(NullLogger.Instance)
             .BuildSpider();
 
         Assert.NotNull(spider);

--- a/WebReaper.Tests/WebReaper.UnitTests/BuilderArgumentValidationTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/BuilderArgumentValidationTests.cs
@@ -12,23 +12,17 @@ namespace WebReaper.UnitTests;
 // throw.
 public class BuilderArgumentValidationTests
 {
+    // ADR-0025: "build with no start URLs or no schema" is now unrepresentable
+    // — the only path to a builder that can Build()/BuildAsync() is the static
+    // Crawl(...).Extract(...) seed (ScraperEngineBuilder's ctor is internal).
+    // The old InvalidOperationException guards in ConfigBuilder.Build are gone,
+    // deleted by construction (the whole solution compiling on the seed entry
+    // is the test). What remains is fail-fast on an *empty* seed.
     [Fact]
-    public void Build_without_start_urls_reports_them_in_the_plural()
+    public void Crawl_with_no_start_url_is_rejected()
     {
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => new ConfigBuilder().Build());
-
-        // The method takes params string[]; the message must not say "Url is".
-        Assert.Contains("Start URLs", ex.Message);
-    }
-
-    [Fact]
-    public void Build_with_an_empty_start_url_set_is_rejected()
-    {
-        // Get() with zero URLs previously built a config that crawled nothing.
-        // (The start-URL check runs before the schema check in Build().)
-        Assert.Throws<InvalidOperationException>(
-            () => new ConfigBuilder().Get().Build());
+        Assert.Throws<ArgumentException>(() => ScraperEngineBuilder.Crawl());
+        Assert.Throws<ArgumentException>(() => ScraperEngineBuilder.CrawlWithBrowser());
     }
 
     [Theory]

--- a/WebReaper/Builders/ConfigBuilder.cs
+++ b/WebReaper/Builders/ConfigBuilder.cs
@@ -7,19 +7,17 @@ using WebReaper.Domain.Selectors;
 namespace WebReaper.Builders;
 
 /// <summary>
-/// Accumulates the crawl definition and produces the immutable
-/// <see cref="ScraperConfig"/> (the build path: <see cref="ScraperEngineBuilder"/>
-/// is a façade over this plus the runtime <c>SpiderBuilder</c>). The
-/// <see cref="Follow"/> / <see cref="Paginate"/> calls build the
-/// <see cref="LinkPathSelector"/> chain that is the crawl's state machine
-/// (ADR-0001): chain length decides parse-vs-follow-vs-paginate. Use this
-/// directly only when you need a <see cref="ScraperConfig"/> without the
-/// engine (e.g. persisting it for the distributed-worker pattern, ADR-0009);
-/// most consumers use the <see cref="ScraperEngineBuilder"/> façade. Fluent —
-/// every method returns the same instance; <see cref="Build"/> validates and
-/// freezes.
+/// Internal collaborator of <see cref="ScraperEngineBuilder"/> (ADR-0025):
+/// accumulates the crawl definition and produces the immutable
+/// <see cref="ScraperConfig"/>. The <see cref="Follow"/> / <see cref="Paginate"/>
+/// calls build the <see cref="LinkPathSelector"/> chain that is the crawl's
+/// state machine (ADR-0001): chain length decides
+/// parse-vs-follow-vs-paginate. Not public — start URLs and the schema are
+/// supplied through the staged <c>Crawl(...).Extract(...)</c> entry, so
+/// <see cref="Build"/> no longer guards against an unset crawl (the guard
+/// became structural). Fluent — every method returns the same instance.
 /// </summary>
-public class ConfigBuilder
+internal class ConfigBuilder
 {
     private readonly List<LinkPathSelector> _linkPathSelectors = new();
 
@@ -188,9 +186,8 @@ public class ConfigBuilder
 
     /// <summary>
     /// The extraction <see cref="Schema"/> applied to target pages (the
-    /// shared fold grammar, ADR-0002). Required: <see cref="Build"/> throws if
-    /// it was never set. (Exposed on the façade as
-    /// <see cref="ScraperEngineBuilder.Parse"/>.)
+    /// shared fold grammar, ADR-0002). Supplied through the staged entry,
+    /// <see cref="ICrawlSeed.Extract"/>.
     /// </summary>
     public ConfigBuilder WithScheme(Schema schema)
     {
@@ -199,23 +196,15 @@ public class ConfigBuilder
     }
 
     /// <summary>
-    /// Validate and produce the immutable <see cref="ScraperConfig"/>. Builder
-    /// order matters — configure before calling this.
+    /// Produce the immutable <see cref="ScraperConfig"/>. Start URLs and a
+    /// schema are present by construction (ADR-0025): the only way here is
+    /// <see cref="ScraperEngineBuilder.Crawl(string[])"/> then
+    /// <see cref="ICrawlSeed.Extract"/>, so the old runtime guards are gone.
     /// </summary>
-    /// <exception cref="InvalidOperationException">no start URLs (neither
-    /// <see cref="Get"/> nor <see cref="GetWithBrowser"/>, or an empty set) or
-    /// no <see cref="Schema"/> (<see cref="WithScheme"/>) was set.</exception>
     public ScraperConfig Build()
     {
-        if (_startUrls is null || !_startUrls.Any())
-            throw new InvalidOperationException(
-                $"Start URLs are missing. You must call the {nameof(Get)} or {nameof(GetWithBrowser)} method with at least one URL");
-        if (_schema is null)
-            throw new InvalidOperationException(
-                $"You must call the {nameof(WithScheme)} method to set the parsing scheme");
-
         return new ScraperConfig(
-            _schema,
+            _schema!,
             ImmutableQueue.Create(_linkPathSelectors.ToArray()),
             _startUrls,
             _blockedUrls,

--- a/WebReaper/Builders/DistributedSpiderBuilder.cs
+++ b/WebReaper/Builders/DistributedSpiderBuilder.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+using WebReaper.ConfigStorage.Abstract;
+using WebReaper.ConfigStorage.Concrete;
+using WebReaper.Core.CookieStorage.Abstract;
+using WebReaper.Core.Loaders.Abstract;
+using WebReaper.Core.Parser.Abstract;
+using WebReaper.Core.Spider.Abstract;
+using WebReaper.Proxy;
+using WebReaper.Proxy.Abstract;
+
+namespace WebReaper.Builders;
+
+/// <summary>
+/// The ADR-0009 distributed-worker reduced shell: builds a bare
+/// <see cref="ISpider"/> that reads its <see cref="Domain.ScraperConfig"/>
+/// from shared config storage at crawl time. Use it in the DIY-distributed
+/// pattern — pull one <c>Job</c> off your own queue, crawl it with
+/// <c>spider.CrawlAsync(job)</c>, and re-enqueue the returned child jobs
+/// yourself (see <c>Examples/WebReaper.AzureFuncs</c>).
+/// <para>
+/// It deliberately has no <c>BuildAsync</c> and no crawl-shape (no start
+/// URLs / schema / <c>Follow</c>): a worker's crawl definition is authored
+/// and persisted by the start endpoint
+/// (<see cref="ScraperEngineBuilder.Build"/>), not here. This is the "two
+/// seams, not one bug" split (ADR-0025) — the structural guarantee that
+/// <see cref="ScraperEngineBuilder.BuildAsync"/> is unreachable without a
+/// Crawl seed lives in <see cref="ScraperEngineBuilder"/>'s internal
+/// constructor; this seam is config-agnostic by design.
+/// </para>
+/// <para>
+/// Distributed adapters (a shared Redis/Mongo link tracker, config storage,
+/// latch) are wired by hand here — pass a public concrete or a DI-resolved
+/// instance, as the ADR-0009 pattern intends. The satellite builder sugar
+/// (<c>.WithRedis*()</c>, …) is the engine-path convenience and stays on
+/// <see cref="ScraperEngineBuilder"/>.
+/// </para>
+/// </summary>
+public class DistributedSpiderBuilder
+{
+    private readonly SpiderBuilder _spiderBuilder = new();
+    private IScraperConfigStorage _configStorage = new InMemoryScraperConfigStorage();
+
+    /// <summary>Route library logging to your <see cref="ILogger"/>.</summary>
+    public DistributedSpiderBuilder WithLogger(ILogger logger)
+    {
+        _spiderBuilder.WithLogger(logger);
+        return this;
+    }
+
+    /// <summary>Use a custom content parser (the Schema-fold backend,
+    /// ADR-0002) instead of the default AngleSharp/CSS one.</summary>
+    public DistributedSpiderBuilder WithContentParser(IJsonContentParser contentParser)
+    {
+        _spiderBuilder.WithContentParser(contentParser);
+        return this;
+    }
+
+    /// <summary>Parse responses as JSON instead of HTML (issue #27).</summary>
+    public DistributedSpiderBuilder WithJsonContentParser()
+    {
+        _spiderBuilder.WithJsonContentParser();
+        return this;
+    }
+
+    /// <summary>Parse responses as HTML with XPath 1.0 selectors
+    /// (discussion #17; ADR 0002/0007).</summary>
+    public DistributedSpiderBuilder WithXPathContentParser()
+    {
+        _spiderBuilder.WithXPathContentParser();
+        return this;
+    }
+
+    /// <summary>Register the Dynamic (headless-browser) transport
+    /// (ADR-0004/0009). Core is HTTP-only by default.</summary>
+    public DistributedSpiderBuilder WithLoadTransport(
+        Func<ICookiesStorage, IProxyProvider?, ILogger, IPageLoadTransport> dynamicTransportFactory)
+    {
+        _spiderBuilder.WithLoadTransport(dynamicTransportFactory);
+        return this;
+    }
+
+    /// <summary>Route page loads through a rotating proxy.</summary>
+    public DistributedSpiderBuilder WithProxies(IProxyProvider proxyProvider)
+    {
+        _spiderBuilder.WithProxies(proxyProvider);
+        return this;
+    }
+
+    /// <summary>Rotate over proxies from <paramref name="source"/>, keeping
+    /// only those every validator approves.</summary>
+    public DistributedSpiderBuilder WithValidatedProxies(
+        IProxySource source,
+        IEnumerable<IProxyValidator> validators,
+        ValidatedProxyProviderOptions? options = null)
+    {
+        _spiderBuilder.WithValidatedProxies(source, validators, options);
+        return this;
+    }
+
+    /// <summary><see cref="WithValidatedProxies(IProxySource, IEnumerable{IProxyValidator}, ValidatedProxyProviderOptions)"/>
+    /// with the validators as params.</summary>
+    public DistributedSpiderBuilder WithValidatedProxies(IProxySource source, params IProxyValidator[] validators)
+    {
+        _spiderBuilder.WithValidatedProxies(source, validators);
+        return this;
+    }
+
+    /// <summary>Seed the crawl's cookie container (e.g. an authenticated
+    /// session) before any page loads.</summary>
+    public DistributedSpiderBuilder SetCookies(Action<CookieContainer> authorize)
+    {
+        _spiderBuilder.SetCookies(authorize);
+        return this;
+    }
+
+    /// <summary>Use a custom <see cref="ICookiesStorage"/>.</summary>
+    public DistributedSpiderBuilder WithCookieStorage(ICookiesStorage cookiesStorage)
+    {
+        _spiderBuilder.WithCookieStorage(cookiesStorage);
+        return this;
+    }
+
+    /// <summary>Persist cookies to a file so an authenticated session
+    /// survives restarts.</summary>
+    /// <exception cref="ArgumentException"><paramref name="fileName"/> is
+    /// null/empty/whitespace.</exception>
+    public DistributedSpiderBuilder WithFileCookieStorage(string fileName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        _spiderBuilder.WithFileCookieStorage(fileName);
+        return this;
+    }
+
+    /// <summary>The shared <see cref="IScraperConfigStorage"/> the worker's
+    /// spider reads its <see cref="Domain.ScraperConfig"/> from at crawl time
+    /// (written by the start endpoint, <see cref="ScraperEngineBuilder.Build"/>).</summary>
+    public DistributedSpiderBuilder WithConfigStorage(IScraperConfigStorage configStorage)
+    {
+        _configStorage = configStorage;
+        return this;
+    }
+
+    /// <summary>Read the shared <see cref="Domain.ScraperConfig"/> from a file.</summary>
+    /// <exception cref="ArgumentException"><paramref name="fileName"/> is
+    /// null/empty/whitespace.</exception>
+    public DistributedSpiderBuilder WithFileConfigStorage(string fileName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        _configStorage = new FileScraperConfigStorage(fileName);
+        return this;
+    }
+
+    /// <summary>
+    /// Build the bare <see cref="ISpider"/> for this distributed worker. No
+    /// start URLs or schema required — the spider reads its
+    /// <see cref="Domain.ScraperConfig"/> from <see cref="WithConfigStorage"/>
+    /// at crawl time (ADR-0009).
+    /// </summary>
+    public ISpider BuildSpider()
+    {
+        _spiderBuilder.WithConfigStorage(_configStorage);
+        return _spiderBuilder.Build();
+    }
+}

--- a/WebReaper/Builders/ICrawlSeed.cs
+++ b/WebReaper/Builders/ICrawlSeed.cs
@@ -1,0 +1,30 @@
+using WebReaper.Domain;
+using WebReaper.Domain.Parsing;
+
+namespace WebReaper.Builders;
+
+/// <summary>
+/// A <b>Crawl seed</b> (ADR-0025): the start URL(s) and page mode produced by
+/// <see cref="ScraperEngineBuilder.Crawl(string[])"/> /
+/// <see cref="ScraperEngineBuilder.CrawlWithBrowser(string[])"/>, awaiting a
+/// <see cref="Schema"/>. It is not yet a builder — its only operation is
+/// <see cref="Extract"/>. This is what makes "build with no start URLs or no
+/// schema" unrepresentable: the gated terminals
+/// (<see cref="ScraperEngineBuilder.BuildAsync"/>,
+/// <see cref="ScraperEngineBuilder.Build"/>) live only on the
+/// <see cref="ScraperEngineBuilder"/> that <see cref="Extract"/> returns, and
+/// that builder has an internal constructor — it cannot exist without a seed
+/// and a schema.
+/// </summary>
+public interface ICrawlSeed
+{
+    /// <summary>
+    /// Apply the extraction <see cref="Schema"/> (the shared fold grammar,
+    /// ADR-0002) and yield the configurable <see cref="ScraperEngineBuilder"/>
+    /// — every free fluent method and every satellite extension, terminating
+    /// in <see cref="ScraperEngineBuilder.BuildAsync"/> (a runnable engine) or
+    /// <see cref="ScraperEngineBuilder.Build"/> (just the
+    /// <see cref="ScraperConfig"/>).
+    /// </summary>
+    ScraperEngineBuilder Extract(Schema schema);
+}

--- a/WebReaper/Builders/ScraperEngineBuilder.cs
+++ b/WebReaper/Builders/ScraperEngineBuilder.cs
@@ -26,18 +26,19 @@ using WebReaper.Sinks.Models;
 namespace WebReaper.Builders;
 
 /// <summary>
-/// The public fluent façade for configuring and building a scraper. It
-/// composes a <see cref="ConfigBuilder"/> (the immutable
-/// <see cref="ScraperConfig"/>: start URLs, the selector chain, the crawl
-/// limit) and an internal <c>SpiderBuilder</c> (runtime components — loaders,
-/// parsers, sinks, trackers, cookie storage), all with in-memory defaults.
-/// Terminate the chain with <see cref="BuildAsync"/> (an engine plus its
-/// persisted config) or <see cref="BuildSpider"/> (a bare
-/// <see cref="ISpider"/> for the distributed-worker pattern, ADR-0009). Every
-/// method returns the same builder for chaining; configuration order is free
-/// except that <see cref="BuildAsync"/> requires a start set
-/// (<see cref="Get"/> / <c>GetWithBrowser</c>) and a schema
-/// (<see cref="Parse"/>).
+/// The public fluent builder for configuring and building a scraper engine
+/// (ADR-0025). A scrape begins with a <b>Crawl seed</b>: obtain one from the
+/// static <see cref="Crawl(string[])"/> / <see cref="CrawlWithBrowser(string[])"/>,
+/// give it a <see cref="Schema"/> via <see cref="ICrawlSeed.Extract"/>, and
+/// you get this builder — every free fluent method and every satellite
+/// extension — terminating in <see cref="BuildAsync"/> (a runnable engine
+/// plus its persisted config) or <see cref="Build"/> (just the immutable
+/// <see cref="ScraperConfig"/>, e.g. for a distributed start endpoint to
+/// persist). The constructor is internal and the terminals live only here, so
+/// "build with no start URLs or no schema" is unrepresentable. The
+/// distributed-worker reduced shell (ADR-0009) is a separate seam —
+/// <see cref="DistributedSpiderBuilder"/>. Composes an internal
+/// <c>ConfigBuilder</c> and <c>SpiderBuilder</c>, all with in-memory defaults.
 /// </summary>
 public class ScraperEngineBuilder
 {
@@ -45,6 +46,81 @@ public class ScraperEngineBuilder
     private int _parallelismDegree = 20;
     private ConfigBuilder ConfigBuilder { get; } = new();
     private SpiderBuilder SpiderBuilder { get; } = new();
+
+    /// <summary>Internal: a <see cref="ScraperEngineBuilder"/> is obtained only
+    /// via <see cref="Crawl(string[])"/> / <see cref="CrawlWithBrowser(string[])"/>
+    /// then <see cref="ICrawlSeed.Extract"/> — never <c>new</c>ed. This is the
+    /// structural guarantee (ADR-0025): the build terminals cannot be reached
+    /// without a Crawl seed and a schema.</summary>
+    internal ScraperEngineBuilder() { }
+
+    /// <summary>
+    /// Begin a scrape: the crawl's start URLs, loaded as static HTTP pages
+    /// (the ADR-0025 Crawl seed). Returns an <see cref="ICrawlSeed"/> whose
+    /// only operation is <see cref="ICrawlSeed.Extract"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">no start URL was supplied
+    /// (fail-fast).</exception>
+    public static ICrawlSeed Crawl(params string[] startUrls)
+    {
+        if (startUrls is null || startUrls.Length == 0)
+            throw new ArgumentException(
+                "At least one start URL is required.", nameof(startUrls));
+        var builder = new ScraperEngineBuilder();
+        builder.ConfigBuilder.Get(startUrls);
+        return new CrawlSeed(builder);
+    }
+
+    /// <summary>
+    /// Begin a scrape whose start pages load through the headless-browser
+    /// transport (the ADR-0025 Crawl seed; requires the WebReaper.Puppeteer
+    /// satellite at run time, ADR-0009).
+    /// </summary>
+    /// <exception cref="ArgumentException">no start URL was supplied
+    /// (fail-fast).</exception>
+    public static ICrawlSeed CrawlWithBrowser(params string[] startUrls)
+    {
+        if (startUrls is null || startUrls.Length == 0)
+            throw new ArgumentException(
+                "At least one start URL is required.", nameof(startUrls));
+        var builder = new ScraperEngineBuilder();
+        builder.ConfigBuilder.GetWithBrowser(startUrls);
+        return new CrawlSeed(builder);
+    }
+
+    /// <summary>
+    /// <see cref="CrawlWithBrowser(string[])"/> with an optional
+    /// <see cref="PageActionBuilder"/> run on each start page before scraping.
+    /// </summary>
+    /// <exception cref="ArgumentException">no start URL was supplied
+    /// (fail-fast).</exception>
+    public static ICrawlSeed CrawlWithBrowser(
+        IEnumerable<string> startUrls,
+        Func<PageActionBuilder, List<PageAction>>? actionBuilder = null)
+    {
+        var urls = startUrls?.ToArray() ?? Array.Empty<string>();
+        if (urls.Length == 0)
+            throw new ArgumentException(
+                "At least one start URL is required.", nameof(startUrls));
+        var builder = new ScraperEngineBuilder();
+        builder.ConfigBuilder.GetWithBrowser(urls, actionBuilder?.Invoke(new PageActionBuilder()));
+        return new CrawlSeed(builder);
+    }
+
+    /// <summary>The <see cref="ICrawlSeed"/> implementation: holds the
+    /// half-built builder so the only operation reachable after
+    /// <see cref="Crawl(string[])"/> is <see cref="ICrawlSeed.Extract"/>.</summary>
+    private sealed class CrawlSeed : ICrawlSeed
+    {
+        private readonly ScraperEngineBuilder _builder;
+        internal CrawlSeed(ScraperEngineBuilder builder) => _builder = builder;
+
+        public ScraperEngineBuilder Extract(Schema schema)
+        {
+            _builder.ConfigBuilder.WithScheme(schema);
+            return _builder;
+        }
+    }
 
     private ILogger Logger { get; set; } = NullLogger.Instance;
 
@@ -274,43 +350,6 @@ public class ScraperEngineBuilder
         return this;
     }
 
-    /// <summary>The extraction <see cref="Schema"/> for target pages (the
-    /// fold grammar, ADR-0002). Required by <see cref="BuildAsync"/>.</summary>
-    public ScraperEngineBuilder Parse(Schema schema)
-    {
-        ConfigBuilder.WithScheme(schema);
-        return this;
-    }
-
-    /// <summary>The crawl's start URLs, loaded as static HTTP pages. Required
-    /// by <see cref="BuildAsync"/> (or use <see cref="GetWithBrowser(string[])"/>).</summary>
-    public ScraperEngineBuilder Get(params string[] startUrls)
-    {
-        ConfigBuilder.Get(startUrls);
-        return this;
-    }
-
-    /// <summary>
-    /// Start URLs loaded through the headless browser, with an optional
-    /// <see cref="PageActionBuilder"/> per page. Requires the
-    /// WebReaper.Puppeteer satellite (ADR-0009).
-    /// </summary>
-    public ScraperEngineBuilder GetWithBrowser(
-        IEnumerable<string> startUrls,
-        Func<PageActionBuilder, List<PageAction>>? actionBuilder = null)
-    {
-        ConfigBuilder.GetWithBrowser(startUrls, actionBuilder?.Invoke(new PageActionBuilder()));
-        return this;
-    }
-
-    /// <summary>Start URLs loaded through the headless browser, no page
-    /// actions. Requires the WebReaper.Puppeteer satellite.</summary>
-    public ScraperEngineBuilder GetWithBrowser(params string[] startUrls)
-    {
-        ConfigBuilder.GetWithBrowser(startUrls);
-        return this;
-    }
-
     /// <summary>Append a follow step over <paramref name="linkSelector"/> (one
     /// link in the crawl's selector chain, ADR-0001).</summary>
     public ScraperEngineBuilder Follow(string linkSelector)
@@ -448,32 +487,26 @@ public class ScraperEngineBuilder
     }
 
     /// <summary>
-    /// Build just the configured <see cref="ISpider"/> — no scheduler, no
-    /// engine loop, and (unlike <see cref="BuildAsync"/>) no
-    /// <c>ConfigBuilder.Build()</c>/persist, so it does <em>not</em> require
-    /// <c>Get</c>/<c>Parse</c>. This is the seam for the distributed-worker
-    /// pattern (ADR-0009): pull one <c>Job</c> off your own queue, crawl it
-    /// with <c>spider.CrawlAsync(job)</c>, and re-enqueue the returned child
-    /// jobs yourself — see <c>Examples/WebReaper.AzureFuncs</c>. The spider
-    /// reads its <see cref="Domain.ScraperConfig"/> from the configured
-    /// config storage at crawl time, so persist it separately (e.g. a
-    /// distributed config storage written by a start-scraping endpoint).
+    /// Produce just the immutable <see cref="ScraperConfig"/> (no engine, no
+    /// persistence) — the gated config terminal. The distributed start
+    /// endpoint uses this, then persists the result to shared config storage
+    /// for workers (ADR-0009; see <c>Examples/WebReaper.AzureFuncs</c>). Only
+    /// reachable after <see cref="Crawl(string[])"/> + <see cref="ICrawlSeed.Extract"/>,
+    /// so start URLs and a schema are always present (ADR-0025); the
+    /// reduced-shell worker that consumes the persisted config is built with
+    /// <see cref="DistributedSpiderBuilder"/>.
     /// </summary>
-    public ISpider BuildSpider()
-    {
-        SpiderBuilder.WithConfigStorage(ConfigStorage);
-        return SpiderBuilder.Build();
-    }
+    public ScraperConfig Build() => ConfigBuilder.Build();
 
     /// <summary>
-    /// Build the engine: validate and persist the <see cref="ScraperConfig"/>
-    /// to the configured <see cref="IScraperConfigStorage"/>, construct the
+    /// Build the engine: persist the <see cref="ScraperConfig"/> to the
+    /// configured <see cref="IScraperConfigStorage"/>, construct the
     /// <see cref="ISpider"/>, and return a runnable <see cref="ScraperEngine"/>
-    /// (the in-process Crawl driver, ADR-0022).
+    /// (the in-process Crawl driver, ADR-0022). Start URLs and a schema are
+    /// guaranteed present — this is reachable only via
+    /// <see cref="Crawl(string[])"/> + <see cref="ICrawlSeed.Extract"/>
+    /// (ADR-0025), so it cannot fail for an unconfigured crawl.
     /// </summary>
-    /// <exception cref="InvalidOperationException">no start URLs
-    /// (<see cref="Get"/>/<see cref="GetWithBrowser(string[])"/>) or no schema
-    /// (<see cref="Parse"/>) was configured.</exception>
     public async Task<ScraperEngine> BuildAsync()
     {
         SpiderBuilder.WithConfigStorage(ConfigStorage);

--- a/WebReaper/Builders/SpiderBuilder.cs
+++ b/WebReaper/Builders/SpiderBuilder.cs
@@ -30,7 +30,8 @@ namespace WebReaper.Builders;
 /// the runtime-component wiring (loaders, parsers, sinks, trackers, cookie
 /// storage). Not public — the registration seam lives only on
 /// <see cref="ScraperEngineBuilder"/>; a bare <see cref="Core.Spider.Abstract.ISpider"/>
-/// is obtained via <see cref="ScraperEngineBuilder.BuildSpider"/>.
+/// is obtained via <see cref="DistributedSpiderBuilder.BuildSpider"/> (the
+/// ADR-0009 reduced shell) or constructed by the engine path internally.
 /// </summary>
 internal class SpiderBuilder
 {

--- a/docs/adr/0025-staged-builder-entry.md
+++ b/docs/adr/0025-staged-builder-entry.md
@@ -1,0 +1,298 @@
+# A scrape begins with a Crawl seed — make "build with no start URLs or no schema" unrepresentable, not documented
+
+## Status
+
+**Accepted — implemented (10.0.0 wave).** Origin: an
+`/improve-codebase-architecture` review (candidate #4, the last of four; #1–#3
+shipped as ADR-0022), a grilling loop, then a source-verification pass that
+*sharpened* it (see *The verification that reshaped the decision*). The grill's
+open fork — does staging cover `ConfigBuilder`, used standalone, or only
+`ScraperEngineBuilder`? — was put to the maintainer and resolved **R-complete:
+stage both**. Implementation then surfaced one further fork the design prose had
+glossed, also resolved with the maintainer (see *Implementation note: the
+trilemma*): the structural guarantee, the seedless `BuildSpider()`, and zero
+satellite ripple cannot all hold with a single type, so the ADR-0009
+distributed-worker reduced shell became its own public type,
+`DistributedSpiderBuilder` — the "two seams, not one bug" framing made concrete.
+Shipped: whole-solution build 0 errors, 94 unit + 27 satellite tests green,
+Native-AOT smoke ALL PASS.
+
+## Context
+
+`ScraperEngineBuilder` and `ConfigBuilder` are the front door of the library.
+The project's whole value proposition — its maintainer's stated first priority —
+is that the call site is easy to read and hard to misuse. Today the front door
+has a runtime trap:
+
+- [`ConfigBuilder.Build()`](../../WebReaper/Builders/ConfigBuilder.cs#L208-L215)
+  `throw`s `InvalidOperationException` if start URLs were never set (L211) or a
+  schema was never set (L214). Its own doc comment says *"Builder order
+  matters — configure before calling this."* — a comment that exists only
+  because the type can't enforce its own contract.
+- [`BuildAsync()`](../../WebReaper/Builders/ScraperEngineBuilder.cs#L477-L488)
+  calls `ConfigBuilder.Build()` (L480) and inherits the throw.
+- `CLAUDE.md` gotcha #3 documents the trap in prose for every future reader.
+
+A documented gotcha guarding an ordering rule the type system could carry is the
+exact smell every prior WebReaper ADR exists to kill: ADR-0001 made an invalid
+crawl outcome unrepresentable (closed sum); ADR-0022 made a non-terminating
+crawl unrepresentable (termination is a value, never a thrown exception);
+ADR-0005/0008/0023 each replaced a duplication-with-drift with one owner. The
+signature move of this codebase is *turn a runtime/implicit failure into a
+structurally impossible one* — and it has not yet been applied to the front
+door it most affects.
+
+Apply the project's own deletion test to the two `throw`s. Delete them and ask
+what reappears: a call site that compiles, runs, hits the network setup, and
+fails *late* with no start URL or no schema — the worst place to learn it, far
+from the mistake. The throws are load-bearing; they are catching a real error.
+That is precisely the signal that the *type*, not a runtime check plus a
+`CLAUDE.md` paragraph, should own the rule.
+
+There are three real client shapes, all verified in `Examples/`:
+
+1. **In-process** (`WebReaper.ConsoleApplication`):
+   `new ScraperEngineBuilder().Get(...).Parse(...)….BuildAsync()`.
+2. **Distributed worker-service**
+   (`DistributedScraperWorkerService/ScrapingWorker.cs`):
+   `await new ScraperEngineBuilder().WithLogger(...).Get(...).Parse(...)
+   .TrackVisitedLinksInRedis(...)….BuildAsync()` — full config in-builder, a
+   satellite extension interleaved.
+3. **DIY-distributed split** (`WebReaper.AzureFuncs`, the ADR-0009 /
+   ADR-0022-slice-4 pattern):
+   - [`StartScraping.cs:55-72`](../../Examples/WebReaper.AzureFuncs/StartScraping.cs#L55-L72)
+     — the *start endpoint* builds a `ScraperConfig` via **`ConfigBuilder`
+     directly** (`new ConfigBuilder().Get(...).WithScheme(...).Build()`, L70)
+     and persists it to shared config storage.
+   - [`WebReaperSpider.cs:52-55`](../../Examples/WebReaper.AzureFuncs/WebReaperSpider.cs#L52-L55)
+     — the *worker* calls `new ScraperEngineBuilder().WithLogger(log)
+     .WithLinkTracker(LinkTracker).BuildSpider()` with **no start URLs and no
+     schema, by design**: it is config-agnostic; its spider reads the
+     `ScraperConfig` from shared storage at crawl time.
+
+## The verification that reshaped the decision
+
+The grilled design proposed gating *all* terminals — including
+[`BuildSpider()`](../../WebReaper/Builders/ScraperEngineBuilder.cs#L462-L466) —
+behind the new prefix, on the belief that `BuildSpider()`'s skipping the
+validation `BuildAsync()` performs was a latent asymmetry to close. Reading the
+source retired that belief:
+
+- `BuildSpider()` is `SpiderBuilder.WithConfigStorage(...); return
+  SpiderBuilder.Build();`. It **never calls `ConfigBuilder.Build()`**. It has no
+  unset-config throw to "fix." It is not a validate-skipping bug; it is the
+  ADR-0009 reduced-shell seam for a config-agnostic distributed worker.
+- Gating it behind the seed would force every distributed worker
+  (`WebReaperSpider.cs` is the canonical one) to declare start URLs and a schema
+  it structurally never uses — silently regressing a documented, shipped
+  pattern. That is the same move ADR-0024 explicitly refused to make to
+  single-satellite releases.
+
+So the friction lives *only* on the config-owning path (`ConfigBuilder.Build()`
+and its caller `BuildAsync()`). The fix stages that path. `BuildSpider()` stays
+seedless — and that is **correct, not asymmetry**. The apparent asymmetry
+dissolves the right way: two seams, not one bug. This is a strict improvement —
+the design stops fighting the ADR-0009 registration seam.
+
+## Decision
+
+**A scrape begins with a Crawl seed.** Make the start URL(s) + page mode a value
+you must hold before any builder exists, and the schema the only thing you can
+do with that value. "Build with no start URLs or no schema" then has no
+representation to construct.
+
+- **Crawl seed** (new `CONTEXT.md` term — proposed; the maintainer drives
+  `CONTEXT.md`): the start URL(s) and page mode, awaiting a `Schema`; not yet a
+  builder. Produced by static entry methods:
+  - `Crawl(params string[] urls)` → a Static-mode seed.
+  - `CrawlWithBrowser(string[] urls, List<PageAction>? actions = null)` → a
+    Dynamic-mode seed.
+- The seed exposes exactly **one** member: `Extract(Schema schema)`. The only
+  thing you can do with a seed is give it a schema. This is the single new
+  public interface, **`ICrawlSeed`** — named for the `CONTEXT.md` concept it
+  *is* (a Crawl seed), so a reader who finds the term finds the type. The
+  grill's earlier `IExtractStep` named the fluent stage — the mechanism;
+  `ICrawlSeed` names the domain noun, the same intent-over-mechanism move that
+  took the schema verb from `Parse` to `Extract`.
+- `seed.Extract(schema)` returns the **one** free builder — every existing free
+  fluent method (`Follow`, `Paginate`, `WithLogger`, `WriteToJsonFile`, …) and
+  **every ADR-0009 satellite extension** (`TrackVisitedLinksInRedis`,
+  `WriteToMongoDb`, `WithPuppeteerPageLoader`, …) unchanged, because the
+  receiver type is unchanged. Zero satellite ripple.
+- The free builder carries the **gated** terminals — both reachable only after
+  `Crawl(…).Extract(…)`, so both unset-config failures are unrepresentable:
+  - `BuildAsync()` → `ScraperEngine` (in-process + worker-service).
+  - `Build()` → `ScraperConfig` (the distributed *start endpoint*; replaces the
+    standalone `new ConfigBuilder()….Build()` in `StartScraping.cs`).
+- The ADR-0009 reduced shell moves to its own public type,
+  **`DistributedSpiderBuilder`** (`new DistributedSpiderBuilder()
+  .WithLogger(…).BuildSpider()`). It is config-agnostic by design — no Crawl
+  seed, no `BuildAsync`, no crawl-shape — and carries only the spider-side
+  runtime seams a worker actually configures. The driver-side link tracker is
+  *not* on it (ADR-0022: it is the driver's idempotency authority, wired by the
+  worker directly — see *Implementation note*). This is why `ScraperEngineBuilder`
+  can have an internal constructor: the seedless path no longer needs it.
+- The two `ConfigBuilder.Build()` `throw`s and `CLAUDE.md` gotcha #3 are
+  **deleted outright** — there is nothing left for them to catch or warn about.
+  `ConfigBuilder` is now `internal`; `ScraperEngineBuilder`'s constructor is
+  `internal` (test-only via `InternalsVisibleTo`).
+
+This is **R-complete** (the resolved fork): a single Crawl seed fronts both
+build outcomes. The alternative — a second, parallel staged front bolted onto a
+still-public `ConfigBuilder` — was rejected as reintroducing the very
+duplication-with-drift the ADR exists to remove (see *Considered options*).
+
+Client code, before and after:
+
+```csharp
+// in-process — before
+await new ScraperEngineBuilder()
+    .Get("https://www.alexpavlov.dev/blog")
+    .Follow(".text-gray-900.transition")
+    .Parse(new() { new("title", ".text-3xl.font-bold"),
+                   new("text",  ".max-w-max.prose") })
+    .WriteToJsonFile("output.json").PageCrawlLimit(10).BuildAsync();
+
+// in-process — after: the prefix is mandatory, the type enforces it
+await ScraperEngineBuilder
+    .Crawl("https://www.alexpavlov.dev/blog")
+    .Extract(new() { new("title", ".text-3xl.font-bold"),
+                     new("text",  ".max-w-max.prose") })
+    .Follow(".text-gray-900.transition")
+    .WriteToJsonFile("output.json").PageCrawlLimit(10).BuildAsync();
+
+// distributed start endpoint — after: same seed, config terminal
+var config = ScraperEngineBuilder
+    .Crawl("https://rutracker.org/forum/index.php?c=33")
+    .Extract(schema)
+    .Follow("#cf-33 .forumlink>a").Paginate("a.torTopic", ".pg")
+    .Build();                       // ScraperConfig, then persist
+await _configStorage.CreateConfigAsync(config);
+
+// distributed worker — its own seam (ADR-0009 reduced shell)
+var spider = new DistributedSpiderBuilder()
+    .WithLogger(log).BuildSpider();   // link tracker is the driver's (ADR-0022)
+```
+
+`ICrawlSeed`, the static `Crawl`/`CrawlWithBrowser`, and
+`DistributedSpiderBuilder` are the public surface added, so they carry the
+ADR-0023 documented-contract obligation (XML doc, CS1591-as-error) — one tiny
+interface plus a small reduced-shell builder, fully the new doc burden.
+
+## Implementation note: the trilemma
+
+Implementing the Decision surfaced a constraint the prose had glossed. Three
+properties the ADR promised cannot all hold with one builder type and no
+generics:
+
+1. **Structural guarantee** — `BuildAsync()`/`Build()` unreachable without
+   `Crawl().Extract()` ⇒ the type carrying them has no public constructor.
+2. **Seedless `BuildSpider()`** — the ADR-0009 worker constructs its shell with
+   no seed.
+3. **Zero satellite ripple** — satellite extensions stay
+   `this ScraperEngineBuilder`, so the post-`Extract` type *is*
+   `ScraperEngineBuilder`.
+
+(1) and (2) collide directly on the same type. The resolution, confirmed with
+the maintainer on "best architecture + most beautiful API": embrace the ADR's
+own "two seams, not one bug" framing as *two types*. `ScraperEngineBuilder`
+(internal ctor, reached only via the Crawl seed) carries the gated terminals
+and every satellite extension, unchanged. The reduced shell is a separate
+public type, `DistributedSpiderBuilder`, with a public constructor and no
+`BuildAsync` — so the guarantee is absolute *and* the worker is still seedless.
+
+The load-bearing fact that made this cost-free: the canonical distributed
+worker ([`AzureFuncs/Startup.cs`](../../Examples/WebReaper.AzureFuncs/Startup.cs))
+wires its shared adapters by **direct construction** (`new
+RedisVisitedLinkTracker(...)`, `new RedisOutstandingWorkLatch(...)`) — satellite
+concretes are public precisely for this DIY pattern (ADR-0009). The worker
+never needed the satellite *builder* sugar, so keeping satellite extensions on
+`ScraperEngineBuilder` only is **zero ripple**, not a regression. Test
+compilation is likewise unaffected: `WebReaper.csproj`'s `InternalsVisibleTo`
+already covers every test assembly, so the internal constructor stays visible
+to white-box tests while the *public* contract has no seedless builder. The
+worker's previously-wired `WithLinkTracker` was dropped: per ADR-0022 the
+visited-link tracker is the *driver's* idempotency authority, used by the
+worker function directly, never a spider-shell concern.
+
+## Considered options
+
+- **Type-state phases — phantom `<TPhase>` threaded through the builder
+  (rejected).** Encodes the same ordering in the type, but `ScraperEngineBuilder`
+  has ~20 fluent methods and is the receiver of **14 `this ScraperEngineBuilder`
+  satellite extension methods** across Mongo, Sqlite, Redis, Cosmos,
+  AzureServiceBus and Puppeteer. Every one would have to become generic in the
+  phase — re-coupling the ADR-0009 registration seam this codebase worked to
+  decouple, a heavy ADR-0023 public-surface churn, and a phantom generic that
+  leaks into client-visible types and compiler errors. It fails the maintainer's
+  first principle: easy to read. The Crawl seed achieves the same impossibility
+  with one interface and one method, and no satellite ripple.
+- **Make `BuildSpider()` symmetric + sharpen the throw (rejected).** The minimal
+  non-structural fix. Keeps the failure at runtime, keeps the `CLAUDE.md`
+  gotcha; fails the deletion test. Worse, "symmetric `BuildSpider()`" is itself
+  wrong: `BuildSpider()` is the seedless ADR-0009 seam — making it validate
+  in-builder config would break the distributed worker (*The verification that
+  reshaped the decision*). The signature move is unrepresentable, not
+  better-documented.
+- **Multi-parameter factory, e.g. `ScraperEngineBuilder.Create(urls, schema,
+  …)` (rejected).** Enforces the prerequisites by making them constructor
+  arguments, but a factory taking several positional parameters is exactly the
+  unreadable call site the maintainer named as the thing to avoid; it discards
+  the self-describing fluent surface.
+- **R-narrow: stage only `ScraperEngineBuilder` (rejected in grilling).** Leaves
+  `ConfigBuilder`'s standalone public use (`StartScraping.cs`, the DIY-distributed
+  start endpoint) still runtime-throwing; the headline "unrepresentable by
+  construction" would be only half-true and the `CLAUDE.md` gotcha would
+  survive, scoped instead of removed. ADR-0024's lesson applies: process
+  discipline (or a scoped doc) is not a fix for a missing structural guarantee.
+- **Status quo + the `CLAUDE.md` gotcha (rejected).** A documented gotcha is the
+  smell this ADR removes, not the fix for it.
+
+## SemVer / impact
+
+**Breaking public API change — a major bump (next after 9.0.0 ⇒ 10.0.0).** A
+clean-cut break, called out loud, never silent (the ADR-0009 / ADR-0023
+precedent for deliberate majors):
+
+- Entry moves: `new ScraperEngineBuilder().Get(...)/.GetWithBrowser(...)` and
+  `.Parse(...)`/`.WithScheme(...)` are replaced by the static
+  `Crawl(...)`/`CrawlWithBrowser(...)` + `Extract(...)` seed.
+- The two `ConfigBuilder.Build()` `throw`s are deleted; `CLAUDE.md` gotcha #3 is
+  deleted.
+- **Public `ConfigBuilder` is retired** — its sole external use is the
+  distributed-start `new ConfigBuilder()….Build()`, which the unified Crawl seed
+  absorbs as the `.Build()` terminal; `ConfigBuilder` becomes an internal
+  implementation detail of the façade (the ADR-0023 "concrete is internal"
+  direction). This is the one consequence flagged for the maintainer to confirm
+  at implementation rather than silently take.
+- The seedless ADR-0009 distributed-worker path **moves** from
+  `new ScraperEngineBuilder()….BuildSpider()` to
+  `new DistributedSpiderBuilder()….BuildSpider()` (a breaking move; the worker
+  also drops the driver-owned `WithLinkTracker`, ADR-0022). `BuildSpider()` is
+  removed from `ScraperEngineBuilder`.
+- README, every `Examples/` project, and `CLAUDE.md` updated in the same wave;
+  satellite READMEs / `API.md` / `CHANGELOG` follow.
+- Guardrail (met): whole-solution build **0 errors**, **94 unit + 27 satellite**
+  tests green, **Native-AOT smoke ALL PASS**. The four `throw`/gotcha sites are
+  gone and the only public way to reach `BuildAsync()`/`Build()` is
+  `Crawl(…).Extract(…)`.
+
+## References
+
+- ADR-0001 (closed `CrawlOutcome` sum) and ADR-0022 (termination as a value,
+  never a thrown exception) — the project's signature move, here extended to the
+  builder front door it most affects.
+- ADR-0009 (registration seam, satellite adapters) — why `BuildSpider()` stays
+  seedless and why the phantom-generic alternative's satellite ripple is the
+  load-bearing rejection.
+- ADR-0023 (the public surface *is* the documented contract, CS1591-as-error) —
+  the doc obligation the one new interface carries, and the churn cost that
+  sinks the phantom-generic alternative.
+- ADR-0024 — the "Proposed — design pass" status and the explicit-grilling-fork
+  precedent this ADR follows.
+- [`ConfigBuilder.cs:208-215`](../../WebReaper/Builders/ConfigBuilder.cs#L208-L215),
+  [`ScraperEngineBuilder.cs:462-488`](../../WebReaper/Builders/ScraperEngineBuilder.cs#L462-L488),
+  `Examples/WebReaper.AzureFuncs/StartScraping.cs` &
+  `WebReaperSpider.cs` — the verified friction and the seam this preserves.
+- The `/improve-codebase-architecture` review (candidates #1–#4; #1–#3 shipped
+  as ADR-0022) — the origin of this candidate.


### PR DESCRIPTION
## ADR-0025 — A scrape begins with a Crawl seed (10.0.0, breaking)

Staged builder entry: `ScraperEngineBuilder.Crawl(...)` / `.CrawlWithBrowser(...)` (static) -> `ICrawlSeed` -> `.Extract(schema)` -> the builder. The builder constructor is `internal`, so `BuildAsync()` / `Build()` are type-impossible without a Crawl seed and a schema — "build with no start URLs or no schema" has no representation to construct. The two `ConfigBuilder.Build()` throws and CLAUDE.md gotcha #3 are deleted by construction; `ConfigBuilder` is now `internal`.

**Two seams, not one bug.** The ADR-0009 distributed-worker reduced shell is its own public type, `DistributedSpiderBuilder` (public ctor, seedless, no `BuildAsync`), so the structural guarantee is absolute with **zero satellite ripple** — verified: the canonical AzureFuncs worker wires shared adapters by direct construction, and `InternalsVisibleTo` keeps tests compiling (3 test files touched, not ~23).

Design, grilled alternatives, the implementation trilemma and its resolution: `docs/adr/0025-staged-builder-entry.md`.

### Breaking
- Entry moved: `new ScraperEngineBuilder().Get(...).Parse(...)` -> `ScraperEngineBuilder.Crawl(...).Extract(...)`. `Get` / `GetWithBrowser` / `Parse` removed; `ScraperEngineBuilder` ctor internal.
- `new ScraperEngineBuilder()...BuildSpider()` -> `new DistributedSpiderBuilder()...BuildSpider()`.
- `ConfigBuilder` internal; `new ConfigBuilder()...Build()` -> `ScraperEngineBuilder.Crawl(...).Extract(...).Build()`.

### Guardrail
Whole-solution build **0 errors** · **94 unit + 27 satellite tests pass** · **Native-AOT smoke ALL PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)