### PR TITLE
docs: mark 10.0.0 as unreleased — release deferred, accumulating on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 10.0.0 — A scrape begins with a Crawl seed (breaking)
+## 10.0.0 *(unreleased — accumulating on `master`)* — A scrape begins with a Crawl seed (breaking)
 
 The builder front door no longer has a runtime trap. Start URLs and a schema
 were a *runtime* `InvalidOperationException` from `ConfigBuilder.Build()` if you

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ dotnet add package WebReaper.Sqlite           # SQLite local durable scheduler +
 
 ## Packages
 
-All seven packages are versioned in lockstep (currently `10.0.0`) — core and the six satellites move
-together in release waves (ADR-0022 → `8.0.0`, ADR-0023 → `9.0.0`, ADR-0025 → `10.0.0`);
-`WebReaper.Sqlite`, added at `7.1.0`, joined the lockstep from `8.0.0`. All packages are GPL-3.0-or-later, and every satellite
+All seven packages are versioned in lockstep — the latest published version is `9.0.0`; the
+next wave, **`10.0.0`, is accumulating on `master` and is not yet released**. Core and the six
+satellites move together in release waves (ADR-0022 → `8.0.0`, ADR-0023 → `9.0.0`, ADR-0025 →
+`10.0.0` *(unreleased)*); `WebReaper.Sqlite`, added at `7.1.0`, joined the lockstep from `8.0.0`. All packages are GPL-3.0-or-later, and every satellite
 wires itself in through the builder's public registration seam.
 
 | Package | Add it for | Key builder calls |


### PR DESCRIPTION
Housekeeping follow-up to PR #80.

PR #80's README/CHANGELOG wording read as if 10.0.0 had shipped — `currently `10.0.0`` in the Packages section and an unqualified `## 10.0.0` CHANGELOG heading — but the latest published tag is `v9.0.0` and the 10.0.0 release is intentionally deferred to batch more changes.

This annotates both as **unreleased / accumulating on `master`** so readers do not mis-attribute the state. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)