### PR TITLE
ADR-0051 HITL refinements: Fork 5 satellite sugar + Fork 8 durable agent state flip + Fork 11 peer grounding

### DIFF
--- a/docs/adr/0051-agent-crawl-driver.md
+++ b/docs/adr/0051-agent-crawl-driver.md
@@ -51,6 +51,11 @@ This ADR establishes:
    ADR-0025); two-line one-liner via static `Agent.Run` sugar.
 5. **`WebReaper.AI.LlmAgentBrain`** — the LLM-backed default brain,
    bound to `Microsoft.Extensions.AI`'s `IChatClient`.
+6. **`IAgentRunStore`** — durable agent run state seam (HITL flip
+   2026-05-24); sibling to `IScheduler` / `IVisitedLinkTracker` /
+   `IScraperConfigStorage` / `ICookiesStorage`. InMemory default +
+   File adapter in core; Redis / Mongo / Sqlite / Cosmos satellites
+   in lockstep.
 
 ### Why this is a fourth dock, not a recolour of an existing one
 
@@ -174,7 +179,11 @@ sinks, processors, visited-link tracker), plus the `IAgentBrain` and
 1 — the LLM is the bottleneck and decisions are causal):
 
 ```text
-seed scheduler with the start URL
+resolve runId (caller-supplied via .WithRunId, or auto-generated)
+load snapshot from IAgentRunStore (resume if found; fresh if not)
+if resuming: restore History/VisitedUrls/Records/CurrentUrl;
+             seed scheduler with CurrentUrl; step := LastDecidedStep
+else:        seed scheduler with the start URL; step := 0
 loop:
   fetch the current job from the scheduler        (drained ⇒ stop)
   if step >= MaxSteps                              ⇒ stop (cap)
@@ -183,6 +192,7 @@ loop:
   build the AgentState snapshot
   decision := await brain.DecideAsync(state, ct)
   record the decision in history
+  await store.SaveStepAsync(runId, decision, postState, ct)  // PERSIST FIRST
   switch decision:
     Extract(schema, _)   → run schema through registered IContentExtractor;
                            record → page-processor pipeline → sinks; step++
@@ -192,6 +202,7 @@ loop:
                            re-load the post-action page; step++
     Stop(_)              → break
   loop
+return AgentResult { RunId, Records, TerminationReason, History, ... }
 ```
 
 Termination conditions, ordered by precedence:
@@ -208,6 +219,7 @@ termination reason, the decision history):
 
 ```csharp
 public sealed record AgentResult(
+    string RunId,
     IReadOnlyList<JsonObject> Records,
     string TerminationReason,
     IReadOnlyList<AgentDecision> History,
@@ -293,6 +305,28 @@ public static class LlmAgentBrainRegistration
 }
 ```
 
+Plus the maximally-AI-first satellite sugar — the firecrawl-shaped one-liner
+the AI-first headline reaches for. Sibling to core `Agent.RunAsync`; this
+overload accepts an `IChatClient` directly and constructs the
+`LlmAgentBrain` itself, so the caller never names a brain type:
+
+```csharp
+public static class LlmAgent
+{
+    public static Task<AgentResult> RunAsync(
+        string startUrl,
+        string goal,
+        IChatClient chatClient,
+        LlmAgentBrainOptions? brainOptions = null,
+        Action<AgentEngineBuilder>? configure = null,
+        CancellationToken cancellationToken = default);
+}
+```
+
+Usage: `await LlmAgent.RunAsync("https://shop.com", "get all products", openAiClient);`
+— three args, zero ceremony. Lives in **`WebReaper.AI/LlmAgent.cs`** (the
+satellite, not core, since `IChatClient` is the LLM dep ADR-0009 quarantines).
+
 The default registration on `AgentEngineBuilder` when no brain is
 supplied is **`NullAgentBrain`** (internal singleton, returns
 `Stop("no IAgentBrain registered")` — fails fast at the first step,
@@ -302,6 +336,119 @@ still the null one. Same shape as ADR-0050's `NullActionResolver`
 warning, sharpened to a throw because the agent is *useless* without a
 brain — unlike a Crawl driver, where a SemanticAct without a resolver
 might still be a 90%-useful crawl).
+
+### 6. `IAgentRunStore` — durable agent run state (HITL 2026-05-24 flip)
+
+The fourth load-bearing piece of agent state. Sibling to `IScheduler`,
+`IVisitedLinkTracker`, `IScraperConfigStorage`, `ICookiesStorage` —
+follows the exact same InMemory-default + durable-adapter pattern those
+seams use. Pluggable so the agent matches the rest of the library's
+distributed-first lineage.
+
+Lives in **`WebReaper/Core/Agent/Abstract/IAgentRunStore.cs`** (public
+interface):
+
+```csharp
+public interface IAgentRunStore
+{
+    ValueTask<AgentRunSnapshot?> LoadAsync(
+        string runId, CancellationToken cancellationToken = default);
+
+    ValueTask SaveStepAsync(
+        string runId,
+        AgentDecision decision,
+        AgentRunSnapshot postState,
+        CancellationToken cancellationToken = default);
+
+    ValueTask DeleteAsync(
+        string runId, CancellationToken cancellationToken = default);
+}
+```
+
+The snapshot — public record in **`WebReaper/Domain/Agent/AgentRunSnapshot.cs`**:
+
+```csharp
+public sealed record AgentRunSnapshot(
+    string Goal,
+    int LastDecidedStep,
+    IReadOnlyList<AgentDecision> History,
+    IReadOnlyList<string> VisitedUrls,
+    IReadOnlyList<JsonObject> Records,
+    string? CurrentUrl);
+```
+
+**Semantics — persist-before-execute, at-least-once on effects:**
+
+1. Brain returns `decision` for step *N*.
+2. Engine calls `SaveStepAsync(runId, decision, postState)` *before* executing.
+3. Engine executes (Extract → sinks; Follow → enqueue; Act → page action; Stop → break).
+4. On crash mid-execute, resume re-executes step *N*'s effect — sinks may
+   see a duplicate record for that step (caller's sink-idempotency concern).
+5. On resume, engine loads the snapshot, restores `History`/`VisitedUrls`/
+   `Records`/`CurrentUrl`, and starts deciding step *N + 1*.
+
+Brain decisions are exactly-once (history is the load-bearing record; re-
+deciding would produce a different `History` and break the run's reasoning).
+Effect execution is at-least-once. **New gotcha for CLAUDE.md: "Resumable
+agent runs require idempotent sinks; the change-tracking processor (ADR-0048)
+deduplicates on hash, so it composes cleanly."**
+
+**Default + built-in adapters (both in v1 core):**
+- `InMemoryAgentRunStore` — internal, default. Dictionary keyed by `runId`.
+  Per-process; suitable for the firecrawl-shaped one-liner where the call
+  is short-lived and awaited.
+- `FileAgentRunStore` — internal, registered via
+  `.WithFileAgentRunStore(directory)`. JSON Lines per run; one file per
+  `runId`. Satisfies ADR-0036's ≥2-adapter rule.
+
+**Satellite adapters (all four in v10, lockstep):**
+- `WebReaper.Redis.RedisAgentRunStore` + `.WithRedisAgentRunStore(...)`
+- `WebReaper.Mongo.MongoAgentRunStore` + `.WithMongoAgentRunStore(...)`
+- `WebReaper.Sqlite.SqliteAgentRunStore` + `.WithSqliteAgentRunStore(...)`
+- `WebReaper.Cosmos.CosmosAgentRunStore` + `.WithCosmosAgentRunStore(...)`
+
+`WebReaper.AzureServiceBus` is queue-shaped, doesn't fit a key-value
+snapshot store — skipped intentionally.
+
+**Builder additions on `AgentEngineBuilder`:**
+
+```csharp
+public AgentEngineBuilder WithRunStore(IAgentRunStore store);
+public AgentEngineBuilder WithRunId(string runId);   // resume if saved
+public AgentEngineBuilder WithNewRun();              // force fresh runId
+public AgentEngineBuilder WithFileAgentRunStore(string directory);
+// + satellite extensions WithRedis/Mongo/Sqlite/Cosmos as above
+```
+
+**Resume default:** calling `.WithRunId("foo")` with a saved snapshot
+resumes from `LastDecidedStep + 1`. Fresh runs use a new `runId` or
+`.WithNewRun()` (engine auto-generates a `runId` if neither set). Matches
+Firecrawl's `jobId` model — caller holds the run identifier; the store
+holds the state.
+
+**Static-sugar overloads:**
+
+```csharp
+// Core (Agent.cs):
+public static Task<AgentResult> Agent.RunAsync(
+    string startUrl, string goal, IAgentBrain brain,
+    Action<AgentEngineBuilder>? configure = null,
+    CancellationToken ct = default);
+
+public static Task<AgentResult> Agent.ResumeAsync(
+    string runId, IAgentBrain brain, IAgentRunStore store,
+    Action<AgentEngineBuilder>? configure = null,
+    CancellationToken ct = default);
+
+// Satellite (LlmAgent.cs):
+public static Task<AgentResult> LlmAgent.RunAsync(
+    string startUrl, string goal, IChatClient chatClient, ...);
+
+public static Task<AgentResult> LlmAgent.ResumeAsync(
+    string runId, IChatClient chatClient, IAgentRunStore store, ...);
+```
+
+`AgentResult` gains a `string RunId` field so the caller can resume later.
 
 ## Considered options (per fork)
 
@@ -343,7 +490,7 @@ might still be a 90%-useful crawl).
 |---|---|---|
 | (a) `ScraperEngineBuilder.AsAgent(goal, brain)` | Add a method on the existing builder. | Rejected. `BuildAsync()` returns `ScraperEngine`, not `AgentEngine` — would need a generic terminal or a second `BuildAgentAsync()`. Conflates two driver types on one builder; misleads the consumer about which one they're building. |
 | (b) New `AgentEngineBuilder` (sibling) | **Recommended.** The two-seam pattern from ADR-0009 (`DistributedSpiderBuilder`) and ADR-0025 (the structural guarantee lives on the *type*, not on a method choice). | The agent and the crawl driver are genuinely different things; two builders make that explicit. Satellite extensions that target both can `this AgentEngineBuilder` + `this ScraperEngineBuilder` (the in-tree examples — Redis, Mongo, Sqlite — would naturally extend both). |
-| (c) New static `Agent.Run(goal, startUrl, brain, options)` only — no builder | One-liner only; no fluent shape. | Rejected as the sole entry. **Kept as sugar over (b).** The one-liner covers the demo case; the builder covers configuration. |
+| (c) New static `Agent.Run(goal, startUrl, brain, options)` only — no builder | One-liner only; no fluent shape. | Rejected as the sole entry. **Kept as sugar over (b).** The one-liner covers the demo case; the builder covers configuration. **Refinement (HITL 2026-05-24):** the satellite adds a second sugar layer — `WebReaper.AI.LlmAgent.RunAsync(startUrl, goal, chatClient, configure?)` — which constructs the `LlmAgentBrain` internally so the firecrawl-shaped caller never touches it. Core `Agent.RunAsync` stays brain-explicit (AOT-clean, no LLM dep); the satellite sugar is where the maximally-AI-first three-arg one-liner lives. |
 
 ### Fork 6 — termination: Stop only vs Stop + hard caps
 
@@ -361,10 +508,22 @@ might still be a 90%-useful crawl).
 
 ### Fork 8 — state persistence: durable vs in-process
 
+Originally proposed: in-process v1, deferred durable to v2. **Verdict flipped
+2026-05-24 after HITL grilling** — the architectural-consistency argument
+landed. See "Why the flip" below.
+
 | Option | What | Verdict |
 |---|---|---|
-| (a) Durable agent state (resumable runs) | Persist `AgentState` after each step; resume across restarts. | Rejected (deferred to v2). Big design: interrupted decisions (partial LLM call), retried decisions (the cost-amortisation question), the Schema-evolution-across-restart question. Wait for a real caller. |
-| (b) In-process only | **Recommended.** Start over on restart. The `IPageCache` (ADR-0041) already covers the page-load amortisation. | Matches the v1 discipline; resumability comes later if asked. |
+| (a) Durable agent state (resumable runs) | `IAgentRunStore` seam; persist the brain's decision before the engine executes it; on resume start at `LastDecidedStep + 1`. Effects re-run at-least-once. | **Recommended (flipped 2026-05-24).** Matches every other WebReaper state seam (`IScheduler`, `IVisitedLinkTracker`, `IScraperConfigStorage`, `ICookiesStorage` are all InMemory + durable adapters); agent state being in-memory-only would be the *one* inconsistent piece of an otherwise distributed-first library. See §Decision §6. |
+| (b) In-process only | Start over on restart. `IPageCache` (ADR-0041) covers the page-load amortisation. | Rejected. Was the original recommendation. Two grounded counter-arguments landed: (1) **architectural consistency** — every other seam pluggable durable/in-memory, agent state alone in-memory is glaring; (2) **peer-pattern landscape** is split — Firecrawl persists agent state server-side (`/v2/agent/{jobId}` poll model); Stagehand keeps the agent loop in-process but persists *browser* state via Browserbase Contexts (`context: { id, persist: true }`). WebReaper is distributed-first by lineage (since 7.x), so the Firecrawl shape is the closer fit. |
+
+**Why the flip:** the original "shape from the second adapter" appeal (ADR-0036)
+assumed durability was a *future* differentiator. Grounding showed it is a
+*current* one — the AI-native pitch for a .NET enterprise library means
+"agent state survives `kubectl rollout restart`," and a v10 that ships an
+in-memory-only agent driver alongside fully-durable crawl state is the
+inconsistency callers will notice first. Breaking-change OK for v10
+(this *is* the AI-native version cut).
 
 ### Fork 9 — result aggregation: per-Extract vs final-record
 
@@ -386,6 +545,23 @@ might still be a 90%-useful crawl).
 |---|---|---|
 | (a) Sequential (degree=1) | **Recommended.** One step at a time; brain decisions are causal. | The LLM is the bottleneck, and decisions are *intentionally* sequential — the brain's next decision depends on the last extract. |
 | (b) Parallel (degree=N) | Multiple agent steps in flight. | Rejected. Parallel brain decisions are not causally ordered; the brain can't reason about a state it hasn't observed. Per-page parallelism is the Crawl driver's strength — the agent is the opposite by design. |
+
+**Peer-pattern grounding (HITL 2026-05-24).** All three reference peers
+run a single agent loop sequentially; parallelism lives at the
+multi-agent / multi-session level, not within one agent's steps.
+**Firecrawl** — `/v2/agent` runs one agent autonomously server-side;
+the client polls a `jobId`. They explicitly price "Parallel Agents"
+(Spark-1 Fast, 10 credits per cell) — i.e., run N independent agents
+concurrently from the client, not parallel steps within one.
+**Browserbase** — explicit `Promise.allSettled` / `asyncio.gather`
+patterns for parallel *sessions* with enforced Max Concurrent Browsers
++ Session Creation Limit; no within-agent parallelism (Browserbase
+isn't an agent layer). **Stagehand** — `agent.execute({ instruction,
+maxSteps: N })` is single-shot; their own docs recommend "break into
+smaller tasks with success checking" for complex work (sequential
+decomposition). Multi-agent parallelism in Stagehand is achieved by
+running multiple Browserbase sessions in parallel. The orthogonal
+multi-agent-orchestration axis is captured here as v2 deferral (i).
 
 ### Fork 12 — visited-link semantics
 
@@ -412,16 +588,19 @@ might still be a 90%-useful crawl).
   REPOSITIONING-PLAN's *funnel-then-agent* narrative.
 - **AOT-clean by design.** The brain is a seam; the LLM impl is in the
   `WebReaper.AI` satellite (ADR-0009 quarantine). Core gains:
-  `AgentDecision` (a closed sum record), `IAgentBrain`, `AgentEngine`,
-  `AgentEngineBuilder`, `AgentState`, `AgentResult`,
-  `NullAgentBrain`. No reflection, no `Microsoft.Extensions.AI`
+  `AgentDecision` (a closed sum record), `IAgentBrain`, `IAgentRunStore`,
+  `AgentEngine`, `AgentEngineBuilder`, `AgentState`, `AgentResult`,
+  `AgentRunSnapshot`, `NullAgentBrain`, `InMemoryAgentRunStore`,
+  `FileAgentRunStore`. No reflection, no `Microsoft.Extensions.AI`
   dependency in core.
 - **Composition with existing pieces is the headline.** The agent reuses
   every loader, cache, extractor, action resolver, sink, processor, and
-  visited-link tracker. The only new collaborator the agent demands is
-  the brain — the rest is registered exactly the way a `ScraperEngine`
-  would. Satellite extensions (`.WithRedis*` / `.WithMongoDb*` etc.) get
-  `this AgentEngineBuilder` overloads in lockstep.
+  visited-link tracker. The two new collaborators the agent demands are
+  the **brain** (`IAgentBrain`) and the **run store** (`IAgentRunStore`)
+  — the rest is registered exactly the way a `ScraperEngine` would.
+  Satellite extensions (`.WithRedis*` / `.WithMongoDb*` / `.WithSqlite*`
+  / `.WithCosmos*`) get `this AgentEngineBuilder` overloads in lockstep
+  — agent-run-store adapters ride those extensions.
 - **The `IContentExtractor` seam (ADR-0039) is the agent's extraction
   authority.** When the brain returns `Extract(schema)`, the engine runs
   the *registered* extractor with that schema. If `WithLlmExtractor` is
@@ -434,6 +613,18 @@ might still be a 90%-useful crawl).
   Puppeteer transport's `SemanticActCoordinator` (ADR-0050) handles it
   exactly as in the Crawl path — cache and all. The agent gets
   selector-caching for free.
+- **`IAgentRunStore` makes the agent distributed-first like the rest of
+  the library.** (HITL flip 2026-05-24.) Every other piece of crawl
+  state — `IScheduler`, `IVisitedLinkTracker`, `IScraperConfigStorage`,
+  `ICookiesStorage` — has been InMemory-default + durable adapters
+  since 7.x; the agent's run state now matches. v10 ships the seam +
+  in-memory default + File adapter + Redis / Mongo / Sqlite / Cosmos
+  satellites in lockstep. Resumable agent runs survive process
+  restarts; the firecrawl-shaped one-liner caller never sees the
+  `runId` unless they ask. **Breaking change for v10** — this is the
+  AI-native version cut, and an in-memory-only agent driver alongside
+  fully-durable crawl state would be the inconsistency callers notice
+  first.
 
 ## Bounded scope (v1)
 
@@ -444,7 +635,7 @@ tables, collected for the v2-deferral ledger:
 - **(b) Summarised history** — capped raw history in v1.
 - **(c) Schema-pre-fixed agent** — `.WithSchema(schema)` once a caller asks.
 - **(d) `IBudget` seam** — options-only enforcement in v1.
-- **(e) Durable agent state** — in-process only in v1; resume is "start over".
+- ~~**(e) Durable agent state** — in-process only in v1; resume is "start over".~~ **Flipped 2026-05-24 — shipped in v1.** `IAgentRunStore` seam + `InMemoryAgentRunStore` default + `FileAgentRunStore` + four satellite adapters (Redis, Mongo, Sqlite, Cosmos). See Fork 8 and §Decision §6.
 - **(f) `IAgentValidator` seam** — brain self-evaluates in v1.
 - **(g) Parallel agent steps** — sequential in v1 (rejected, may stay rejected).
 - **(h) Distributed agent** — agent runs in-process in v1; sharing a
@@ -462,38 +653,106 @@ tables, collected for the v2-deferral ledger:
 
 ## Implementation (slice, when accepted)
 
+**Core domain + seams:**
+
 1. **`WebReaper/Domain/Agent/AgentDecision.cs`** — closed-sum record.
 2. **`WebReaper/Domain/Agent/AgentState.cs`** — public state record.
-3. **`WebReaper/Domain/Agent/AgentResult.cs`** — public result record.
-4. **`WebReaper/Core/Agent/Abstract/IAgentBrain.cs`** — new seam.
-5. **`WebReaper/Core/Agent/Concrete/NullAgentBrain.cs`** — internal
+3. **`WebReaper/Domain/Agent/AgentResult.cs`** — public result record
+   (includes `string RunId` so the caller can resume).
+4. **`WebReaper/Domain/Agent/AgentRunSnapshot.cs`** — public snapshot
+   record persisted by `IAgentRunStore`.
+5. **`WebReaper/Core/Agent/Abstract/IAgentBrain.cs`** — brain seam.
+6. **`WebReaper/Core/Agent/Abstract/IAgentRunStore.cs`** — durable-state
+   seam (HITL flip 2026-05-24; §Decision §6).
+
+**Core implementations:**
+
+7. **`WebReaper/Core/Agent/Concrete/NullAgentBrain.cs`** — internal
    default, returns `Stop`.
-6. **`WebReaper/Core/Agent/Concrete/AgentEngine.cs`** — the driver loop.
-7. **`WebReaper/Core/Agent/Concrete/AgentEngineOptions.cs`** —
-   `MaxSteps`, `MaxBudgetTokens`.
-8. **`WebReaper/Builders/AgentEngineBuilder.cs`** — public builder
-   (Static `Start` + fluent + `BuildAsync`).
-9. **`WebReaper/Agent.cs`** — static `Agent.RunAsync(...)` sugar.
-10. **`WebReaper.AI/LlmAgentBrain.cs`** — satellite implementation.
-11. **`WebReaper.AI/LlmAgentBrainOptions.cs`** — options record.
-12. **`WebReaper.AI/LlmAgentBrainRegistration.cs`** — `WithLlmBrain`.
-13. **`WebReaper.Tests/WebReaper.UnitTests/AgentEngineDriverTests.cs`**
+8. **`WebReaper/Core/Agent/Concrete/InMemoryAgentRunStore.cs`** —
+   internal default `IAgentRunStore`; dictionary keyed by `runId`.
+9. **`WebReaper/Core/Agent/Concrete/FileAgentRunStore.cs`** — internal
+   File adapter; JSON Lines per run, one file per `runId`. Satisfies
+   ADR-0036 ≥2-adapter rule.
+10. **`WebReaper/Core/Agent/Concrete/AgentEngine.cs`** — driver loop.
+    Persist-before-execute semantics (§Decision §6).
+11. **`WebReaper/Core/Agent/Concrete/AgentEngineOptions.cs`** —
+    `MaxSteps`, `MaxBudgetTokens`.
+12. **`WebReaper/Builders/AgentEngineBuilder.cs`** — public builder.
+    Includes `.WithRunStore`, `.WithRunId`, `.WithNewRun`,
+    `.WithFileAgentRunStore` alongside `.WithBrain` etc.
+13. **`WebReaper/Agent.cs`** — static `Agent.RunAsync(...)` +
+    `Agent.ResumeAsync(...)` sugar.
+
+**AI satellite (LLM brain + sugar):**
+
+14. **`WebReaper.AI/LlmAgentBrain.cs`** — `IAgentBrain` via `IChatClient`.
+15. **`WebReaper.AI/LlmAgentBrainOptions.cs`** — options record.
+16. **`WebReaper.AI/LlmAgentBrainRegistration.cs`** — `WithLlmBrain`.
+17. **`WebReaper.AI/LlmAgent.cs`** — satellite static sugar
+    `LlmAgent.RunAsync(startUrl, goal, chatClient, ...)` +
+    `LlmAgent.ResumeAsync(runId, chatClient, store, ...)`.
+
+**Durable `IAgentRunStore` satellites (all four in v10 lockstep):**
+
+18. **`WebReaper.Redis/RedisAgentRunStore.cs`** + registration
+    `WithRedisAgentRunStore(...)`. Snapshot stored as JSON under
+    key `webreaper:agent:run:{runId}`.
+19. **`WebReaper.Mongo/MongoAgentRunStore.cs`** + registration
+    `WithMongoAgentRunStore(...)`. Snapshot as a document in the
+    `agent_runs` collection keyed by `runId`.
+20. **`WebReaper.Sqlite/SqliteAgentRunStore.cs`** + registration
+    `WithSqliteAgentRunStore(...)`. Two-table schema (`runs` header
+    + `run_steps` decision log) for transactional persist-before-execute.
+21. **`WebReaper.Cosmos/CosmosAgentRunStore.cs`** + registration
+    `WithCosmosAgentRunStore(...)`. Snapshot as a document keyed by
+    `runId` in the partitioned `AgentRuns` container.
+
+`WebReaper.AzureServiceBus` is queue-shaped, doesn't fit a snapshot
+store — intentionally skipped.
+
+**Tests:**
+
+22. **`WebReaper.Tests/WebReaper.UnitTests/AgentEngineDriverTests.cs`**
     — pins driver-loop semantics with a stub brain (every termination
-    case, decision dispatch, visited-link enforcement, sink fan-out).
-14. **`WebReaper.Tests/WebReaper.UnitTests/AgentEngineBuilderTests.cs`**
-    — pins builder grammar (start URL required, brain registration
-    required for `BuildAsync` success).
-15. **`WebReaper.Tests/WebReaper.AI.Tests/LlmAgentBrainTests.cs`** —
+    case, decision dispatch, visited-link enforcement, sink fan-out,
+    persist-before-execute, resume from snapshot, `RunId` on result).
+23. **`WebReaper.Tests/WebReaper.UnitTests/AgentEngineBuilderTests.cs`**
+    — pins builder grammar (start URL required; brain registration
+    required for `BuildAsync` success; `WithRunId` resumes from saved
+    snapshot, `WithNewRun` forces fresh).
+24. **`WebReaper.Tests/WebReaper.UnitTests/AgentRunStoreContractTests.cs`**
+    — shared contract test base; every `IAgentRunStore` implementation
+    is exercised against it (load-missing returns null, save+load
+    round-trips, delete clears, concurrent runIds don't collide).
+25. **`WebReaper.Tests/WebReaper.UnitTests/InMemoryAgentRunStoreTests.cs`**
+    + **`FileAgentRunStoreTests.cs`** — derive from contract base.
+26. **`WebReaper.Tests/WebReaper.AI.Tests/LlmAgentBrainTests.cs`** —
     pins prompt shape, decision parsing, every arm round-trip,
-    code-fence stripping (mirror `LlmActionResolverTests`).
-16. **CONTEXT.md** — new **Agent driver** + **Agent brain** +
-    **Agent decision** + **Agent step** terms; relationships
-    connecting the four proposer-validator docks.
-17. **CLAUDE.md** — extend the AI-native paragraph to `ADR-0040..0051`;
-    one new gotcha per quirk (brain-required-or-throw,
-    sequential-by-design, token-budget-needs-Usage).
-18. **CHANGELOG.md** — new bullet under the AI-native wave, naming
-    `AgentEngine` + `AgentEngineBuilder` + `WithLlmBrain`.
+    code-fence stripping (mirror `LlmActionResolverTests`). Includes
+    one round-trip for `LlmAgent.RunAsync` confirming it ends-to-ends
+    via the satellite sugar.
+27. **`WebReaper.Tests/WebReaper.Redis.Tests/RedisAgentRunStoreTests.cs`**,
+    **`WebReaper.Tests/WebReaper.Mongo.Tests/MongoAgentRunStoreTests.cs`**,
+    **`WebReaper.Tests/WebReaper.Sqlite.Tests/SqliteAgentRunStoreTests.cs`**,
+    **`WebReaper.Tests/WebReaper.Cosmos.Tests/CosmosAgentRunStoreTests.cs`**
+    — derive from contract base; satellite-specific quirks (Sqlite
+    transactional, Cosmos partition key, etc.).
+
+**Docs:**
+
+28. **CONTEXT.md** — new **Agent driver**, **Agent brain**, **Agent
+    decision**, **Agent step**, **Agent run state** terms; relationships
+    connecting the four proposer-validator docks; note `IAgentRunStore`
+    as the agent's pluggable state seam, sibling to `IScheduler` etc.
+29. **CLAUDE.md** — extend the AI-native paragraph to `ADR-0040..0051`;
+    add seam table row for `IAgentRunStore`; new gotchas
+    (brain-required-or-throw, sequential-by-design,
+    token-budget-needs-Usage, **resumable-runs-need-idempotent-sinks**).
+30. **CHANGELOG.md** — new bullet under the AI-native wave naming
+    `AgentEngine` + `AgentEngineBuilder` + `WithLlmBrain` +
+    `LlmAgent.RunAsync` + `IAgentRunStore` (InMemory / File / Redis /
+    Mongo / Sqlite / Cosmos).
 
 ### Guardrails (when implemented)
 


### PR DESCRIPTION
Follow-up to [PR #107](https://github.com/pavlovtech/WebReaper/pull/107) which merged with the original design-pass commit before the HITL grilling concluded. This brings the three settled refinements onto master.

## Summary of refinements

### Fork 5 — satellite-side firecrawl-shaped one-liner

New \`WebReaper.AI/LlmAgent.cs\` ships \`LlmAgent.RunAsync(url, goal, chatClient, ...)\` so callers with the AI satellite never construct the \`LlmAgentBrain\` themselves. Core \`Agent.RunAsync\` stays brain-explicit (AOT-clean, no LLM dep in core).

Usage: \`await LlmAgent.RunAsync("https://shop.com", "get all products", openAiClient);\` — three args, zero ceremony.

### Fork 8 — verdict flipped: durable agent state ships in v10

**Original verdict** was "in-process v1, durable v2." **Flipped after HITL grilling on two grounded counter-arguments:**

1. **Architectural consistency.** Every other WebReaper state seam (\`IScheduler\`, \`IVisitedLinkTracker\`, \`IScraperConfigStorage\`, \`ICookiesStorage\`) is InMemory-default + durable adapters since 7.x. Agent state being the *one* in-memory-only thing in v10 would be the inconsistency callers notice first.
2. **Peer-pattern grounding via Context7.** Firecrawl persists agent state server-side (\`jobId\` poll model); Stagehand keeps the agent loop in-process but persists *browser* state via Browserbase Contexts (\`context: { id, persist: true }\`). WebReaper is distributed-first by lineage; the Firecrawl shape is the closer fit.

**Design (§Decision §6):**

- \`IAgentRunStore\` seam (public): \`LoadAsync\` / \`SaveStepAsync\` / \`DeleteAsync\`.
- \`AgentRunSnapshot\` record: \`Goal\`, \`LastDecidedStep\`, \`History\`, \`VisitedUrls\`, \`Records\`, \`CurrentUrl\`.
- **Persist-before-execute**, at-least-once on effects (brain decisions exactly-once; sink effects may dup → caller's sink-idempotency concern; ADR-0048 change-tracking processor composes cleanly).
- \`InMemoryAgentRunStore\` default + \`FileAgentRunStore\` in core.
- Satellite adapters: **Redis + Mongo + Sqlite + Cosmos** in v10 lockstep (AzureServiceBus skipped — queue-shaped).
- \`AgentEngineBuilder\` gains: \`.WithRunStore\`, \`.WithRunId\` (resume default), \`.WithNewRun\`, \`.WithFileAgentRunStore\` + satellite extensions.
- **Resume default:** \`.WithRunId("foo")\` resumes from \`LastDecidedStep + 1\` if snapshot exists; fresh run otherwise.
- \`Agent.ResumeAsync\` + \`LlmAgent.ResumeAsync\` static-sugar overloads.
- \`AgentResult\` gains \`RunId\` field.

**Breaking change acceptable** — v10 is the AI-native version cut.

### Fork 11 — sequential-within-agent confirmed by peers

Context7 lookup confirmed all three reference peers run a single agent loop sequentially; parallelism lives at the multi-agent / multi-session level. **Firecrawl**'s "Parallel Agents" pricing is multi-agent. **Browserbase** parallel sessions use \`Promise.allSettled\` / \`asyncio.gather\`. **Stagehand** \`agent.execute({ maxSteps })\` is single-shot; docs recommend sequential decomposition. Citation added to Fork 11 row; verdict unchanged.

## ADR changes (file-level)

- §Context: 6th piece (\`IAgentRunStore\`) added to headline list.
- §Decision §3 (\`AgentEngine\`): driver-loop pseudocode shows persist-before-execute + resume snapshot restoration; \`AgentResult\` record adds \`RunId\` field.
- §Decision §5 (\`LlmAgentBrain\`): adds \`LlmAgent.RunAsync\` sugar.
- §Decision §6: new — \`IAgentRunStore\` + snapshot + semantics + adapters + builder + sugar.
- §Considered options Fork 5: refinement note pointing at satellite sugar.
- §Considered options Fork 8: verdict flipped; both options have full reasoning trail; "Why the flip" explainer.
- §Considered options Fork 11: peer-pattern grounding paragraph.
- §Consequences: AOT-clean bullet (new core types); composition bullet (two new collaborators); new bullet on architectural consistency + AI-native v10 framing.
- §Bounded scope (e): struck through; pointer to new section.
- §Implementation ledger: restructured (Core domain + seams / Core impls / AI satellite / Run-store satellites / Tests / Docs) — now 30 items.

## Why this lands as its own PR

[PR #107](https://github.com/pavlovtech/WebReaper/pull/107) merged with the original commit \`86eed69\` before the HITL grilling produced these refinements. Per the project's design-pass-first working style, the refinements are still ADR-only — no code yet. The implementation slice (the 30-item file ledger) will be its own PR off the post-merge state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)