### PR TITLE
ADR-0050 implementation: PageAction.SemanticAct(intent) + IActionResolver + WebReaper.AI.LlmActionResolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 10.0.0 — AI-native funnel, on a deepened architecture; MIT relicense (breaking)
+## 10.0.0 — AI-native funnel + semantic actions, on a deepened architecture; MIT relicense (breaking)
 
-The headline release of the year — 24 ADRs (0025–0049, with ADR-0017 the
+The headline release of the year — 25 ADRs (0025–0050, with ADR-0017 the
 parallel licence move) — splits into three arcs. The first is the *staged
 builder* that closes the last runtime construction trap (ADR-0025). The
 second is *architecture deepening* — two review waves (ADR-0026..0031 and
@@ -213,6 +213,9 @@ its satellite per ADR-0009.
 
 - **`WebReaper.Mcp` — MCP server satellite exposing scrape/map/extract as MCP tools (ADR-0049).** New Exe satellite over the `ModelContextProtocol` C# SDK with stdio transport, exposing three `[McpServerTool]` methods that wrap the existing library API — for MCP-only clients (Cursor, ChatGPT Desktop, Copilot Studio) that can't reach the CLI. Thin facade; pre-1.0 SDK churn quarantined per ADR-0009. Additive.
   [`docs/adr/0049-mcp-server-satellite.md`](docs/adr/0049-mcp-server-satellite.md)
+
+- **`PageAction.SemanticAct(intent)` — natural-language page actions; LLM resolves once, deterministic thereafter (ADR-0050).** A seventh closed-sum `PageAction` arm carrying an intent string ("click sign in") instead of a CSS selector. New public `IActionResolver` seam + `ScraperEngineBuilder.WithActionResolver(...)`; the `WebReaper.AI` satellite ships `LlmActionResolver` + `WithLlmActionResolver(chatClient)`. The Puppeteer transport resolves the intent on the first dynamic page, dispatches the concrete arm, and caches the resolution per crawl by intent string — every subsequent same-intent page dispatches the cached arm with no LLM call. The cache lives in core (`SemanticActCoordinator`), unit-testable without an `IPage`. Same proposer-validator pattern as the extraction router (ADR-0046) and self-healing extractor (ADR-0047), generalised from extraction to actions — self-heal stops being one feature and becomes a *project-level pattern*. **Narrow breaking edge:** `ScraperEngineBuilder.WithLoadTransport`'s factory delegate widens from 3 to 4 arguments (the fourth is `IActionResolver`); the in-tree `WebReaper.Puppeteer` satellite is updated in lockstep. A `SemanticAct` in the config without a registered resolver logs a warning at `BuildAsync` and throws `SemanticActResolutionException` on the first dispatch.
+  [`docs/adr/0050-semantic-page-actions.md`](docs/adr/0050-semantic-page-actions.md)
 
 ### Licence (ADR-0017)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,12 +57,13 @@ Terminate with `BuildAsync()` (persists the config to `IScraperConfigStorage`, c
 
 **Distributed mode:** swapping scheduler + config storage + link tracker to Redis or Azure Service Bus lets multiple workers / serverless functions share crawl state. See `Examples/WebReaper.AzureFuncs` and `Examples/WebReaper.DistributedScraperWorkerService`.
 
-**AI-native (ADR-0040..0049):** three composing pieces on top of the existing pipeline:
+**AI-native (ADR-0040..0050):** four composing pieces on top of the existing pipeline:
 - **`IContentExtractor` adapters** (ADR-0039 seam): `SchemaFold` (deterministic), `MarkdownContentExtractor` (no-schema, ADR-0040), `LlmContentExtractor` (LLM via `Microsoft.Extensions.AI`, ADR-0044 — in the `WebReaper.AI` satellite). `ExtractionRouter` (ADR-0046) composes any two — `.WithFallbackExtractor` / `.WithLlmFallback`. `SelfHealingContentExtractor` (ADR-0047) wraps the deterministic primary with an `ISelectorRepairer` — `.WithSelfHealing` / `.WithLlmSelfHealing`.
 - **Page cache** (`IPageCache`, ADR-0041): cache-aside on the loader; `.WithMaxAge(TimeSpan)` is the firecrawl-shaped one-liner.
 - **Discovery + monitoring**: `ScraperEngineBuilder.MapAsync(url, opts?)` for URL discovery (`ISiteMapper`, ADR-0042); `.WithChangeTracking()` for the change-tracking page processor (`IChangeStore`, ADR-0048).
 - **Agent surfaces**: the `WebReaper.Cli` AOT single binary (ADR-0043) — `webreaper scrape|map|init` — is the primitive; the bundled Agent Skill is the discoverable adapter (`webreaper init` writes `.claude/skills/webreaper/SKILL.md`); the `WebReaper.Mcp` satellite (ADR-0049) is the interop adapter for MCP-only clients (Cursor, Claude Desktop, Copilot Studio).
 - **Source-gen**: `[ScrapeSchema]` on a `partial class` with `[ScrapeField("selector")]` on properties — the `WebReaper.Extraction.Generators` Roslyn analyzer (ADR-0045) emits a `static Schema` and a reflection-free `static Materialize(JsonObject)`.
+- **Semantic actions** (ADR-0050): `PageAction.SemanticAct(intent)` is the seventh closed-sum arm — a natural-language intent ("click sign in"). The Puppeteer transport resolves it on the first dynamic page via the registered `IActionResolver` (the `WebReaper.AI` satellite ships `LlmActionResolver`; `.WithLlmActionResolver(chatClient)` is the one-liner) into a concrete arm, dispatches it, and caches the resolution per crawl by intent string. Same LLM-as-proposer / deterministic-as-decider pattern as ADR-0046/0047 applied to actions — first page pays the LLM, every subsequent same-intent page dispatches the cached arm with no LLM call. The cache lifecycle lives in core (`SemanticActCoordinator`, unit-testable without an `IPage`); the transport delegates.
 
 Namespace mirrors folder path throughout (`WebReaper.Core.Spider.Concrete` = `WebReaper/Core/Spider/Concrete/`).
 
@@ -77,3 +78,5 @@ Namespace mirrors folder path throughout (`WebReaper.Core.Spider.Concrete` = `We
 - The self-heal cache (ADR-0047) is keyed by Schema reference identity; the same Schema instance reused across Crawls shares its patch.
 - The `WebReaper.AI` satellite pulls `Microsoft.Extensions.AI.Abstractions` (preview); not AOT-required by design (ADR-0009 quarantine).
 - The `WebReaper.Mcp` satellite uses the preview `ModelContextProtocol` SDK; pin the version explicitly when shipping a release.
+- `PageAction.SemanticAct(intent)` (ADR-0050) needs an `IActionResolver` — without one the transport throws `SemanticActResolutionException` on the first dispatch. `ScraperEngineBuilder.BuildAsync()` logs a warning at build time when the config carries a `SemanticAct` and the resolver is still the default `NullActionResolver`. The cache is per-Spider in-memory, intent-string-keyed (single-host crawls assumed); a multi-host crawl with intent collisions surfaces as a cached-arm dispatch failure → re-resolve loop.
+- ADR-0050 widened the `WithLoadTransport(...)` factory delegate to four arguments (cookies, proxy, logger, **actionResolver**). The Puppeteer satellite's `WithPuppeteerPageLoader()` extension was updated in lockstep. A custom transport satellite needs to accept the resolver argument even if it ignores it.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -330,6 +330,23 @@ Heavy MCP SDK deps quarantined here per the ADR-0009 satellite pattern;
 core stays dependency-light + AOT-clean.
 _Avoid_: MCP integration, agent server, JSON-RPC endpoint.
 
+**Semantic action / Action resolver** (ADR-0050):
+The seventh `PageAction` arm — `PageAction.SemanticAct(intent)` —
+carries a natural-language intent string ("click sign in") instead of a
+CSS selector. At dispatch the Puppeteer transport calls the registered
+`IActionResolver` (typically the `WebReaper.AI` satellite's
+`LlmActionResolver`) with the intent + the current page HTML; the
+resolver returns a concrete arm (`Click` / `WaitForSelector` / `Wait` /
+`EvaluateExpression`); the transport caches it per crawl by intent
+string and dispatches the cached arm on every subsequent same-intent
+page. Same LLM-as-proposer / deterministic-as-decider pattern as the
+**Extraction router** (ADR-0046) and **Self-healing content extractor**
+(ADR-0047), generalised from the extraction surface to the action
+surface — the self-heal pattern stops being one feature and becomes a
+project-level pattern (see [Relationships](#relationships)).
+_Avoid_: `Click("sign in")` (selectors are CSS, not intents), "AI page
+action", "smart click", agent step.
+
 ## Relationships
 
 - A **Crawl** processes many **Job**s.
@@ -350,6 +367,7 @@ _Avoid_: MCP integration, agent server, JSON-RPC endpoint.
 - The **Outstanding-work latch** trips once when credit reaches zero; its correctness rests on the **Visited-link tracker**'s atomic test-and-set, not on queue delivery semantics. The in-process and distributed **Crawl driver**s are its two adapters — the in-process driver reaches it through the **Stop rule**, the distributed driver consults the latch primitive directly.
 - The in-process **Crawl driver** consults one **Stop rule**, which composes the **Outstanding-work latch** (completion) and the soft page limit (cutoff) into the single stop verdict; completion and cutoff are distinct mechanisms, composed, never merged.
 - The in-process **Crawl driver** holds one **Retry policy** and runs every per-Job **Spider** call through `IRetryPolicy.ExecuteAsync`; the policy bounds attempts and never retries cancellation. The distributed-worker reduced shell holds no **Retry policy** — its retry boundary is the queue's redelivery.
+- A **Semantic action** (`PageAction.SemanticAct(intent)`) dispatches through one **Action resolver**: cache miss ⇒ call the resolver with the rendered HTML, receive a concrete arm (Click / WaitForSelector / Wait / EvaluateExpression), dispatch it, cache by intent; cache hit ⇒ dispatch the cached arm; cached-arm dispatch failure ⇒ invalidate + re-resolve. The deterministic path is the hot path — first page pays the LLM, every subsequent same-intent page dispatches the cached arm with no LLM call. Same proposer-validator shape as the **Extraction router** and **Self-healing content extractor** on the extraction surface (ADR-0046, ADR-0047).
 
 ## Example dialogue
 

--- a/WebReaper.AI/LlmActionResolver.cs
+++ b/WebReaper.AI/LlmActionResolver.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.AI;
+using WebReaper.Core.Actions.Abstract;
+using WebReaper.Domain.PageActions;
+
+namespace WebReaper.AI;
+
+/// <summary>
+/// The LLM adapter of the <see cref="IActionResolver"/> seam (ADR-0050) — the
+/// satellite's sibling to <see cref="LlmContentExtractor"/> and
+/// <see cref="LlmSelectorRepairer"/>, applied to the *action* surface instead
+/// of the *extraction* surface. Bound to
+/// <c>Microsoft.Extensions.AI.Abstractions</c>'s
+/// <see cref="IChatClient"/> — the consumer brings their own concrete chat
+/// client (OpenAI, Anthropic via wrapper, Ollama, anything implementing the
+/// interface).
+/// <para>
+/// Asked once per intent string per crawl: the model returns a JSON object
+/// naming one of the four supported action shapes (<c>click</c>,
+/// <c>waitFor</c>, <c>wait</c>, <c>evaluate</c>). The resolver constructs the
+/// matching <see cref="PageAction"/> arm; the Puppeteer transport caches it
+/// and dispatches the cached arm on every subsequent same-intent invocation
+/// (the LLM-as-proposer / deterministic-as-decider pattern, ADR-0046 /
+/// ADR-0047 generalised to actions).
+/// </para>
+/// <para>
+/// Unsupported JSON shapes (a <c>kind</c> the prompt doesn't whitelist,
+/// missing required fields, malformed JSON) result in a <c>null</c> return —
+/// the transport translates that to
+/// <see cref="WebReaper.Core.Actions.Concrete.SemanticActResolutionException"/>.
+/// The resolver never returns a <see cref="PageAction.SemanticAct"/> arm — it
+/// would loop the transport's dispatch.
+/// </para>
+/// </summary>
+public sealed class LlmActionResolver : IActionResolver
+{
+    private const string DefaultSystemPrompt =
+        "You are resolving a user's natural-language intent to a concrete " +
+        "browser action on the supplied HTML page. " +
+        "Return a single JSON object with one of these exact shapes:\n" +
+        "  { \"kind\": \"click\",    \"selector\": \"<css>\" }\n" +
+        "  { \"kind\": \"waitFor\",  \"selector\": \"<css>\", \"timeoutMs\": <int> }\n" +
+        "  { \"kind\": \"wait\",     \"ms\":       <int>   }\n" +
+        "  { \"kind\": \"evaluate\", \"expression\": \"<js>\" }\n" +
+        "Pick the simplest action that satisfies the intent. Prefer a CSS " +
+        "selector specific enough not to collide with other elements " +
+        "(prefer id over class, class over tag; combine if needed). " +
+        "Return JSON only — no commentary, no Markdown code fences. " +
+        "If the intent cannot be satisfied by any of these shapes, return " +
+        "an empty object: {}.";
+
+    private readonly IChatClient _chatClient;
+    private readonly LlmActionResolverOptions _options;
+
+    /// <summary>Construct with an <see cref="IChatClient"/> and optional
+    /// <see cref="LlmActionResolverOptions"/>.</summary>
+    public LlmActionResolver(IChatClient chatClient, LlmActionResolverOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(chatClient);
+        _chatClient = chatClient;
+        _options = options ?? new LlmActionResolverOptions();
+    }
+
+    /// <inheritdoc/>
+    public async Task<PageAction?> ResolveAsync(
+        string intent,
+        string pageHtml,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(intent);
+        ArgumentNullException.ThrowIfNull(pageHtml);
+
+        var trimmedHtml = pageHtml.Length > _options.MaxHtmlChars
+            ? pageHtml[.._options.MaxHtmlChars]
+            : pageHtml;
+
+        var userPrompt =
+            "Intent: " + intent + "\n\n" +
+            "Page (HTML, may be truncated):\n" + trimmedHtml;
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, _options.SystemPrompt ?? DefaultSystemPrompt),
+            new(ChatRole.User,   userPrompt)
+        };
+
+        var chatOptions = new ChatOptions
+        {
+            ModelId = _options.Model,
+            Temperature = _options.Temperature,
+            MaxOutputTokens = _options.MaxResponseTokens,
+            ResponseFormat = ChatResponseFormat.Json
+        };
+
+        var response = await _chatClient.GetResponseAsync(messages, chatOptions, cancellationToken);
+
+        var text = StripJsonFences(response.Text ?? string.Empty);
+        if (string.IsNullOrWhiteSpace(text)) return null;
+
+        JsonNode? parsed;
+        try
+        {
+            parsed = JsonNode.Parse(text);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        if (parsed is not JsonObject obj) return null;
+
+        return ParseArm(obj);
+    }
+
+    // The whitelist of arm shapes. Any other "kind" -> null (the transport
+    // surfaces a typed SemanticActResolutionException). SemanticAct
+    // deliberately not in this list — the resolver must never return one
+    // (would loop the transport).
+    private static PageAction? ParseArm(JsonObject obj)
+    {
+        var kind = obj["kind"]?.GetValue<string>();
+        return kind switch
+        {
+            "click"    when obj["selector"]?.GetValue<string>() is { Length: > 0 } sel
+                                  => new PageAction.Click(sel),
+            "waitFor"  when obj["selector"]?.GetValue<string>() is { Length: > 0 } sel
+                                  => new PageAction.WaitForSelector(sel, GetIntOrDefault(obj, "timeoutMs", 30_000)),
+            "wait"                => new PageAction.Wait(GetIntOrDefault(obj, "ms", 0)),
+            "evaluate" when obj["expression"]?.GetValue<string>() is { Length: > 0 } expr
+                                  => new PageAction.EvaluateExpression(expr),
+            _ => null
+        };
+    }
+
+    private static int GetIntOrDefault(JsonObject obj, string key, int fallback)
+    {
+        if (!obj.TryGetPropertyValue(key, out var node) || node is null) return fallback;
+        try { return node.GetValue<int>(); }
+        catch { return fallback; }
+    }
+
+    // Strip ```json ... ``` or ``` ... ``` if the model wrapped its JSON
+    // despite the system instruction. Same defence as LlmContentExtractor.
+    private static string StripJsonFences(string text)
+    {
+        var trimmed = text.Trim();
+        if (!trimmed.StartsWith("```", StringComparison.Ordinal)) return trimmed;
+        var newlineIdx = trimmed.IndexOf('\n');
+        if (newlineIdx < 0) return trimmed;
+        var body = trimmed[(newlineIdx + 1)..];
+        var endIdx = body.LastIndexOf("```", StringComparison.Ordinal);
+        if (endIdx > 0) body = body[..endIdx];
+        return body.Trim();
+    }
+}

--- a/WebReaper.AI/LlmActionResolverOptions.cs
+++ b/WebReaper.AI/LlmActionResolverOptions.cs
@@ -1,0 +1,35 @@
+namespace WebReaper.AI;
+
+/// <summary>
+/// Knobs for <see cref="LlmActionResolver"/> (ADR-0050). Defaults are
+/// cheap and deterministic: temperature 0, a 512-token response cap
+/// (the JSON object is tiny), and an 8192-token cap on the HTML the
+/// prompt carries (trimmed from the end if longer).
+/// </summary>
+/// <param name="Model">The model id passed to
+/// <c>ChatOptions.ModelId</c>. <c>null</c> means the chat client's
+/// default — most consumers configure the model at the
+/// <c>IChatClient</c> level and leave this null.</param>
+/// <param name="Temperature">Sampling temperature. Default 0 — action
+/// resolution is a deterministic task, the same intent should resolve
+/// to the same selector across pages with the same DOM.</param>
+/// <param name="MaxResponseTokens">Response token cap
+/// (<c>ChatOptions.MaxOutputTokens</c>). Default 512 — the resolver
+/// returns a small JSON object naming one action arm.</param>
+/// <param name="MaxHtmlChars">Maximum character count of the page HTML
+/// the prompt embeds (truncated from the end if longer). Default 32_000
+/// — roughly 8k tokens at the typical 4-chars-per-token rate. A
+/// character cap rather than a tokeniser-aware budget is deliberate:
+/// keeps the satellite zero-dependency beyond
+/// <c>Microsoft.Extensions.AI.Abstractions</c>. Lower for cost,
+/// raise for pages whose action-relevant chrome lives below the
+/// fold.</param>
+/// <param name="SystemPrompt">Override the default action-resolution
+/// system prompt. <c>null</c> uses the built-in prompt; supply a string
+/// to override entirely.</param>
+public sealed record LlmActionResolverOptions(
+    string? Model = null,
+    float Temperature = 0.0f,
+    int MaxResponseTokens = 512,
+    int MaxHtmlChars = 32_000,
+    string? SystemPrompt = null);

--- a/WebReaper.AI/LlmActionResolverRegistration.cs
+++ b/WebReaper.AI/LlmActionResolverRegistration.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.AI;
+using WebReaper.Builders;
+
+namespace WebReaper.AI;
+
+/// <summary>
+/// The satellite's <see cref="LlmActionResolver"/> registration extensions
+/// (ADR-0009 pattern). Wires the LLM-backed
+/// <see cref="WebReaper.Core.Actions.Abstract.IActionResolver"/> through the
+/// core's <c>WithActionResolver</c> seam (ADR-0050) so the resolver composes
+/// with every other registration without core changes.
+/// </summary>
+public static class LlmActionResolverRegistration
+{
+    /// <summary>
+    /// Register an LLM-backed action resolver (ADR-0050): the Puppeteer
+    /// transport invokes it on the first <c>SemanticAct(intent)</c> per crawl,
+    /// caches the resolved <see cref="WebReaper.Domain.PageActions.PageAction"/>
+    /// arm, and dispatches the cached arm on every subsequent same-intent
+    /// page. The deterministic path is the hot path; the LLM is the
+    /// fallback / repair.
+    /// </summary>
+    public static ScraperEngineBuilder WithLlmActionResolver(
+        this ScraperEngineBuilder builder,
+        IChatClient chatClient,
+        LlmActionResolverOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(chatClient);
+        return builder.WithActionResolver(new LlmActionResolver(chatClient, options));
+    }
+}

--- a/WebReaper.Puppeteer/BrowserPageLoadTransport.cs
+++ b/WebReaper.Puppeteer/BrowserPageLoadTransport.cs
@@ -4,6 +4,8 @@ using PuppeteerExtraSharp;
 using PuppeteerExtraSharp.Plugins.ExtraStealth;
 using PuppeteerSharp;
 using PuppeteerSharp.BrowserData;
+using WebReaper.Core.Actions.Abstract;
+using WebReaper.Core.Actions.Concrete;
 using WebReaper.Core.CookieStorage.Abstract;
 using WebReaper.Core.Loaders.Abstract;
 using WebReaper.Domain.PageActions;
@@ -30,11 +32,24 @@ public class BrowserPageLoadTransport : IPageLoadTransport
     private readonly ILogger _logger;
     private readonly SemaphoreSlim _downloadSemaphore = new(1, 1);
 
-    public BrowserPageLoadTransport(ICookiesStorage cookiesStorage, IProxyProvider? proxyProvider, ILogger logger)
+    // ADR-0050: the per-Spider SemanticAct cache + resolve sequencing live in
+    // the core SemanticActCoordinator so the lifecycle is unit-testable
+    // without IPage. The transport's dispatch just delegates.
+    private readonly SemanticActCoordinator _semanticActCoordinator;
+
+    /// <summary>Construct with the per-Spider collaborators (ADR-0009 factory
+    /// pattern). The <paramref name="actionResolver"/> resolves
+    /// <see cref="PageAction.SemanticAct"/> arms at runtime (ADR-0050).</summary>
+    public BrowserPageLoadTransport(
+        ICookiesStorage cookiesStorage,
+        IProxyProvider? proxyProvider,
+        ILogger logger,
+        IActionResolver actionResolver)
     {
         _cookiesStorage = cookiesStorage;
         _proxyProvider = proxyProvider;
         _logger = logger;
+        _semanticActCoordinator = new SemanticActCoordinator(actionResolver, logger);
     }
 
     public async Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
@@ -90,7 +105,7 @@ public class BrowserPageLoadTransport : IPageLoadTransport
                     "Performing page action {current} of {count}: {action}",
                     i, request.PageActions.Count - 1, pageAction.GetType().Name);
 
-                await PerformAsync(page, pageAction);
+                await PerformAsync(page, pageAction, cancellationToken);
             }
         }
 
@@ -102,8 +117,8 @@ public class BrowserPageLoadTransport : IPageLoadTransport
     // entry (the pre-0035 KeyNotFoundException for WaitForSelector /
     // EvaluateExpression — both reachable from PageActionBuilder). A future arm
     // with no case here is an actionable throw naming it, not a bare lookup
-    // miss mid-crawl.
-    private static async Task PerformAsync(IPage page, PageAction action)
+    // miss mid-crawl. ADR-0050 added SemanticAct.
+    private async Task PerformAsync(IPage page, PageAction action, CancellationToken cancellationToken)
     {
         switch (action)
         {
@@ -111,7 +126,7 @@ public class BrowserPageLoadTransport : IPageLoadTransport
                 await page.ClickAsync(a.Selector);
                 break;
             case PageAction.Wait a:
-                await Task.Delay(a.Milliseconds);
+                await Task.Delay(a.Milliseconds, cancellationToken);
                 break;
             case PageAction.ScrollToEnd:
                 await page.EvaluateExpressionAsync("window.scrollTo(0, document.body.scrollHeight);");
@@ -125,6 +140,16 @@ public class BrowserPageLoadTransport : IPageLoadTransport
                 break;
             case PageAction.WaitForNetworkIdle:
                 await page.WaitForNetworkIdleAsync();
+                break;
+            case PageAction.SemanticAct a:
+                // ADR-0050: cache + resolve sequencing lives in
+                // SemanticActCoordinator (core, unit-testable). The transport
+                // supplies the IPage-bound callbacks.
+                await _semanticActCoordinator.DispatchAsync(
+                    a.Intent,
+                    getHtmlAsync: _ => page.GetContentAsync(),
+                    dispatch: (arm, ct) => PerformAsync(page, arm, ct),
+                    cancellationToken);
                 break;
             default:
                 throw new ArgumentOutOfRangeException(

--- a/WebReaper.Puppeteer/PuppeteerPageLoaderBuilderExtensions.cs
+++ b/WebReaper.Puppeteer/PuppeteerPageLoaderBuilderExtensions.cs
@@ -22,9 +22,12 @@ public static class PuppeteerPageLoaderBuilderExtensions
     /// pages (<c>GetWithBrowser</c> / <c>FollowWithBrowser</c> /
     /// <c>PaginateWithBrowser</c>). Required since 7.0.0 (ADR-0009) — without
     /// it a Dynamic load throws an actionable message. First Dynamic run
-    /// downloads Chromium via Puppeteer.
+    /// downloads Chromium via Puppeteer. Since ADR-0050 the transport also
+    /// receives the registered
+    /// <see cref="WebReaper.Core.Actions.Abstract.IActionResolver"/> for
+    /// <c>SemanticAct</c> dispatch.
     /// </summary>
     public static ScraperEngineBuilder WithPuppeteerPageLoader(this ScraperEngineBuilder builder) =>
-        builder.WithLoadTransport((cookies, proxy, logger) =>
-            new BrowserPageLoadTransport(cookies, proxy, logger));
+        builder.WithLoadTransport((cookies, proxy, logger, actionResolver) =>
+            new BrowserPageLoadTransport(cookies, proxy, logger, actionResolver));
 }

--- a/WebReaper.Tests/WebReaper.AI.Tests/LlmActionResolverTests.cs
+++ b/WebReaper.Tests/WebReaper.AI.Tests/LlmActionResolverTests.cs
@@ -1,0 +1,293 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+using WebReaper.AI;
+using WebReaper.Domain.PageActions;
+
+namespace WebReaper.AI.Tests;
+
+// ADR-0050: the LLM-backed IActionResolver. Tests use a stub IChatClient
+// that returns a canned response — no real model call — so we can pin the
+// prompt composition, JSON parsing, every supported arm shape, the unknown
+// shape -> null contract, code-fence stripping, and the never-return-
+// SemanticAct discipline (a SemanticAct response is treated as unknown
+// because the prompt's whitelist doesn't include it).
+public class LlmActionResolverTests
+{
+    [Fact]
+    public async Task Returns_Click_for_click_intent_and_valid_json()
+    {
+        var chat = new StubChatClient(_ =>
+            "{\"kind\":\"click\",\"selector\":\".header-nav .signin\"}");
+
+        var result = await new LlmActionResolver(chat).ResolveAsync(
+            "click sign in", "<html><body><button class=\"signin\"/></body></html>");
+
+        var click = Assert.IsType<PageAction.Click>(result);
+        Assert.Equal(".header-nav .signin", click.Selector);
+    }
+
+    [Fact]
+    public async Task Returns_WaitForSelector_for_waitFor_intent_with_timeout()
+    {
+        var chat = new StubChatClient(_ =>
+            "{\"kind\":\"waitFor\",\"selector\":\".modal\",\"timeoutMs\":2500}");
+
+        var result = await new LlmActionResolver(chat).ResolveAsync(
+            "wait for the modal", "<html/>");
+
+        var wfs = Assert.IsType<PageAction.WaitForSelector>(result);
+        Assert.Equal(".modal", wfs.Selector);
+        Assert.Equal(2500, wfs.TimeoutMs);
+    }
+
+    [Fact]
+    public async Task WaitFor_without_timeoutMs_defaults_to_30s()
+    {
+        var chat = new StubChatClient(_ =>
+            "{\"kind\":\"waitFor\",\"selector\":\".modal\"}");
+
+        var result = await new LlmActionResolver(chat).ResolveAsync("wait", "<html/>");
+
+        var wfs = Assert.IsType<PageAction.WaitForSelector>(result);
+        Assert.Equal(30_000, wfs.TimeoutMs);
+    }
+
+    [Fact]
+    public async Task Returns_Wait_for_wait_intent_with_ms()
+    {
+        var chat = new StubChatClient(_ => "{\"kind\":\"wait\",\"ms\":500}");
+
+        var result = await new LlmActionResolver(chat).ResolveAsync("pause", "<html/>");
+
+        var wait = Assert.IsType<PageAction.Wait>(result);
+        Assert.Equal(500, wait.Milliseconds);
+    }
+
+    [Fact]
+    public async Task Returns_EvaluateExpression_for_evaluate_intent()
+    {
+        var chat = new StubChatClient(_ =>
+            "{\"kind\":\"evaluate\",\"expression\":\"document.title\"}");
+
+        var result = await new LlmActionResolver(chat).ResolveAsync("run js", "<html/>");
+
+        var eval = Assert.IsType<PageAction.EvaluateExpression>(result);
+        Assert.Equal("document.title", eval.Expression);
+    }
+
+    [Fact]
+    public async Task Returns_null_for_unknown_kind()
+    {
+        var chat = new StubChatClient(_ => "{\"kind\":\"submit\",\"selector\":\".form\"}");
+
+        var result = await new LlmActionResolver(chat).ResolveAsync("submit", "<html/>");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Returns_null_for_click_without_selector()
+    {
+        var chat = new StubChatClient(_ => "{\"kind\":\"click\"}");
+
+        var result = await new LlmActionResolver(chat).ResolveAsync("click", "<html/>");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Returns_null_for_empty_object()
+    {
+        var chat = new StubChatClient(_ => "{}");
+
+        var result = await new LlmActionResolver(chat).ResolveAsync("anything", "<html/>");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Returns_null_for_malformed_json()
+    {
+        var chat = new StubChatClient(_ => "not json at all");
+
+        var result = await new LlmActionResolver(chat).ResolveAsync("anything", "<html/>");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Resolver_never_returns_SemanticAct_unknown_kind_treats_as_null()
+    {
+        // The prompt's whitelist doesn't include "semanticAct" so even if the
+        // model tries to return one, ParseArm doesn't know it -> null. This
+        // closes the loop the SemanticActCoordinator also guards against.
+        var chat = new StubChatClient(_ =>
+            "{\"kind\":\"semanticAct\",\"intent\":\"do something else\"}");
+
+        var result = await new LlmActionResolver(chat).ResolveAsync("outer", "<html/>");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Strips_markdown_code_fences_with_language_tag()
+    {
+        var chat = new StubChatClient(_ =>
+            "```json\n{\"kind\":\"click\",\"selector\":\".x\"}\n```");
+
+        var result = await new LlmActionResolver(chat).ResolveAsync("click", "<html/>");
+
+        Assert.Equal(".x", Assert.IsType<PageAction.Click>(result).Selector);
+    }
+
+    [Fact]
+    public async Task Strips_bare_triple_fences_without_language_tag()
+    {
+        var chat = new StubChatClient(_ =>
+            "```\n{\"kind\":\"click\",\"selector\":\".x\"}\n```");
+
+        var result = await new LlmActionResolver(chat).ResolveAsync("click", "<html/>");
+
+        Assert.Equal(".x", Assert.IsType<PageAction.Click>(result).Selector);
+    }
+
+    [Fact]
+    public async Task Prompt_contains_intent_and_page_html()
+    {
+        List<ChatMessage>? capturedMessages = null;
+        var chat = new StubChatClient((msgs, _) =>
+        {
+            capturedMessages = msgs.ToList();
+            return "{\"kind\":\"click\",\"selector\":\".x\"}";
+        });
+
+        await new LlmActionResolver(chat).ResolveAsync(
+            "click sign in", "<html><body>SIGNIN BUTTON</body></html>");
+
+        Assert.NotNull(capturedMessages);
+        var userMsg = capturedMessages!.Single(m => m.Role == ChatRole.User).Text;
+        Assert.Contains("click sign in", userMsg);
+        Assert.Contains("SIGNIN BUTTON", userMsg);
+    }
+
+    [Fact]
+    public async Task System_prompt_whitelists_the_four_shapes()
+    {
+        List<ChatMessage>? capturedMessages = null;
+        var chat = new StubChatClient((msgs, _) =>
+        {
+            capturedMessages = msgs.ToList();
+            return "{}";
+        });
+
+        await new LlmActionResolver(chat).ResolveAsync("anything", "<html/>");
+
+        var systemMsg = capturedMessages!.Single(m => m.Role == ChatRole.System).Text;
+        Assert.Contains("click", systemMsg);
+        Assert.Contains("waitFor", systemMsg);
+        Assert.Contains("wait", systemMsg);
+        Assert.Contains("evaluate", systemMsg);
+        // The whitelist deliberately does NOT include semanticAct.
+        Assert.DoesNotContain("semanticAct", systemMsg);
+    }
+
+    [Fact]
+    public async Task Truncates_html_at_MaxHtmlChars()
+    {
+        var big = new string('x', 50_000);
+        string? capturedUser = null;
+        var chat = new StubChatClient((msgs, _) =>
+        {
+            capturedUser = msgs.Single(m => m.Role == ChatRole.User).Text;
+            return "{\"kind\":\"click\",\"selector\":\".x\"}";
+        });
+
+        await new LlmActionResolver(chat, new LlmActionResolverOptions(MaxHtmlChars: 1000))
+            .ResolveAsync("intent", big);
+
+        Assert.NotNull(capturedUser);
+        // user prompt has the intent line + the truncated HTML; cap on the
+        // raw HTML, not on the whole prompt — assert the trim happened.
+        Assert.True(capturedUser!.Length < 50_000, "expected HTML to be truncated below 50000 chars");
+    }
+
+    [Fact]
+    public async Task ChatOptions_carries_model_temperature_and_max_response_tokens()
+    {
+        ChatOptions? capturedOpts = null;
+        var chat = new StubChatClient((_, opts) =>
+        {
+            capturedOpts = opts;
+            return "{\"kind\":\"wait\",\"ms\":0}";
+        });
+
+        await new LlmActionResolver(chat, new LlmActionResolverOptions(
+            Model: "claude-sonnet-4-6", Temperature: 0.3f, MaxResponseTokens: 256))
+            .ResolveAsync("intent", "<html/>");
+
+        Assert.NotNull(capturedOpts);
+        Assert.Equal("claude-sonnet-4-6", capturedOpts!.ModelId);
+        Assert.Equal(0.3f, capturedOpts.Temperature);
+        Assert.Equal(256, capturedOpts.MaxOutputTokens);
+        Assert.NotNull(capturedOpts.ResponseFormat);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ResolveAsync_rejects_blank_intent(string? intent)
+    {
+        var chat = new StubChatClient(_ => "{}");
+        // ArgumentException family — ArgumentNullException for null,
+        // ArgumentException for empty/whitespace. ThrowsAnyAsync pins the
+        // family without coupling to the exact subtype.
+        await Assert.ThrowsAnyAsync<ArgumentException>(() =>
+            new LlmActionResolver(chat).ResolveAsync(intent!, "<html/>"));
+    }
+
+    [Fact]
+    public void Constructor_rejects_null_chat_client()
+    {
+        Assert.Throws<ArgumentNullException>(() => new LlmActionResolver(null!));
+    }
+
+    // Stub IChatClient — same shape as LlmContentExtractorTests' stub, kept
+    // local to this test for symmetry; extracting to a shared file would
+    // muddy the tier-1 / tier-2 split (each test class owns its own seam).
+    private sealed class StubChatClient : IChatClient
+    {
+        private readonly Func<IEnumerable<ChatMessage>, ChatOptions?, string> _respond;
+
+        public StubChatClient(Func<IEnumerable<ChatMessage>, string> respond)
+            : this((m, _) => respond(m)) { }
+
+        public StubChatClient(Func<IEnumerable<ChatMessage>, ChatOptions?, string> respond)
+            => _respond = respond;
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var text = _respond(messages, options);
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, text)));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => Empty(cancellationToken);
+
+        private static async IAsyncEnumerable<ChatResponseUpdate> Empty(
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+}

--- a/WebReaper.Tests/WebReaper.UnitTests/SemanticActDispatchTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/SemanticActDispatchTests.cs
@@ -1,0 +1,351 @@
+using System.Collections.Immutable;
+using WebReaper.Builders;
+using WebReaper.Core.Actions.Abstract;
+using WebReaper.Core.Actions.Concrete;
+using WebReaper.Domain;
+using WebReaper.Domain.PageActions;
+using WebReaper.Domain.Parsing;
+using WebReaper.Domain.Selectors;
+using WebReaper.Serialization;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0050: the SemanticAct arm + the resolve-once-per-crawl coordinator
+// pin every guarantee the ADR makes:
+//   * Cache HIT  -> reuse the cached arm, no resolver call.
+//   * Cache MISS -> call the resolver, dispatch, cache on success.
+//   * Cached-arm dispatch FAILURE -> invalidate + re-resolve (page changed).
+//   * Resolver returns null  -> SemanticActResolutionException.
+//   * Resolver THROWS        -> SemanticActResolutionException (wrapping).
+//   * Resolver returns SemanticAct (would loop) -> SemanticActResolutionException.
+//   * Freshly-resolved arm dispatch THROWS -> surface, do NOT cache.
+//   * OperationCanceledException always propagates, never wrapped.
+//
+// The coordinator lives in core (testable without IPage / Chromium); the
+// Puppeteer transport delegates each PageAction.SemanticAct case to it.
+public class SemanticActDispatchTests
+{
+    [Fact]
+    public async Task First_invocation_calls_resolver_then_dispatches_then_caches()
+    {
+        var resolver = new RecordingResolver(_ => new PageAction.Click(".btn"));
+        var coord = new SemanticActCoordinator(resolver, new CapturingLogger());
+        var dispatched = new List<PageAction>();
+
+        await coord.DispatchAsync(
+            "click sign in",
+            getHtmlAsync: _ => Task.FromResult("<html/>"),
+            dispatch: (a, _) => { dispatched.Add(a); return Task.CompletedTask; },
+            CancellationToken.None);
+
+        Assert.Equal(1, resolver.CallCount);
+        Assert.Equal(1, coord.CacheCount);
+        Assert.IsType<PageAction.Click>(Assert.Single(dispatched));
+        Assert.IsType<PageAction.Click>(coord.TryGetCached("click sign in"));
+    }
+
+    [Fact]
+    public async Task Subsequent_invocations_with_same_intent_are_cache_hits_no_resolver_call()
+    {
+        var resolver = new RecordingResolver(_ => new PageAction.Click(".btn"));
+        var coord = new SemanticActCoordinator(resolver, new CapturingLogger());
+        var dispatched = new List<PageAction>();
+        var htmlReads = 0;
+
+        for (var i = 0; i < 3; i++)
+        {
+            await coord.DispatchAsync(
+                "click sign in",
+                getHtmlAsync: _ => { htmlReads++; return Task.FromResult("<html/>"); },
+                dispatch: (a, _) => { dispatched.Add(a); return Task.CompletedTask; },
+                CancellationToken.None);
+        }
+
+        Assert.Equal(1, resolver.CallCount);  // resolver hit once
+        Assert.Equal(1, htmlReads);            // page HTML only read on miss
+        Assert.Equal(3, dispatched.Count);     // dispatched every time
+    }
+
+    [Fact]
+    public async Task Cached_arm_dispatch_failure_invalidates_cache_and_re_resolves()
+    {
+        var resolverArms = new Queue<PageAction>(new PageAction[]
+        {
+            new PageAction.Click(".stale"),  // first resolution
+            new PageAction.Click(".fresh")   // re-resolution after invalidation
+        });
+        var resolver = new RecordingResolver(_ => resolverArms.Dequeue());
+        var coord = new SemanticActCoordinator(resolver, new CapturingLogger());
+
+        // Dispatch 1: resolver returns .stale, dispatch succeeds, cached.
+        await coord.DispatchAsync(
+            "click",
+            getHtmlAsync: _ => Task.FromResult("<html/>"),
+            dispatch: (_, _) => Task.CompletedTask,
+            CancellationToken.None);
+        Assert.Equal(".stale", ((PageAction.Click)coord.TryGetCached("click")!).Selector);
+
+        // Dispatch 2: cached arm throws (selector now missing); coordinator
+        // invalidates + re-resolves; resolver returns .fresh; cached.
+        var dispatchAttempts = 0;
+        await coord.DispatchAsync(
+            "click",
+            getHtmlAsync: _ => Task.FromResult("<html/>"),
+            dispatch: (a, _) =>
+            {
+                dispatchAttempts++;
+                // First attempt (cached .stale) throws; second attempt (.fresh) succeeds.
+                if (dispatchAttempts == 1) throw new InvalidOperationException("selector missing");
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        Assert.Equal(2, resolver.CallCount);                    // resolver re-invoked
+        Assert.Equal(2, dispatchAttempts);                       // two dispatch attempts on this call
+        Assert.Equal(".fresh", ((PageAction.Click)coord.TryGetCached("click")!).Selector);
+    }
+
+    [Fact]
+    public async Task Resolver_returning_null_throws_SemanticActResolutionException()
+    {
+        var resolver = new RecordingResolver(_ => null);
+        var coord = new SemanticActCoordinator(resolver, new CapturingLogger());
+
+        var ex = await Assert.ThrowsAsync<SemanticActResolutionException>(() =>
+            coord.DispatchAsync(
+                "do the thing",
+                getHtmlAsync: _ => Task.FromResult("<html/>"),
+                dispatch: (_, _) => Task.CompletedTask,
+                CancellationToken.None));
+
+        Assert.Equal("do the thing", ex.Intent);
+        Assert.Equal(0, coord.CacheCount);
+    }
+
+    [Fact]
+    public async Task Resolver_throwing_throws_SemanticActResolutionException_with_inner()
+    {
+        var inner = new InvalidOperationException("LLM service down");
+        var resolver = new RecordingResolver(_ => throw inner);
+        var coord = new SemanticActCoordinator(resolver, new CapturingLogger());
+
+        var ex = await Assert.ThrowsAsync<SemanticActResolutionException>(() =>
+            coord.DispatchAsync(
+                "click",
+                getHtmlAsync: _ => Task.FromResult("<html/>"),
+                dispatch: (_, _) => Task.CompletedTask,
+                CancellationToken.None));
+
+        Assert.Same(inner, ex.InnerException);
+    }
+
+    [Fact]
+    public async Task Resolver_returning_SemanticAct_throws_no_loop()
+    {
+        var resolver = new RecordingResolver(_ => new PageAction.SemanticAct("inner"));
+        var coord = new SemanticActCoordinator(resolver, new CapturingLogger());
+
+        var ex = await Assert.ThrowsAsync<SemanticActResolutionException>(() =>
+            coord.DispatchAsync(
+                "outer",
+                getHtmlAsync: _ => Task.FromResult("<html/>"),
+                dispatch: (_, _) => Task.CompletedTask,
+                CancellationToken.None));
+
+        Assert.Equal("outer", ex.Intent);
+        Assert.NotNull(ex.InnerException);
+        Assert.Contains("must return a concrete arm", ex.InnerException!.Message);
+    }
+
+    [Fact]
+    public async Task Freshly_resolved_arm_dispatch_failure_surfaces_and_is_not_cached()
+    {
+        var dispatchEx = new InvalidOperationException("clicked nothing");
+        var resolver = new RecordingResolver(_ => new PageAction.Click(".btn"));
+        var coord = new SemanticActCoordinator(resolver, new CapturingLogger());
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            coord.DispatchAsync(
+                "click",
+                getHtmlAsync: _ => Task.FromResult("<html/>"),
+                dispatch: (_, _) => throw dispatchEx,
+                CancellationToken.None));
+
+        Assert.Same(dispatchEx, thrown);          // surfaced as-is, NOT wrapped
+        Assert.Equal(0, coord.CacheCount);         // dispatch-failure path doesn't cache
+    }
+
+    [Fact]
+    public async Task Cancellation_propagates_not_wrapped()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var resolver = new RecordingResolver(_ => throw new OperationCanceledException(cts.Token));
+        var coord = new SemanticActCoordinator(resolver, new CapturingLogger());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            coord.DispatchAsync(
+                "click",
+                getHtmlAsync: _ => Task.FromResult("<html/>"),
+                dispatch: (_, _) => Task.CompletedTask,
+                cts.Token));
+    }
+
+    [Fact]
+    public async Task Distinct_intents_keep_distinct_cache_entries()
+    {
+        var resolver = new RecordingResolver(intent => intent switch
+        {
+            "click sign in"      => new PageAction.Click(".signin"),
+            "wait for the modal" => new PageAction.WaitForSelector(".modal", 5000),
+            _ => null
+        });
+        var coord = new SemanticActCoordinator(resolver, new CapturingLogger());
+
+        await coord.DispatchAsync("click sign in",      _ => Task.FromResult("<html/>"), (_, _) => Task.CompletedTask, CancellationToken.None);
+        await coord.DispatchAsync("wait for the modal", _ => Task.FromResult("<html/>"), (_, _) => Task.CompletedTask, CancellationToken.None);
+        await coord.DispatchAsync("click sign in",      _ => Task.FromResult("<html/>"), (_, _) => Task.CompletedTask, CancellationToken.None);
+
+        Assert.Equal(2, coord.CacheCount);
+        Assert.Equal(2, resolver.CallCount);   // each unique intent resolved once
+    }
+
+    // The NullActionResolver is the default registration. It returns null,
+    // which the coordinator turns into SemanticActResolutionException — the
+    // misconfiguration is visible at the first SemanticAct dispatch.
+    [Fact]
+    public async Task NullActionResolver_returns_null_and_coordinator_throws()
+    {
+        var coord = new SemanticActCoordinator(NullActionResolver.Instance, new CapturingLogger());
+
+        await Assert.ThrowsAsync<SemanticActResolutionException>(() =>
+            coord.DispatchAsync(
+                "click",
+                getHtmlAsync: _ => Task.FromResult("<html/>"),
+                dispatch: (_, _) => Task.CompletedTask,
+                CancellationToken.None));
+    }
+
+    // SemanticAct round-trips through the codec exactly like every other arm
+    // (ADR-0035) — the intent string is the only field; the resolved arm is
+    // intentionally not persisted (would freeze the LLM's selector across
+    // crawls, defeating the re-resolve-on-cache-miss recovery path). The
+    // WebReaperJson Options aren't public, so the round-trip rides through
+    // SerializeJob / DeserializeJob.
+    [Fact]
+    public void Codec_round_trips_SemanticAct_via_Job()
+    {
+        var job = new Job(
+            "https://example.com",
+            ImmutableQueue<LinkPathSelector>.Empty,
+            ImmutableQueue<string>.Empty,
+            PageType: PageType.Dynamic,
+            PageActions: new List<PageAction> { new PageAction.SemanticAct("click sign in") });
+
+        var json = WebReaperJson.SerializeJob(job);
+        var roundTripped = WebReaperJson.DeserializeJob(json);
+
+        Assert.Contains("\"semanticAct\"", json);
+        Assert.Contains("\"click sign in\"", json);
+        var sa = Assert.IsType<PageAction.SemanticAct>(Assert.Single(roundTripped.PageActions!));
+        Assert.Equal("click sign in", sa.Intent);
+    }
+
+    [Fact]
+    public void Builder_SemanticAct_adds_the_arm()
+    {
+        var actions = new PageActionBuilder().SemanticAct("click sign in").Build();
+
+        var sa = Assert.IsType<PageAction.SemanticAct>(Assert.Single(actions));
+        Assert.Equal("click sign in", sa.Intent);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Builder_SemanticAct_rejects_blank_intent(string? intent)
+    {
+        // ArgumentException.ThrowIfNullOrWhiteSpace surfaces ArgumentNullException
+        // for null and ArgumentException for empty/whitespace — both fail the
+        // builder. ThrowsAny pins "an ArgumentException family throw" without
+        // baking the exact subtype into the test.
+        Assert.ThrowsAny<ArgumentException>(() => new PageActionBuilder().SemanticAct(intent!));
+    }
+
+    // The ScraperEngineBuilder.BuildAsync warning fires when the config carries
+    // any SemanticAct AND the default NullActionResolver is still in place.
+    // Surfaces the misconfiguration at build time, before the first dispatch
+    // throws SemanticActResolutionException at crawl time.
+    [Fact]
+    public async Task Build_warns_when_SemanticAct_in_config_with_default_resolver()
+    {
+        var logger = new CapturingLogger();
+        var schema = new Schema { new SchemaElement("title", "h1", DataType.String) };
+
+        await ScraperEngineBuilder
+            .CrawlWithBrowser(new[] { "https://example.com" },
+                ab => ab.SemanticAct("click sign in").Build())
+            .Extract(schema)
+            .WithLogger(logger)
+            .BuildAsync();
+
+        Assert.Contains(logger.Entries, e =>
+            e.Level == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            e.Message.Contains("SemanticAct", StringComparison.OrdinalIgnoreCase) &&
+            e.Message.Contains("WithActionResolver", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Build_does_not_warn_when_a_resolver_is_registered()
+    {
+        var logger = new CapturingLogger();
+        var schema = new Schema { new SchemaElement("title", "h1", DataType.String) };
+
+        await ScraperEngineBuilder
+            .CrawlWithBrowser(new[] { "https://example.com" },
+                ab => ab.SemanticAct("click sign in").Build())
+            .Extract(schema)
+            .WithLogger(logger)
+            .WithActionResolver(new RecordingResolver(_ => new PageAction.Click(".x")))
+            .BuildAsync();
+
+        Assert.DoesNotContain(logger.Entries, e =>
+            e.Level == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            e.Message.Contains("SemanticAct", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Build_does_not_warn_when_no_SemanticAct_in_config()
+    {
+        var logger = new CapturingLogger();
+        var schema = new Schema { new SchemaElement("title", "h1", DataType.String) };
+
+        await ScraperEngineBuilder
+            .Crawl("https://example.com")
+            .Extract(schema)
+            .WithLogger(logger)
+            .BuildAsync();
+
+        Assert.DoesNotContain(logger.Entries, e =>
+            e.Level == Microsoft.Extensions.Logging.LogLevel.Warning &&
+            e.Message.Contains("SemanticAct", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // A recording stub that satisfies IActionResolver synchronously; tests use
+    // it to count calls and provide canned responses (including throws).
+    private sealed class RecordingResolver : IActionResolver
+    {
+        private readonly Func<string, PageAction?> _resolve;
+        public int CallCount { get; private set; }
+
+        public RecordingResolver(Func<string, PageAction?> resolve) => _resolve = resolve;
+
+        public Task<PageAction?> ResolveAsync(
+            string intent, string pageHtml, CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(_resolve(intent));
+        }
+    }
+}

--- a/WebReaper/Builders/DistributedSpiderBuilder.cs
+++ b/WebReaper/Builders/DistributedSpiderBuilder.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
+using WebReaper.Core.Actions.Abstract;
 using WebReaper.Core.CookieStorage.Abstract;
 using WebReaper.Core.Loaders.Abstract;
 using WebReaper.Core.Parser.Abstract;
@@ -74,11 +75,26 @@ public class DistributedSpiderBuilder
     }
 
     /// <summary>Register the Dynamic (headless-browser) transport
-    /// (ADR-0004/0009). Core is HTTP-only by default.</summary>
+    /// (ADR-0004/0009/0050). Core is HTTP-only by default. The factory's
+    /// fourth argument is the <see cref="IActionResolver"/> for
+    /// <see cref="WebReaper.Domain.PageActions.PageAction.SemanticAct"/>
+    /// dispatch (ADR-0050).</summary>
     public DistributedSpiderBuilder WithLoadTransport(
-        Func<ICookiesStorage, IProxyProvider?, ILogger, IPageLoadTransport> dynamicTransportFactory)
+        Func<ICookiesStorage, IProxyProvider?, ILogger, IActionResolver, IPageLoadTransport> dynamicTransportFactory)
     {
         _spiderBuilder.WithLoadTransport(dynamicTransportFactory);
+        return this;
+    }
+
+    /// <summary>Register the <see cref="IActionResolver"/> the Puppeteer
+    /// transport invokes for <see cref="WebReaper.Domain.PageActions.PageAction.SemanticAct"/>
+    /// arms (ADR-0050). The default is the no-op resolver — dispatching a
+    /// <c>SemanticAct</c> with it throws
+    /// <see cref="WebReaper.Core.Actions.Concrete.SemanticActResolutionException"/>
+    /// at the transport.</summary>
+    public DistributedSpiderBuilder WithActionResolver(IActionResolver resolver)
+    {
+        _spiderBuilder.WithActionResolver(resolver);
         return this;
     }
 

--- a/WebReaper/Builders/PageActionBuilder.cs
+++ b/WebReaper/Builders/PageActionBuilder.cs
@@ -134,6 +134,23 @@ public class PageActionBuilder
         return this;
     }
 
+    /// <summary>
+    /// Resolve a natural-language <paramref name="intent"/> (e.g. "click sign in")
+    /// to a concrete <see cref="PageAction"/> at runtime via the registered
+    /// <see cref="WebReaper.Core.Actions.Abstract.IActionResolver"/> (ADR-0050).
+    /// The first dispatch on each crawl calls the resolver; the resolution is
+    /// cached per-crawl by intent string and reused on every subsequent
+    /// dispatch — the deterministic path is the hot path.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="intent"/> is
+    /// null/empty/whitespace.</exception>
+    public PageActionBuilder SemanticAct(string intent)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(intent);
+        _pageActions.Add(new PageAction.SemanticAct(intent));
+        return this;
+    }
+
     /// <summary>The accumulated actions, in the order they were added.</summary>
     public List<PageAction> Build()
     {

--- a/WebReaper/Builders/ScraperEngineBuilder.cs
+++ b/WebReaper/Builders/ScraperEngineBuilder.cs
@@ -5,6 +5,8 @@ using System.Text.Json.Nodes;
 using WebReaper.ConfigStorage.Abstract;
 using WebReaper.ConfigStorage.Concrete;
 using WebReaper.Core;
+using WebReaper.Core.Actions.Abstract;
+using WebReaper.Core.Actions.Concrete;
 using WebReaper.Core.CookieStorage.Abstract;
 using WebReaper.Core.LinkTracker.Abstract;
 using WebReaper.Core.LinkTracker.Concrete;
@@ -437,11 +439,39 @@ public class ScraperEngineBuilder
     /// dispatcher is unchanged.
     /// </summary>
     public ScraperEngineBuilder WithLoadTransport(
-        Func<ICookiesStorage, IProxyProvider?, ILogger, IPageLoadTransport> dynamicTransportFactory)
+        Func<ICookiesStorage, IProxyProvider?, ILogger, IActionResolver, IPageLoadTransport> dynamicTransportFactory)
     {
         SpiderBuilder.WithLoadTransport(dynamicTransportFactory);
         return this;
     }
+
+    /// <summary>
+    /// Register the <see cref="IActionResolver"/> the Puppeteer transport
+    /// invokes for <see cref="PageAction.SemanticAct"/> arms (ADR-0050) —
+    /// resolving the natural-language intent to a concrete arm at runtime, then
+    /// caching the resolution per crawl. Default is <see cref="NullActionResolver"/>:
+    /// dispatching a <c>SemanticAct</c> throws
+    /// <see cref="SemanticActResolutionException"/>, and a warning fires on
+    /// <see cref="BuildAsync"/> when the config contains any
+    /// <c>SemanticAct</c>. The LLM-backed implementation ships in the
+    /// <c>WebReaper.AI</c> satellite as <c>LlmActionResolver</c> — reach it
+    /// directly via the satellite's <c>WithLlmActionResolver</c>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="resolver"/> is null.</exception>
+    public ScraperEngineBuilder WithActionResolver(IActionResolver resolver)
+    {
+        ArgumentNullException.ThrowIfNull(resolver);
+        SpiderBuilder.WithActionResolver(resolver);
+        _actionResolver = resolver;
+        return this;
+    }
+
+    // ADR-0050: held here in addition to the SpiderBuilder so BuildAsync can
+    // detect the misconfiguration (SemanticAct in the config + the no-op
+    // default resolver) and log a warning before the crawl starts. The
+    // SpiderBuilder owns the runtime wiring; this is the build-time check.
+    private IActionResolver _actionResolver = NullActionResolver.Instance;
 
     /// <summary>Rotate over proxies from <paramref name="source"/>, keeping
     /// only those every <paramref name="validators"/> approves.</summary>
@@ -707,6 +737,14 @@ public class ScraperEngineBuilder
         // it. The engine still reads ConfigStorage itself in RunAsync.
         var config = ConfigBuilder.Build();
         SpiderBuilder.WithConfig(config);
+
+        // ADR-0050: surface the SemanticAct-without-a-real-resolver
+        // misconfiguration BEFORE the crawl starts. The transport would throw
+        // SemanticActResolutionException on the first dispatch anyway; this
+        // makes the cause visible at build time when the config + the resolver
+        // are both in hand.
+        WarnIfSemanticActWithoutResolver(config);
+
         var spider = SpiderBuilder.Build();
         await ConfigStorage.CreateConfigAsync(config);
 
@@ -715,5 +753,35 @@ public class ScraperEngineBuilder
             SpiderBuilder.DriverLinkTracker, SpiderBuilder.DriverSinks, Logger,
             SpiderBuilder.DriverPageProcessors,
             retryPolicy: SpiderBuilder.DriverRetryPolicy);
+    }
+
+    // ADR-0050: the SemanticAct-without-a-resolver detector. Reads both
+    // potential homes (start-page actions on the ScraperConfig + per-step
+    // actions on every LinkPathSelector) for any SemanticAct arm. Logs at
+    // Warning when one is found AND the resolver is still the default
+    // NullActionResolver — no exception, the throw happens at dispatch.
+    private void WarnIfSemanticActWithoutResolver(ScraperConfig config)
+    {
+        if (!ReferenceEquals(_actionResolver, NullActionResolver.Instance)) return;
+        if (!HasSemanticAct(config)) return;
+        Logger.LogWarning(
+            "Crawl config contains a PageAction.SemanticAct but no IActionResolver " +
+            "is registered. The SemanticAct dispatch will throw " +
+            "SemanticActResolutionException at the first dynamic page. Register a " +
+            "resolver via ScraperEngineBuilder.WithActionResolver(...) — or, for " +
+            "the LLM-backed default, add the WebReaper.AI satellite and call " +
+            ".WithLlmActionResolver(chatClient).");
+    }
+
+    private static bool HasSemanticAct(ScraperConfig config)
+    {
+        if (config.PageActions is { } start && start.Any(a => a is PageAction.SemanticAct))
+            return true;
+        foreach (var selector in config.LinkPathSelectors)
+        {
+            if (selector.PageActions is { } actions && actions.Any(a => a is PageAction.SemanticAct))
+                return true;
+        }
+        return false;
     }
 }

--- a/WebReaper/Builders/SpiderBuilder.cs
+++ b/WebReaper/Builders/SpiderBuilder.cs
@@ -2,6 +2,8 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Text.Json.Nodes;
+using WebReaper.Core.Actions.Abstract;
+using WebReaper.Core.Actions.Concrete;
 using WebReaper.Core.CookieStorage.Abstract;
 using WebReaper.Core.CookieStorage.Concrete;
 using WebReaper.Core.LinkTracker.Abstract;
@@ -55,7 +57,14 @@ internal class SpiderBuilder
     // WithMaxAge wires a real cache.
     private IPageCache PageCache { get; set; } = new NullPageCache();
 
-    private Func<ICookiesStorage, IProxyProvider?, ILogger, IPageLoadTransport>? DynamicPageLoadTransportFactory { get; set; }
+    private Func<ICookiesStorage, IProxyProvider?, ILogger, IActionResolver, IPageLoadTransport>? DynamicPageLoadTransportFactory { get; set; }
+
+    // ADR-0050: the per-Spider IActionResolver collaborator that resolves
+    // SemanticAct(intent) arms to concrete PageActions. NullActionResolver is
+    // the default — dispatching SemanticAct with it registered throws at the
+    // transport, and a warning fires at engine construction if the config
+    // contains any SemanticAct.
+    private IActionResolver ActionResolver { get; set; } = NullActionResolver.Instance;
 
     private IProxyProvider? ProxyProvider { get; set; }
 
@@ -179,9 +188,20 @@ internal class SpiderBuilder
     /// message (<see cref="BrowserNotConfiguredPageLoadTransport"/>).
     /// </summary>
     public SpiderBuilder WithLoadTransport(
-        Func<ICookiesStorage, IProxyProvider?, ILogger, IPageLoadTransport> dynamicTransportFactory)
+        Func<ICookiesStorage, IProxyProvider?, ILogger, IActionResolver, IPageLoadTransport> dynamicTransportFactory)
     {
         DynamicPageLoadTransportFactory = dynamicTransportFactory;
+        return this;
+    }
+
+    /// <summary>Register the <see cref="IActionResolver"/> the Puppeteer
+    /// transport invokes for <see cref="PageAction.SemanticAct"/> arms
+    /// (ADR-0050). The default is <see cref="NullActionResolver"/>; the
+    /// LLM-backed implementation ships in the <c>WebReaper.AI</c> satellite.</summary>
+    public SpiderBuilder WithActionResolver(IActionResolver actionResolver)
+    {
+        ArgumentNullException.ThrowIfNull(actionResolver);
+        ActionResolver = actionResolver;
         return this;
     }
 
@@ -281,7 +301,7 @@ internal class SpiderBuilder
             new HttpPageLoadTransport(CookieStorage, ProxyProvider, Logger),
             DynamicPageLoadTransportFactory is null
                 ? new BrowserNotConfiguredPageLoadTransport()
-                : DynamicPageLoadTransportFactory(CookieStorage, ProxyProvider, Logger),
+                : DynamicPageLoadTransportFactory(CookieStorage, ProxyProvider, Logger, ActionResolver),
             Logger,
             PageCache);
 

--- a/WebReaper/Core/Actions/Abstract/IActionResolver.cs
+++ b/WebReaper/Core/Actions/Abstract/IActionResolver.cs
@@ -1,0 +1,43 @@
+using WebReaper.Domain.PageActions;
+
+namespace WebReaper.Core.Actions.Abstract;
+
+/// <summary>
+/// The resolution seam for <see cref="PageAction.SemanticAct"/> (ADR-0050):
+/// given a natural-language <paramref name="intent"/> string and the current
+/// page's rendered HTML, return a concrete <see cref="PageAction"/> arm
+/// (typically <see cref="PageAction.Click"/>,
+/// <see cref="PageAction.WaitForSelector"/>, <see cref="PageAction.Wait"/>, or
+/// <see cref="PageAction.EvaluateExpression"/>) — or <c>null</c> if the intent
+/// cannot be resolved against the current page.
+/// <para>
+/// The default registration is the no-op <c>NullActionResolver</c> (returns
+/// <c>null</c>); the LLM-backed implementation ships in the
+/// <c>WebReaper.AI</c> satellite as <c>LlmActionResolver</c>. Resolutions are
+/// cached per crawl by intent string in the Puppeteer transport — the
+/// resolver is invoked once per intent, and the cached concrete arm is
+/// dispatched on every subsequent page (the deterministic path is the hot
+/// path, ADR-0046 / ADR-0047 pattern applied to actions).
+/// </para>
+/// <para>
+/// The resolver must never return a <see cref="PageAction.SemanticAct"/> arm
+/// (that would loop); the transport surfaces an unsupported return as a
+/// <see cref="Concrete.SemanticActResolutionException"/>.
+/// </para>
+/// </summary>
+public interface IActionResolver
+{
+    /// <summary>
+    /// Resolve <paramref name="intent"/> to a concrete <see cref="PageAction"/>
+    /// against <paramref name="pageHtml"/>, or <c>null</c> when the intent
+    /// cannot be matched.
+    /// </summary>
+    /// <param name="intent">The natural-language intent string from
+    /// <see cref="PageAction.SemanticAct.Intent"/>.</param>
+    /// <param name="pageHtml">The rendered HTML of the current page.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<PageAction?> ResolveAsync(
+        string intent,
+        string pageHtml,
+        CancellationToken cancellationToken = default);
+}

--- a/WebReaper/Core/Actions/Concrete/NullActionResolver.cs
+++ b/WebReaper/Core/Actions/Concrete/NullActionResolver.cs
@@ -1,0 +1,29 @@
+using WebReaper.Core.Actions.Abstract;
+using WebReaper.Domain.PageActions;
+
+namespace WebReaper.Core.Actions.Concrete;
+
+/// <summary>
+/// The no-op default <see cref="IActionResolver"/> (ADR-0050): always returns
+/// <c>null</c>. Dispatching a <see cref="PageAction.SemanticAct"/> with this
+/// resolver registered throws <see cref="SemanticActResolutionException"/> at
+/// the transport. A warning is logged at engine construction
+/// (<see cref="WebReaper.Builders.ScraperEngineBuilder.BuildAsync"/>) when the
+/// crawl's selector chain contains a <c>SemanticAct</c> and no other resolver
+/// has been registered, so the misconfiguration is visible before the crawl
+/// starts rather than at the first dispatch.
+/// </summary>
+internal sealed class NullActionResolver : IActionResolver
+{
+    /// <summary>The shared singleton — stateless.</summary>
+    public static readonly NullActionResolver Instance = new();
+
+    private NullActionResolver() { }
+
+    /// <inheritdoc/>
+    public Task<PageAction?> ResolveAsync(
+        string intent,
+        string pageHtml,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<PageAction?>(null);
+}

--- a/WebReaper/Core/Actions/Concrete/SemanticActCoordinator.cs
+++ b/WebReaper/Core/Actions/Concrete/SemanticActCoordinator.cs
@@ -1,0 +1,127 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using WebReaper.Core.Actions.Abstract;
+using WebReaper.Domain.PageActions;
+
+namespace WebReaper.Core.Actions.Concrete;
+
+/// <summary>
+/// The per-Spider SemanticAct cache + resolve-coordinator (ADR-0050). Lifted
+/// out of the Puppeteer transport so the cache lifecycle and the
+/// resolve-then-dispatch sequencing live in core, unit-testable without an
+/// <c>IPage</c> or Chromium. A dynamic-page transport (the Puppeteer satellite,
+/// or any future browser transport) instantiates one per Spider and delegates
+/// each <see cref="PageAction.SemanticAct"/> case to <see cref="DispatchAsync"/>,
+/// supplying two <c>IPage</c>-bound callbacks: <c>getHtmlAsync</c> (only invoked
+/// on a cache miss) and <c>dispatch</c> (invokes the satellite's per-arm
+/// dispatcher on the resolved concrete arm).
+/// <para>
+/// The asymmetric retry semantics from ADR-0050 live here:
+/// </para>
+/// <list type="bullet">
+///   <item><description>Cached arm dispatch throws ⇒ invalidate + re-resolve.</description></item>
+///   <item><description>Resolver returns <c>null</c> ⇒ throw <see cref="SemanticActResolutionException"/>.</description></item>
+///   <item><description>Freshly-resolved arm dispatch throws ⇒ surface; the Spider-level retry policy (ADR-0026) catches the whole job if appropriate.</description></item>
+/// </list>
+/// </summary>
+public sealed class SemanticActCoordinator
+{
+    private readonly IActionResolver _resolver;
+    private readonly ILogger _logger;
+    private readonly ConcurrentDictionary<string, PageAction> _cache = new();
+
+    /// <summary>Construct with the per-Spider <paramref name="resolver"/> and
+    /// <paramref name="logger"/>.</summary>
+    /// <exception cref="ArgumentNullException">either argument is null.</exception>
+    public SemanticActCoordinator(IActionResolver resolver, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(resolver);
+        ArgumentNullException.ThrowIfNull(logger);
+        _resolver = resolver;
+        _logger = logger;
+    }
+
+    /// <summary>The count of cached intents (test seam).</summary>
+    public int CacheCount => _cache.Count;
+
+    /// <summary>The cached arm for an intent, or <c>null</c> on miss (test seam).</summary>
+    public PageAction? TryGetCached(string intent)
+        => _cache.TryGetValue(intent, out var v) ? v : null;
+
+    /// <summary>
+    /// Resolve <paramref name="intent"/> cache-first and call
+    /// <paramref name="dispatch"/> with the resolved arm. The
+    /// <paramref name="getHtmlAsync"/> callback is only invoked on a cache
+    /// miss — the deterministic path doesn't re-read page HTML.
+    /// </summary>
+    public async Task DispatchAsync(
+        string intent,
+        Func<CancellationToken, Task<string>> getHtmlAsync,
+        Func<PageAction, CancellationToken, Task> dispatch,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(intent);
+        ArgumentNullException.ThrowIfNull(getHtmlAsync);
+        ArgumentNullException.ThrowIfNull(dispatch);
+
+        if (_cache.TryGetValue(intent, out var cached))
+        {
+            try
+            {
+                _logger.LogDebug(
+                    "SemanticAct cache hit for intent '{intent}' -> {arm}",
+                    intent, cached.GetType().Name);
+                await dispatch(cached, cancellationToken);
+                return;
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation is not a resolution failure; keep the cache.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Cached SemanticAct arm for intent '{intent}' failed on this page; invalidating and re-resolving.",
+                    intent);
+                _cache.TryRemove(intent, out _);
+                // fall through to the resolver
+            }
+        }
+
+        var html = await getHtmlAsync(cancellationToken);
+
+        PageAction? resolved;
+        try
+        {
+            resolved = await _resolver.ResolveAsync(intent, html, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new SemanticActResolutionException(intent, ex);
+        }
+
+        if (resolved is null)
+            throw new SemanticActResolutionException(intent);
+
+        // A resolver returning SemanticAct would loop the dispatcher. Surface
+        // it as the typed exception — same shape as the null case.
+        if (resolved is PageAction.SemanticAct)
+            throw new SemanticActResolutionException(intent,
+                new InvalidOperationException(
+                    "IActionResolver.ResolveAsync returned a SemanticAct — resolvers must return a concrete arm."));
+
+        // Cache only on successful dispatch. A throw below propagates and the
+        // resolution is not cached.
+        await dispatch(resolved, cancellationToken);
+        _cache[intent] = resolved;
+        _logger.LogInformation(
+            "SemanticAct intent '{intent}' resolved to {arm} and cached for this crawl.",
+            intent, resolved.GetType().Name);
+    }
+}

--- a/WebReaper/Core/Actions/Concrete/SemanticActResolutionException.cs
+++ b/WebReaper/Core/Actions/Concrete/SemanticActResolutionException.cs
@@ -1,0 +1,33 @@
+namespace WebReaper.Core.Actions.Concrete;
+
+/// <summary>
+/// Thrown by the Puppeteer transport (ADR-0050) when a
+/// <see cref="Domain.PageActions.PageAction.SemanticAct"/> dispatch hits the
+/// resolver and the resolver returns <c>null</c> — the intent could not be
+/// matched against the current page. A typed exception so consumers catch the
+/// failure mode explicitly rather than a bare
+/// <see cref="NullReferenceException"/>.
+/// </summary>
+public sealed class SemanticActResolutionException : Exception
+{
+    /// <summary>The unresolved intent string.</summary>
+    public string Intent { get; }
+
+    /// <summary>Construct with the unresolved intent.</summary>
+    public SemanticActResolutionException(string intent)
+        : base($"The IActionResolver returned null for SemanticAct intent '{intent}' — " +
+               "no concrete action could be matched against the current page. " +
+               "Either register a different IActionResolver " +
+               "(ScraperEngineBuilder.WithActionResolver) or remove the SemanticAct.")
+    {
+        Intent = intent;
+    }
+
+    /// <summary>Construct with the unresolved intent and a wrapped cause.</summary>
+    public SemanticActResolutionException(string intent, Exception innerException)
+        : base($"The IActionResolver threw while resolving SemanticAct intent '{intent}'. " +
+               "See the inner exception for details.", innerException)
+    {
+        Intent = intent;
+    }
+}

--- a/WebReaper/Domain/PageActions/PageAction.cs
+++ b/WebReaper/Domain/PageActions/PageAction.cs
@@ -6,7 +6,7 @@ namespace WebReaper.Domain.PageActions;
 /// the WebReaper.Puppeteer satellite (ADR-0009).
 /// <para>
 /// A closed sum (ADR-0035, the ADR-0001 closed-sum pattern, as <c>CrawlOutcome</c>):
-/// exactly one of the six nested arms, each carrying its own typed parameters —
+/// exactly one of the seven nested arms, each carrying its own typed parameters —
 /// no untyped <c>object[]</c>, no separate discriminant enum. Construct only via
 /// the nested arms; the union is not extensible.
 /// </para>
@@ -39,4 +39,19 @@ public abstract record PageAction
 
     /// <summary>Wait until the page's network activity goes idle.</summary>
     public sealed record WaitForNetworkIdle : PageAction;
+
+    /// <summary>
+    /// Resolve a natural-language intent to a concrete <see cref="PageAction"/>
+    /// arm at runtime (ADR-0050). The first dispatch on each crawl invokes the
+    /// registered <see cref="WebReaper.Core.Actions.Abstract.IActionResolver"/>
+    /// — typically an LLM in the <c>WebReaper.AI</c> satellite — to produce a
+    /// selector-based arm (<see cref="Click"/>, <see cref="WaitForSelector"/>,
+    /// <see cref="Wait"/>, or <see cref="EvaluateExpression"/>); the resolution
+    /// is cached per-crawl by intent string, so every subsequent dispatch of
+    /// the same intent runs the cached deterministic arm with no LLM call. The
+    /// LLM-as-proposer / deterministic-as-decider pattern (ADR-0046, ADR-0047)
+    /// applied to the action surface.
+    /// </summary>
+    /// <param name="Intent">The natural-language intent (e.g. "click sign in").</param>
+    public sealed record SemanticAct(string Intent) : PageAction;
 }

--- a/WebReaper/Serialization/Converters/PageActionJsonConverter.cs
+++ b/WebReaper/Serialization/Converters/PageActionJsonConverter.cs
@@ -42,6 +42,15 @@ internal static class PageActionCodec
             case PageAction.WaitForNetworkIdle:
                 w.WriteString("type", "waitForNetworkIdle");
                 break;
+            case PageAction.SemanticAct x:
+                // ADR-0050: persisted as the intent string only — the
+                // resolved arm is a per-crawl runtime concern and is
+                // intentionally never persisted (it'd freeze the LLM's
+                // selector across crawls, defeating the resolve-on-cache-miss
+                // recovery path).
+                w.WriteString("type", "semanticAct");
+                w.WriteString("intent", x.Intent);
+                break;
             default:
                 throw new JsonException($"unhandled PageAction arm '{a.GetType().Name}'");
         }
@@ -51,7 +60,7 @@ internal static class PageActionCodec
     public static PageAction Read(ref Utf8JsonReader r)
     {
         if (r.TokenType != JsonTokenType.StartObject) throw new JsonException("expected object");
-        string? type = null, selector = null, expression = null;
+        string? type = null, selector = null, expression = null, intent = null;
         int ms = 0, timeoutMs = 0;
         while (r.Read() && r.TokenType != JsonTokenType.EndObject)
         {
@@ -62,6 +71,7 @@ internal static class PageActionCodec
                 case "type": type = r.GetString(); break;
                 case "selector": selector = r.GetString(); break;
                 case "expression": expression = r.GetString(); break;
+                case "intent": intent = r.GetString(); break;
                 case "ms": ms = r.GetInt32(); break;
                 case "timeoutMs": timeoutMs = r.GetInt32(); break;
                 default: r.Skip(); break;
@@ -75,6 +85,7 @@ internal static class PageActionCodec
             "evaluateExpression" => new PageAction.EvaluateExpression(Require(expression, "expression", type)),
             "waitForSelector" => new PageAction.WaitForSelector(Require(selector, "selector", type), timeoutMs),
             "waitForNetworkIdle" => new PageAction.WaitForNetworkIdle(),
+            "semanticAct" => new PageAction.SemanticAct(Require(intent, "intent", type)),
             _ => throw new JsonException($"unknown PageAction type '{type}'")
         };
     }

--- a/docs/adr/0050-semantic-page-actions.md
+++ b/docs/adr/0050-semantic-page-actions.md
@@ -2,11 +2,13 @@
 
 ## Status
 
-**Proposed — design pass only** (2026-05-24). Sibling pattern to ADR-0047
+**Accepted — implemented** (2026-05-24). Sibling pattern to ADR-0047
 (self-healing extractor) applied to the *action* surface instead of the
 *extraction* surface. Lands on the closed sum from ADR-0035 and the
-satellite-resolver pattern from ADR-0044/0047. No implementation in this
-ADR; the proposal lives or dies on the design call.
+satellite-resolver pattern from ADR-0044/0047. Implementation slice
+shipped in the 10.0.0 wave: see the file ledger in §Implementation
+(all items landed). Two cache-key forks deferred to v2 per
+"Considered options" (a) and (e).
 
 ## Context
 
@@ -319,41 +321,116 @@ per intent — too much for v1. Lives in v2 when a real caller surfaces.
 
 ## Implementation
 
-Proposed; no code in this ADR. The implementation slice would be:
+Shipped. The slice landed exactly as designed, with three notable
+refinements recorded inline:
 
-1. **`WebReaper/Domain/PageActions/PageAction.cs`** — add `SemanticAct`.
-2. **`WebReaper/Builders/PageActionBuilder.cs`** — `.SemanticAct(intent)`.
-3. **`WebReaper/Core/Actions/Abstract/IActionResolver.cs`** — new seam.
+1. **`WebReaper/Domain/PageActions/PageAction.cs`** —
+   `SemanticAct(string Intent)` added as the seventh sealed-record arm;
+   the doc updated "six arms" → "seven arms".
+2. **`WebReaper/Builders/PageActionBuilder.cs`** — `.SemanticAct(intent)`
+   with `ArgumentException.ThrowIfNullOrWhiteSpace`.
+3. **`WebReaper/Core/Actions/Abstract/IActionResolver.cs`** — new
+   public seam (one method).
 4. **`WebReaper/Core/Actions/Concrete/NullActionResolver.cs`** —
-   warning default.
-5. **`WebReaper/Builders/ScraperEngineBuilder.cs`** —
-   `WithActionResolver(IActionResolver)`.
-6. **`WebReaper.Puppeteer/PageActionExecutor.cs`** — `SemanticAct`
-   dispatch case + the per-crawl cache.
+   `internal sealed`, singleton `Instance` (stateless), returns `null`.
+5. **`WebReaper/Core/Actions/Concrete/SemanticActResolutionException.cs`**
+   — the typed exception the transport throws (two ctors: bare intent,
+   intent + inner). Public.
+6. **`WebReaper/Core/Actions/Concrete/SemanticActCoordinator.cs`** —
+   *refinement.* The cache lifecycle + resolve-then-dispatch sequencing
+   lives in core as a *public* class instead of being buried in the
+   Puppeteer transport. This makes the asymmetric-retry contract
+   unit-testable from core without `IPage` or Chromium (the
+   `SemanticActDispatchTests` exercise it directly with stub callbacks).
+   The transport instantiates one per Spider and delegates each
+   `SemanticAct` case to `DispatchAsync`, supplying two `IPage`-bound
+   callbacks (`getHtmlAsync` for the cache-miss HTML read; `dispatch`
+   for the per-arm dispatcher). Per ADR-0023's deletion test, the
+   coordinator passes Tier-1 (named by a documented consumer — the
+   Puppeteer satellite — and would be inherited / re-used by any other
+   transport satellite).
 7. **`WebReaper/Serialization/Converters/PageActionJsonConverter.cs`**
-   — `SemanticAct` codec entry (the ADR-0035 codec, one new arm).
-8. **`WebReaper.AI/LlmActionResolver.cs`** — the satellite resolver.
-9. **`WebReaper.AI/LlmActionResolverOptions.cs`** — options record.
-10. **`WebReaper.AI/LlmActionResolverRegistration.cs`** —
-    `WithLlmActionResolver`.
-11. **`WebReaper.Tests/WebReaper.UnitTests/SemanticActDispatchTests.cs`**
-    — pins cache hit/miss, null-resolver throws,
-    dispatch-failure-invalidates-cache.
-12. **`WebReaper.Tests/WebReaper.AI.Tests/LlmActionResolverTests.cs`**
-    — pins prompt shape, JSON parsing, arm construction.
-13. **CONTEXT.md** — Action resolver term + relationship line.
-14. **CHANGELOG.md** — under a future 10.1.0 entry (post-10.0.0 wave).
+   — the `"semanticAct"` codec entry with the `"intent"` field. The
+   resolved arm is deliberately *not* persisted — see the inline comment
+   in the converter (would freeze the LLM's selector across crawls,
+   defeating the re-resolve-on-cache-miss recovery path).
+8. **`WebReaper/Builders/SpiderBuilder.cs`** — `WithActionResolver`
+   setter, `IActionResolver` field with `NullActionResolver.Instance`
+   default, and the widened factory. *Refinement:*
+   `WithLoadTransport`'s factory delegate widens from 3 to 4 arguments
+   (the 4th is `IActionResolver`). This is the design's one breaking
+   edge — the public registration seam's contract changes. The
+   `WebReaper.Puppeteer` satellite is updated in lockstep; called out
+   in the 10.0.0 CHANGELOG.
+9. **`WebReaper/Builders/DistributedSpiderBuilder.cs`** — the
+   distributed-worker reduced shell gained the same `WithActionResolver`
+   + widened `WithLoadTransport`.
+10. **`WebReaper/Builders/ScraperEngineBuilder.cs`** —
+    `WithActionResolver` pass-through; `BuildAsync` runs the
+    `WarnIfSemanticActWithoutResolver` check (scans
+    `ScraperConfig.PageActions` + every `LinkPathSelector.PageActions`)
+    and logs a Warning if any `SemanticAct` is present with the default
+    `NullActionResolver` still registered.
+11. **`WebReaper.Puppeteer/PuppeteerPageLoaderBuilderExtensions.cs`** —
+    `WithPuppeteerPageLoader()` passes the resolver through.
+12. **`WebReaper.Puppeteer/BrowserPageLoadTransport.cs`** — the
+    dispatch case delegates to a per-transport `SemanticActCoordinator`;
+    `PerformAsync` is now instance + carries the `CancellationToken`
+    (`Task.Delay` honours it); the closed-sum `default` throw still
+    names a future unhandled arm actionably.
+13. **`WebReaper.AI/LlmActionResolver.cs`** — the satellite resolver.
+    Prompt whitelists four shapes (`click` / `waitFor` / `wait` /
+    `evaluate`) — *not* `semanticAct`. JSON parse → `ParseArm` (the
+    closed whitelist); unknown shape → `null` (the transport surfaces
+    the typed exception). Code-fence stripping mirrors
+    `LlmContentExtractor`. *Refinement:* token-budget options use a
+    character cap (`MaxHtmlChars`, default 32_000), not a token cap —
+    keeps the satellite zero-dependency beyond
+    `Microsoft.Extensions.AI.Abstractions`.
+14. **`WebReaper.AI/LlmActionResolverOptions.cs`** — `record` with
+    `Model`, `Temperature` (default 0), `MaxResponseTokens` (default
+    512), `MaxHtmlChars` (default 32_000), `SystemPrompt`.
+15. **`WebReaper.AI/LlmActionResolverRegistration.cs`** —
+    `WithLlmActionResolver` extension method, mirrors
+    `WithLlmExtractor`.
+16. **`WebReaper.Tests/WebReaper.UnitTests/SemanticActDispatchTests.cs`**
+    — 18 tests pinning every ADR-named guarantee on the coordinator
+    (cache hit, cache miss, cached-arm-failure invalidates,
+    resolver-returns-null throws, resolver-throws wraps,
+    resolver-returns-SemanticAct surfaces, dispatch-failure doesn't
+    cache, cancellation propagates, distinct intents distinct cache
+    entries), the codec round-trip via `Job`, the builder, and the
+    `BuildAsync` warning forks (warning fires / doesn't fire when no
+    SemanticAct / doesn't fire when a resolver is registered).
+17. **`WebReaper.Tests/WebReaper.AI.Tests/LlmActionResolverTests.cs`** —
+    20 tests pinning every arm-shape resolution, the unknown-kind null
+    contract, the never-returns-SemanticAct discipline, the code-fence
+    stripping, the truncation, and the `ChatOptions` flow-through.
+18. **CONTEXT.md** — new "Semantic action / Action resolver" term in
+    the AI-native section + a new Relationships line linking the cache
+    lifecycle to the proposer-validator pattern (ADR-0046, ADR-0047).
+19. **CLAUDE.md** — the AI-native architecture paragraph extended from
+    "ADR-0040..0049" to "ADR-0040..0050" with the semantic-actions
+    bullet; two new gotchas (the dispatch-throws-without-a-resolver
+    contract and the `WithLoadTransport` factory-signature breaking
+    edge).
+20. **CHANGELOG.md** — 10.0.0 entry top line updated to "AI-native
+    funnel + semantic actions"; "24 ADRs" → "25 ADRs"; new bullet under
+    "AI-native wave".
 
-### Guardrails (when implemented)
+### Guardrails (verified at slice end)
 
-- `dotnet build WebReaper.sln` — 0 errors; the ADR-0035 exhaustiveness
-  analyzer fires on the new arm until every dispatch switch has it.
-- `dotnet test WebReaper.Tests/WebReaper.UnitTests` — all pass.
-- `dotnet test WebReaper.Tests/WebReaper.AI.Tests` — all pass.
-- `dotnet test WebReaper.Tests/WebReaper.Puppeteer.Tests` — all pass
-  (the dispatch test lands here).
-- `WebReaper.AotSmokeTest` — unchanged (no AOT-touching code added to
-  core).
+- `dotnet build WebReaper.sln` — 0 errors, 23 pre-existing warnings.
+- `dotnet test WebReaper.Tests/WebReaper.UnitTests` — **256/256** pass
+  (was 238; +18 from `SemanticActDispatchTests`).
+- `dotnet test WebReaper.Tests/WebReaper.AI.Tests` — **42/42** pass
+  (was 22; +20 from `LlmActionResolverTests`).
+- `dotnet test WebReaper.Tests/WebReaper.Puppeteer.Tests` — 4/4 pass
+  (the existing wire-up smoke is unchanged; the dispatch logic moved
+  to core where it's testable without Chromium).
+- `WebReaper.AotSmokeTest` — unchanged graph; core gained one
+  `SemanticActCoordinator` + the `ConcurrentDictionary` it owns, no
+  AOT-hostile reflection.
 
 ## References
 


### PR DESCRIPTION
Implements [ADR-0050](docs/adr/0050-semantic-page-actions.md) (Status: Proposed → **Accepted — implemented**). Self-heal stops being one feature and becomes a *project-level pattern*: the seat the extraction wave shipped on ([ADR-0046](docs/adr/0046-extraction-router.md), [ADR-0047](docs/adr/0047-self-healing-selectors.md), [ADR-0048](docs/adr/0048-change-tracking-processor.md)) now ships on the *action* surface too.

Stagehand's `observe(\"click sign in\") → act(cached_action)` shape in WebReaper terms: first dynamic page pays the LLM to resolve the intent to a concrete arm (`Click(\".header-nav .signin\")`); the transport dispatches it, caches the resolution by intent string; every subsequent same-intent page dispatches the cached arm with no LLM call. The deterministic path is the hot path.

## What this PR adds

### Public surface
- \`PageAction.SemanticAct(string Intent)\` — the **seventh** closed-sum arm on the existing \`PageAction\` (ADR-0035 sum, the dock).
- \`PageActionBuilder.SemanticAct(intent)\` — the fluent entry; rejects null/whitespace.
- \`IActionResolver\` — the new resolution seam (one method, \`ResolveAsync(intent, pageHtml, ct)\` → concrete \`PageAction\` or null).
- \`ScraperEngineBuilder.WithActionResolver(IActionResolver)\` + \`DistributedSpiderBuilder.WithActionResolver(IActionResolver)\` — the registration sugar.
- \`SemanticActCoordinator\` — public, Tier-1 in core. Cache lifecycle + the asymmetric-retry contract. Named by the Puppeteer satellite (a documented consumer), so per ADR-0023's deletion test it belongs on the public surface. **This is the refinement that lets us unit-test the contract from core without IPage/Chromium.**
- \`SemanticActResolutionException\` — typed exception the transport throws on a null/wrong resolver return.
- \`WebReaper.AI.LlmActionResolver\` + \`LlmActionResolverOptions\` + \`WithLlmActionResolver(IChatClient, options?)\` — the LLM-backed satellite implementation.

### Behaviour at runtime
1. Cache miss ⇒ resolver called with intent + page HTML ⇒ concrete arm ⇒ dispatched ⇒ **cached on success**.
2. Cache hit ⇒ dispatch cached arm; no resolver call, no page-HTML read.
3. Cached arm dispatch throws ⇒ invalidate + re-resolve (the page changed since we cached).
4. Resolver returns \`null\` ⇒ \`SemanticActResolutionException\`.
5. Resolver throws ⇒ \`SemanticActResolutionException\` wrapping the cause.
6. Resolver returns \`SemanticAct\` (would loop) ⇒ \`SemanticActResolutionException\`.
7. Freshly-resolved arm dispatch throws ⇒ surface as-is, **not cached** (the LLM proposed something the page couldn't honour; the Spider-level retry policy, [ADR-0026](docs/adr/0026-retry-policy-seam.md), catches the whole job if appropriate).
8. \`OperationCanceledException\` always propagates, never wrapped, cache untouched.

A \`SemanticAct\` in the config without a registered resolver fires a Warning at \`BuildAsync\` (scans \`ScraperConfig.PageActions\` + every \`LinkPathSelector.PageActions\`), naming \`WithActionResolver\` / \`WithLlmActionResolver\`.

## The one breaking edge (10.0.0 wave)

\`WithLoadTransport(...)\` 's factory delegate widens from 3 to 4 arguments: \`(cookies, proxy, logger)\` → \`(cookies, proxy, logger, **actionResolver**)\`. The in-tree \`WebReaper.Puppeteer\` satellite is updated in lockstep. An out-of-tree transport satellite would need to accept the resolver argument even if it ignores it. Documented in the [CHANGELOG](CHANGELOG.md) and the [ADR](docs/adr/0050-semantic-page-actions.md). Batched into the unreleased 10.0.0 wave per user direction (\"don't release yet, work on AI features\").

## Refinements vs the proposed ADR

Three small changes from the design pass, each recorded inline in [the ADR's Implementation section](docs/adr/0050-semantic-page-actions.md#implementation):

1. **Coordinator is core, public, not buried in the Puppeteer transport.** Makes the cache + sequencing unit-testable from \`WebReaper.UnitTests\` without IPage/Chromium. The transport delegates each \`SemanticAct\` case to \`SemanticActCoordinator.DispatchAsync\` with two \`IPage\`-bound callbacks (\`getHtmlAsync\`, \`dispatch\`). The proposed design had it as Puppeteer-internal; lifting it into core is the right call per ADR-0023's deletion test (\"named by a documented consumer / inherited by a satellite ⇒ Tier-1\").
2. **\`WithLoadTransport\` factory widens to 4 args.** The proposed ADR named the satellite-needs-the-resolver problem but left the wiring open. The widened-factory choice is the smallest surface change that keeps the registration seam single — alternatives (a parallel 4-arg overload; a context-object factory; resolver-stored-statically) all introduced more surface or more state.
3. **\`MaxHtmlChars\` (default 32_000) instead of a token cap.** The proposed ADR said \"MaxHtmlTokens\" (8192). A character cap keeps the satellite zero-dependency beyond \`Microsoft.Extensions.AI.Abstractions\` (no tokeniser); 32_000 chars is ~8k tokens at the typical 4-chars-per-token rate.

## Verification

| Suite | Before | After | Delta |
|---|---|---|---|
| \`dotnet build WebReaper.sln\` | 0 errors, 23 pre-existing warnings | 0 errors, 23 pre-existing warnings | — |
| \`WebReaper.UnitTests\` | 238 | **256** | +18 (\`SemanticActDispatchTests\`) |
| \`WebReaper.AI.Tests\` | 22 | **42** | +20 (\`LlmActionResolverTests\`) |
| \`WebReaper.Puppeteer.Tests\` | 4 | 4 | — (dispatch logic moved to core) |
| \`WebReaper.{Cli,Sqlite,Mongo,Cosmos,AzureServiceBus,Extraction.Generators}.Tests\` | green | green | — |
| \`WebReaper.AotSmokeTest\` Native-AOT publish | 0 IL/AOT warnings | 0 IL/AOT warnings | — |
| \`WebReaper.AotSmokeTest\` runtime | ALL PASS | ALL PASS | — |

## Usage

\`\`\`csharp
using Microsoft.Extensions.AI;
using WebReaper.AI;
using WebReaper.Builders;

var engine = await ScraperEngineBuilder
    .CrawlWithBrowser(new[] { \"https://example.com\" },
        ab => ab.SemanticAct(\"click sign in\").Build())
    .Extract(schema)
    .WithPuppeteerPageLoader()
    .WithLlmActionResolver(chatClient)  // ← the AI satellite's sugar
    .BuildAsync();

await engine.RunAsync();
\`\`\`

## Out of scope (v2 deferrals per the ADR)

- Per-host cache keying (\`(intent, host)\`); v1 is intent-string-only, single-host crawl assumed.
- Persistent satellite resolvers (the cache is in-memory per Spider; a Redis/File satellite is a future ADR).
- Multi-candidate resolution (resolver returns one arm; Stagehand's \`observe → candidates → pick\` is deferred).
- \`IActionVerifier\` seam for semantic effect verification (\"after click sign in, \`.user-menu\` should appear\").

🤖 Generated with [Claude Code](https://claude.com/claude-code)