### PR TITLE
Transports wave (ADR-0052..0055): CDP-direct + Playwright + stealth + CLI policy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -178,8 +178,12 @@ The single seam (`IPageLoader`) that turns a **PageRequest** into a page's HTML,
 _Avoid_: page fetcher, downloader, static/dynamic loader.
 
 **Load transport**:
-The per-mechanism adapter behind the **page loader** — HTTP (`HttpPageLoadTransport`) or headless browser (`BrowserPageLoadTransport`) — and the only place that mechanism's client/launch quirks and its proxy application live.
+The per-mechanism adapter behind the **page loader** — HTTP (`HttpPageLoadTransport`, in core), Playwright (browser SDK, `WebReaper.Playwright` satellite), or CDP-direct (raw protocol, `WebReaper.Cdp` satellite — the bedrock for **Browser backend** swaps) — and the only place that mechanism's client/launch quirks and its proxy application live. Browser transports launch and drive a **Browser backend** (the Chromium binary, a separate axis). ADR-0050's `(cookies, proxy, logger, actionResolver)` factory contract applies uniformly across transports.
 _Avoid_: requester, loader, driver, channel.
+
+**Browser backend**:
+The Chromium binary a browser **Load transport** launches and drives — system Chrome (detected on `PATH`), managed Chromium (the CLI's `~/.webreaper/browsers/` cache, downloaded on first use), or a stealth Chromium fork (CloakBrowser, Patchright, …). One transport (the CDP-direct transport) drives many backends; each stealth fork has its own per-launch flag set and binary-discovery rules. The `WebReaper.Stealth.X` satellites are per-backend, not per-transport — they ship installer + launcher helpers that conform to ADR-0055's backend-fork detection registry. Distinct from **Load transport**: transport is *how* WebReaper drives the page-loader; backend is *which binary* it launches.
+_Avoid_: transport (that is how we drive, not what we drive), driver, runtime.
 
 **PageRequest**:
 What the **page loader** needs to fetch one page — URL, **PageType**, optional page actions, headless flag — projected from a **Job** plus the crawl's headless setting (the loader never sees the selector chain or backlinks).

--- a/docs/adr/0052-cdp-direct-loader-satellite.md
+++ b/docs/adr/0052-cdp-direct-loader-satellite.md
@@ -1,0 +1,219 @@
+# `WebReaper.Cdp` — raw Chrome DevTools Protocol transport satellite, the bedrock for **Browser backend** swaps
+
+## Status
+
+**Proposed** (2026-05-24). Slice 1 of 4 in the **Transports wave** (v11.0.0
+target): ADR-0052 (this one, CDP-direct), ADR-0053 (Playwright satellite +
+Puppeteer deletion), ADR-0054 (`WebReaper.Stealth.CloakBrowser`), ADR-0055
+(CLI browser/stealth acquisition policy). New satellite per ADR-0009 — core
+stays dependency-light and AOT-clean.
+
+## Context
+
+ADR-0004 collapsed page loading into one seam: `IPageLoader` dispatches on
+`PageRequest.PageType` to one of two `IPageLoadTransport` adapters — the
+HTTP transport (Static) and the browser transport (Dynamic). Through
+v10.0.0 the Dynamic slot has had exactly one occupant: `BrowserPageLoadTransport`
+in `WebReaper.Puppeteer` (ADR-0009). The seam was already "two adapters,
+one mechanism each"; the *naming* of the second adapter as "Browser"
+was honest because there was one browser SDK driving the slot.
+
+The Transports wave breaks that one-SDK assumption from three angles
+simultaneously:
+
+1. **Stealth Chromium forks** (CloakBrowser, Patchright, Camoufox) ship as
+   raw Chromium binaries you launch with `--remote-debugging-port=N` and
+   talk to over CDP. They do not ship PuppeteerSharp or Microsoft.Playwright
+   bindings; the only seam they expose is CDP itself. A `WebReaper.Stealth.X`
+   satellite cannot use the Puppeteer transport — it has to speak CDP
+   directly to the spawned binary.
+2. **The CLI's AOT guarantee** (ADR-0043) ships a single Native-AOT binary
+   across 6 RIDs. PuppeteerSharp and Microsoft.Playwright both depend on
+   reflection-heavy serialisation that is not AOT-clean inside a single
+   binary (the satellites stay library-usable in JIT consumers; baking
+   them into the CLI binary is not). The CLI needs a *transport* it can
+   bake without forfeiting AOT — a raw-CDP client built on
+   `System.Net.WebSockets` + source-generated JSON.
+3. **BYO scenarios** — testing, sidecar architectures, users who already
+   have a Chrome running with `--remote-debugging-port=9222`, a remote
+   browser farm — all want "connect to this CDP URL" and nothing else.
+   The Puppeteer transport's "launch a managed Chromium" shape doesn't
+   fit; a thin connect-only transport does.
+
+CONTEXT.md's revised **Load transport** glossary now lists three transports
+(HTTP, Playwright, CDP-direct) and a new sibling axis: **Browser backend**.
+A backend is the Chromium binary a browser transport drives. The CDP-direct
+transport is the *one transport* that drives many backends — that's its
+job. Playwright drives only what Microsoft.Playwright ships (Chromium,
+Firefox, WebKit, all vanilla); the CDP-direct transport drives anything
+that exposes a CDP endpoint, including every stealth fork.
+
+## Decision
+
+- **New satellite `WebReaper.Cdp`** (NuGet package, satellite-pattern per
+  ADR-0009). Core never references it; the dependency enters the
+  consumer's graph only when they `dotnet add package WebReaper.Cdp` and
+  `using WebReaper.Cdp;`.
+
+- **`CdpPageLoadTransport : IPageLoadTransport`** lives in the satellite.
+  Implements the existing ADR-0004 seam. Wired through the standard
+  ADR-0050 4-arg `WithLoadTransport(Func<ICookiesStorage, IProxyProvider?, ILogger, IActionResolver, IPageLoadTransport>)`
+  factory contract. The transport accepts the 4-tuple even where it
+  ignores arguments (e.g. cookies handling differs in CDP from
+  PuppeteerSharp's `CookieContainer` bridge — see Accepted cost).
+
+- **Two public builder overloads** in `WebReaper.Cdp.CdpPageLoaderBuilderExtensions`:
+
+  ```csharp
+  // Connect-to-existing: BYO browser, transport just opens the WebSocket
+  ScraperEngineBuilder WithCdpPageLoader(this ScraperEngineBuilder b, string cdpUrl);
+
+  // Launch-and-connect: transport spawns Chromium with --remote-debugging-port=0,
+  // waits for the port, connects, manages lifecycle, tears down on Dispose
+  ScraperEngineBuilder WithCdpPageLoader(this ScraperEngineBuilder b, CdpLaunchOptions opts);
+  ```
+
+  `CdpLaunchOptions` carries: executable path (default = PATH-detected
+  Chrome / Chromium / Edge in that order), additional command-line flags
+  (`--headless=new`, `--no-sandbox`, …), startup timeout, user-data-dir
+  policy. The launch path internally calls `CdpLaunchHelpers`.
+
+- **Public `CdpLaunchHelpers` static utility class** in the satellite — the
+  shared layer the `WebReaper.Stealth.X` satellites depend on:
+
+  ```csharp
+  public static class CdpLaunchHelpers {
+      // Find an executable by name across PATH and platform-conventional install dirs
+      public static string? FindOnPath(params string[] candidateNames);
+
+      // Spawn `executable` with the given args + `--remote-debugging-port=0`,
+      // wait for the port to be readable, return the resolved WebSocket CDP URL
+      public static Task<LaunchedCdpEndpoint> LaunchAsync(CdpLaunchSpec spec, CancellationToken ct);
+
+      // Validate that the URL responds to a CDP "Browser.getVersion" probe within timeout
+      public static Task<bool> ProbeAsync(string cdpUrl, TimeSpan timeout, CancellationToken ct);
+  }
+  ```
+
+  Stealth satellites compose `CdpLaunchHelpers.LaunchAsync(...)` →
+  resulting CDP URL → `WithCdpPageLoader(url)` (connect-to-existing
+  overload). The transport itself stays unaware of which fork launched
+  the browser.
+
+- **PageAction dispatch — six concrete arms via raw CDP primitives.** The
+  ADR-0035 closed sum has seven arms today; the seventh is `SemanticAct`
+  (ADR-0050, resolved by `IActionResolver`). The transport dispatches the
+  six concrete arms through CDP `Input.*` / `Runtime.evaluate` /
+  `Page.navigate` directly. Behaviour parity with the Puppeteer
+  transport's table is the acceptance criterion — pinned by the existing
+  `SemanticActDispatchTests` plus a new `CdpPageActionDispatchTests`
+  derived from the same shape.
+
+- **`SemanticAct` (ADR-0050) preserved end to end.** The transport
+  receives the resolver argument from the 4-arg factory; on a
+  `SemanticAct(intent)` arm it delegates to `IActionResolver.ResolveAsync`,
+  receives one of the six concrete arms back, dispatches it via the
+  primitive layer above, and caches the resolution per crawl per intent
+  string (`SemanticActCoordinator` already lives in core — the transport
+  is a delegator, not a re-implementer).
+
+- **AOT-clean by construction.** No reflection-driven serialisation. CDP
+  messages are JSON; the transport uses `System.Text.Json` source-gen
+  (`WebReaperCdpJson` context, sibling to the existing
+  `WebReaperAgentJson` from ADR-0051). The transitive dep is
+  `System.Net.WebSockets` (in-box) and nothing else. The
+  `WebReaper.AotSmokeTest` is extended to publish a consumer that pulls
+  the satellite and asserts zero IL/AOT warnings — same guardrail the
+  rest of the satellites have.
+
+- **Cookies and proxies — same shape as ADR-0009 documented.** Cookies:
+  `ICookiesStorage`'s `CookieContainer` is projected to CDP
+  `Network.setCookies` calls before the first navigation; on navigation
+  completion CDP `Network.getAllCookies` is reverse-projected back into
+  the container. Proxy: `IProxyProvider`, when set, supplies a proxy URL
+  that becomes the launched Chromium's `--proxy-server=` flag (the same
+  *application* the Puppeteer transport used). The connect-to-existing
+  overload assumes the BYO browser already has its proxy configured;
+  passing `IProxyProvider` with that overload logs a warning and is
+  ignored.
+
+## Considered options
+
+- **CDP-direct as a new satellite (chosen).** Matches ADR-0009 per-technology
+  packaging. Stealth satellites depend on `WebReaper.Cdp`; users who only
+  want BYO-CDP add one package; the dependency stays out of core.
+- **Fold CDP-direct into core (rejected).** `System.Net.WebSockets` is
+  in-box and the source-gen JSON is light, so the *weight* argument doesn't
+  hold here. But the *concentration* argument from ADR-0009 still does: a
+  consumer doing a plain HTTP→JSON-lines crawl gains an unused CDP client
+  and a `PageActions` dispatch layer. More importantly, the `WebReaper.Cdp`
+  package becomes the shared dependency of all `WebReaper.Stealth.X` satellites;
+  having it as a separate addressable package is the right packaging
+  primitive. Inverting that into core would force every consumer to pay for
+  the CDP layer to enable stealth scenarios that most consumers don't run.
+- **Skip CDP-direct, force stealth users through Playwright (rejected).**
+  Stealth Chromium forks don't ship Playwright bindings. A user wiring
+  CloakBrowser via Playwright would have to call
+  `playwright.chromium.connect_over_cdp(...)` — re-introducing CDP, just
+  inside Playwright. Strictly worse than CDP-direct: extra dependency
+  weight, indirection through Microsoft.Playwright's connection logic,
+  and the AOT-CLI story collapses (Microsoft.Playwright is not AOT-clean).
+- **Build CDP-direct on top of PuppeteerSharp's CDP client (rejected).**
+  Defeats every motivation. The wave deletes the Puppeteer satellite in
+  ADR-0053; building the bedrock on a dependency we're removing is
+  incoherent. PuppeteerSharp's CDP client is also not AOT-clean.
+- **Two transport satellites that share an internal `IBrowserTransport`
+  super-seam (rejected).** Would unify Playwright and CDP-direct under one
+  abstraction. The Dynamic-slot singleton constraint stays — `IPageLoader`
+  holds at most one browser transport at a time — so the super-seam earns
+  no rent in v11. Premature; revisit if a third browser transport
+  (WebDriver-BiDi, e.g.) appears.
+
+## Accepted cost
+
+- **Cookie projection runs per-navigation, not per-request.** PuppeteerSharp
+  bridges `CookieContainer` once at launch. CDP's `Network.setCookies` is
+  per-target; the transport re-applies the container on each navigation to
+  keep parity with the HTTP transport's "cookies are crawl-wide state"
+  contract. Measured cost is a small CDP round-trip per page; negligible
+  versus the page-load cost itself.
+- **`PageActions` dispatch is the satellite's responsibility — duplicated
+  with ADR-0053's Playwright transport.** Six arms × two transports = two
+  dispatch tables, both shadowing the deleted Puppeteer table. This is the
+  ADR-0004 cost we already accepted ("per-mechanism client/launch quirks
+  live in the transport"). A future ADR may extract a shared
+  `PageActionDispatcher` over CDP primitives once the pattern has stabilised
+  across two adapters; v11 ships the duplication knowingly.
+- **`PageRequest` carries `Headless` and `PageActions` that the HTTP
+  transport ignores** — the ADR-0004 "mildly fat request type" cost is
+  preserved. The CDP transport reads both fields; no widening needed.
+
+## Deliberate consequences
+
+- **The Dynamic-slot picker becomes meaningful.** Through v10, users
+  wired the Browser transport by adding `WebReaper.Puppeteer` and calling
+  `.WithPuppeteerPageLoader()` — only one choice. Through v11+, the user
+  picks between `WebReaper.Playwright` (`.WithPlaywrightPageLoader(...)`)
+  and `WebReaper.Cdp` (`.WithCdpPageLoader(...)`) plus the stealth
+  satellites that compose on top of `WebReaper.Cdp`. The
+  `BrowserNotConfiguredPageLoadTransport`'s actionable error message
+  (the one in core that throws when Dynamic load is requested without a
+  transport registered) is extended in lockstep — see ADR-0053.
+- **Stealth satellites become thin.** Each `WebReaper.Stealth.X` is
+  conceptually: per-fork binary discovery + per-fork launch flag set +
+  `WithCdpPageLoader(url)` wiring. The shared work lives in
+  `CdpLaunchHelpers`; per-satellite work is the per-fork details. See
+  ADR-0054 for the documented recipe.
+- **CDP-direct is the CLI's only baked browser transport.** Per ADR-0055,
+  `WebReaper.Cli` references `WebReaper.Cdp` but never `WebReaper.Playwright`
+  or any `WebReaper.Stealth.X` — the CLI's auto-spawn path and `--browser-cdp-url`
+  flag both produce a CDP URL the baked transport connects to. The AOT
+  guarantee survives.
+
+## SemVer
+
+**Minor (additive).** The transport is new public surface in a new
+satellite package; nothing in core or existing satellites changes
+behaviour because of this ADR. The deletion of `WebReaper.Puppeteer`
+(carried by ADR-0053) is the **major** break of v11.0.0; the satellites
+ship together in the lockstep wave.

--- a/docs/adr/0053-playwright-satellite-puppeteer-deletion.md
+++ b/docs/adr/0053-playwright-satellite-puppeteer-deletion.md
@@ -1,0 +1,204 @@
+# `WebReaper.Playwright` — Playwright transport satellite; clean-cut deletion of `WebReaper.Puppeteer` in the same release
+
+## Status
+
+**Proposed** (2026-05-24). Slice 2 of 4 in the **Transports wave** (v11.0.0
+target). Carries the **major break** of v11.0.0: the `WebReaper.Puppeteer`
+satellite and its `WebReaper.Puppeteer.Tests` companion are deleted in the
+same release that ships `WebReaper.Playwright`. Actions the future named
+in ADR-0009 ("Puppeteer becomes removable as a package-drop — a stated
+2026 direction, recorded here, deliberately not actioned here").
+
+## Context
+
+ADR-0009 sized this break two years ago. The satellite quarantine was the
+prerequisite ("**Puppeteer becomes removable as a package-drop**, not core
+surgery"). Two years on, the conditions have crystallised:
+
+1. **Microsoft.Playwright is the modern .NET-native browser SDK.** Official
+   Microsoft maintenance; idiomatic `Task`-returning API; multi-browser
+   (Chromium, Firefox, WebKit); better network interception (`page.RouteAsync`
+   over PuppeteerSharp's older interception API); auto-wait semantics that
+   reduce the need for explicit `WaitForSelector` in user code.
+2. **Stealth Chromium forks have made PuppeteerSharp a strict liability.**
+   CloakBrowser, Patchright, Camoufox, undetected-chromedriver all ship as
+   bare Chromium binaries you talk to via raw CDP. PuppeteerSharp's
+   `connectAsync` path works but adds the entire PuppeteerSharp dependency
+   plus its CDP client to the consumer graph for no functional gain over
+   the `WebReaper.Cdp` satellite (ADR-0052).
+3. **The ADR-0050 4-arg widening was the last addition** to the Puppeteer
+   transport. Its action-dispatch table covers exactly four `PageActionType`
+   arms — `WaitForSelector` and `EvaluateExpression` throw at runtime — a
+   limitation called out in ADR-0004 §"Out of scope" and never closed. The
+   Playwright transport ships full seven-arm coverage on day one.
+
+The wave is structurally aligned: ADR-0052 introduced the `WebReaper.Cdp`
+bedrock that absorbs stealth use cases; this ADR retires the SDK-shaped
+predecessor and replaces it with the supported one. ADR-0054 + ADR-0055
+build on top.
+
+## Decision
+
+- **New satellite `WebReaper.Playwright`** (NuGet package, satellite pattern
+  per ADR-0009). Depends on `Microsoft.Playwright` (the current GA major).
+  Core never references it; consumers add the package and the using
+  directive — same shape as every other satellite.
+
+- **`PlaywrightPageLoadTransport : IPageLoadTransport`** lives in the
+  satellite. Implements the ADR-0004 seam directly (not layered on
+  `CdpPageLoadTransport`); Microsoft.Playwright drives Chromium, Firefox,
+  and WebKit through three different protocols (CDP, Juggler-fork, Web
+  Inspector) and reusing the CDP transport would lose Firefox/WebKit and
+  double-wrap Chromium. Independent transports, same singleton-Dynamic-slot
+  constraint as before.
+
+- **Public builder extension** in `WebReaper.Playwright.PlaywrightPageLoaderBuilderExtensions`:
+
+  ```csharp
+  ScraperEngineBuilder WithPlaywrightPageLoader(
+      this ScraperEngineBuilder b,
+      PlaywrightBrowser browser = PlaywrightBrowser.Chromium,
+      PlaywrightLaunchOptions? opts = null);
+
+  public enum PlaywrightBrowser { Chromium, Firefox, Webkit }
+  ```
+
+  `PlaywrightLaunchOptions` (a thin wrapper around Microsoft.Playwright's
+  `BrowserTypeLaunchOptions`) carries headless flag, channel (e.g.
+  `"chrome"`, `"msedge"`), proxy, executable path override, additional
+  args. Defaults match ADR-0004's `Networkidle2` navigation convention via
+  Playwright's `WaitUntilState.NetworkIdle`.
+
+- **All seven `PageAction` arms implemented.** Maps to Playwright's
+  `IPage`/`IElementHandle` APIs:
+  - `Click(sel)` → `page.ClickAsync(sel)`
+  - `Type(sel, text)` → `page.FillAsync(sel, text)`
+  - `WaitForSelector(sel, timeoutMs)` → `page.WaitForSelectorAsync(sel, new() { Timeout = timeoutMs })`
+  - `EvaluateExpression(js)` → `page.EvaluateAsync(js)`
+  - `WaitForNavigation` → `page.WaitForNavigationAsync()` (deprecated in
+    Playwright; mapped to `page.WaitForLoadStateAsync` for parity)
+  - `Scroll` → `page.EvaluateAsync(window.scrollBy(0, opts.dy))`
+  - `SemanticAct(intent)` (ADR-0050) → delegates to `IActionResolver`,
+    dispatches the resolved arm through this same table, caches per crawl
+    per intent string via `SemanticActCoordinator`.
+
+  Replacing the four-arm Puppeteer coverage that left two arms throwing
+  at runtime closes the ADR-0004 §"Out of scope" gap.
+
+- **Multi-browser default = Chromium.** `WithPlaywrightPageLoader()` with
+  no argument launches Chromium; the `PlaywrightBrowser` parameter opts
+  into Firefox or WebKit. Integration tests in v11 cover Chromium only —
+  the existing flaky `WebReaper.IntegrationTests` suite is too slow
+  (live `alexpavlov.dev`, `Task.Delay` up to 25s) to triple. Firefox/WebKit
+  parity tests are explicitly community-contributable and documented as
+  such in the satellite's `README`.
+
+- **`WebReaper.Puppeteer` satellite is deleted in the same release.** Clean
+  cut, no `[Obsolete]` deprecation window. Three .cs files in the
+  satellite proper + the `WebReaper.Puppeteer.Tests` project + the
+  `Examples/WebReaper.ConsoleApplication` and `Examples/BrownsfashionScraper`
+  consumers + the `WebReaper.IntegrationTests/ScraperTests.cs` and
+  `RedisDistributedAdapterTests.cs` references + the unit-tests'
+  `HttpOnlyDefaultPageLoaderTests.cs` + `SemanticActDispatchTests.cs`
+  all migrate to the Playwright transport in one wave PR.
+
+- **The `BrowserNotConfiguredPageLoadTransport` error string** (core's
+  default Dynamic-slot occupant that throws actionable migration text) is
+  updated from *"add WebReaper.Puppeteer"* to:
+
+  > Dynamic page loading requires a browser transport. Wire one of:
+  > • `WithPlaywrightPageLoader(...)` — `WebReaper.Playwright` satellite
+  > • `WithCdpPageLoader(...)` — `WebReaper.Cdp` satellite (for stealth backends)
+
+  The message change is part of this ADR's core surgery (the one core file
+  touched by the wave).
+
+- **CLAUDE.md's transport listing flips in lockstep.** The "page loaders"
+  row of the seam table changes from `Http + Puppeteer` to
+  `Http + Playwright + Cdp`; the "First dynamic-page run downloads
+  Chromium via Puppeteer" gotcha flips to "First Playwright run downloads
+  browsers via `playwright install` (the satellite's standard first-run
+  step)".
+
+## Considered options
+
+- **Clean cut: ship Playwright, delete Puppeteer same release (chosen).**
+  Matches ADR-0009's exact precedent. The compat-shell argument doesn't
+  apply here: a shell forwarding `WithPuppeteerPageLoader()` to
+  `WithPlaywrightPageLoader()` would have wildly different runtime
+  behaviour (different browser-launch quirks, different action-dispatch
+  semantics, different network-interception API surface). A "compatibility
+  forwarder" that silently changes the runtime is worse than a compile-time
+  error pointing at the new method.
+- **Parallel-ship: both satellites coexist; mark Puppeteer `[Obsolete]`
+  with one-major deprecation window, remove in v12 (considered, rejected).**
+  Was the original recommendation in HITL Round 1; user reversed it to
+  clean-cut. Cost: extra ongoing maintenance of a satellite the project
+  is moving off; users on the deprecation path stuck on a less-capable
+  transport for an entire release cycle; ambiguous "which is the future"
+  signal.
+- **Skip Playwright entirely, just delete Puppeteer; leave CDP-direct as
+  the only browser option (rejected).** CDP-direct is too low-level for
+  casual users — wiring `page.click` via raw CDP is not the abstraction
+  level most .NET consumers want for a one-off scrape. Playwright is the
+  modern equivalent of the abstraction Puppeteer provided. Removing
+  Puppeteer without replacing the abstraction layer would regress the
+  library.
+- **Keep Puppeteer indefinitely, ship Playwright as a second option
+  (rejected).** Two browser-SDK satellites in permanent parallel ship
+  maintenance debt for negative gain. ADR-0009's named direction has been
+  on the table for two years; not actioning it indefinitely is the worst
+  of both worlds.
+- **Microsoft.Playwright.NUnit / xUnit test-helper packages as
+  transitive deps (rejected).** The satellite ships only
+  `Microsoft.Playwright`. Users writing tests with Playwright pull the
+  test-helper package themselves. Keeps the consumer graph minimal.
+
+## Accepted cost
+
+- **Examples and integration-tests migrate in the same PR.** Two example
+  apps, three test files touched. Mechanical work — `.WithPuppeteerPageLoader()`
+  → `.WithPlaywrightPageLoader()` plus one `using` swap.
+- **First-run downloads Playwright browsers via `playwright install`.**
+  Microsoft.Playwright's standard first-run step downloads Chromium (and
+  Firefox/WebKit if the consumer enabled them). Same shape as the
+  PuppeteerSharp Chromium-provisioning path it replaces; documented in
+  the satellite's README.
+- **No PageAction-dispatcher abstraction yet** (ADR-0052 §Accepted cost
+  flagged this; this ADR preserves the duplication). Two dispatch tables —
+  CDP-direct and Playwright — both implementing the same seven arms.
+  Extraction to a shared dispatcher is a future ADR once the pattern has
+  stabilised across two adapters.
+- **Microsoft.Playwright trim warnings.** The satellite is not AOT-clean
+  in isolation; that is the ADR-0009 satellite-quarantine pattern working
+  exactly as designed. Core's AOT smoke test does not pull this satellite;
+  the CLI (ADR-0043) does not bake it. JIT consumers of the satellite are
+  unaffected.
+
+## Deliberate consequences
+
+- **The Dynamic-slot picker UX is now genuine.** Through v11 a consumer
+  picks between three transport satellites: the existing HTTP transport
+  in core (Static slot), and for the Dynamic slot one of Playwright
+  (`WebReaper.Playwright`) or CDP-direct (`WebReaper.Cdp` — including all
+  stealth backends that compose on top). The seam shape from ADR-0004 is
+  unchanged; the *option set* widens.
+- **The CLI gains a coherent browser story.** Per ADR-0055, the CLI bakes
+  only `WebReaper.Cdp` (AOT-clean); the CLI's `--browser` flag auto-spawns
+  a managed Chromium and connects via CDP. Users who want Playwright
+  per-transport features pick it explicitly at the library level. Two
+  distinct surfaces, both supported, no ambiguity.
+- **`PuppeteerExtraSharp` is dropped from the consumer graph.** The
+  `WebReaper.Puppeteer` satellite pulled it; nothing in v11 does. Any
+  consumer using the `PuppeteerExtraSharp`-based stealth plugins through
+  the deleted satellite migrates to `WebReaper.Stealth.CloakBrowser`
+  (ADR-0054) — a cleaner path than the puppeteer-extra plugin ecosystem.
+
+## SemVer
+
+**Major (11.0.0).** Public surface — the entire `WebReaper.Puppeteer`
+package — is deleted. Clean cut, no compat shell, no deprecation window.
+Announced via this ADR, CHANGELOG migration section, and the `README`
+upgrade guide. Consistent with ADR-0009's exact precedent ("the project's
+'called out loud, never silent' rule even though it does not use the
+compat-shell mechanism").

--- a/docs/adr/0054-stealth-backend-pattern-cloakbrowser.md
+++ b/docs/adr/0054-stealth-backend-pattern-cloakbrowser.md
@@ -1,0 +1,252 @@
+# Stealth-backend pattern: per-fork `WebReaper.Stealth.X` satellites composing on `WebReaper.Cdp`; `WebReaper.Stealth.CloakBrowser` ships first
+
+## Status
+
+**Proposed** (2026-05-24). Slice 3 of 4 in the **Transports wave** (v11.0.0
+target). New satellite per ADR-0009 — `WebReaper.Stealth.CloakBrowser`
+ships as the first concrete backend. The recipe other stealth Chromium
+forks follow (Patchright, Camoufox, undetected-chromedriver, …) is
+documented here so community-contributed satellites land on the same
+shape without each one needing its own ADR.
+
+## Context
+
+The transports wave is structurally three layers:
+
+1. **ADR-0052 — `WebReaper.Cdp`**: the CDP-direct transport + the public
+   `CdpLaunchHelpers` utility. The bedrock for **Browser backend** swaps.
+2. **ADR-0053 — `WebReaper.Playwright`**: the modern SDK-shaped browser
+   transport; not relevant to stealth (Microsoft.Playwright doesn't bind
+   stealth Chromium forks).
+3. **This ADR** — the per-backend satellites that compose `CdpLaunchHelpers`
+   + per-fork details + `WithCdpPageLoader(url)` wiring to give consumers
+   a one-liner: `.WithCloakBrowser()` and equivalent.
+
+Stealth scraping is the use case the current `WebReaper.Puppeteer` satellite
+fundamentally cannot serve. PuppeteerSharp drives vanilla Chromium; vanilla
+Chromium fails Cloudflare, reCAPTCHA v3, DataDome, FingerprintJS — every
+mainstream invisible-bot-check on every site that matters. The whole point
+of stealth Chromium forks like CloakBrowser is that **the fingerprint
+patches live at the C++ level** — there's no JS-level "stealth plugin" that
+catches up. The wave's transport split makes those forks first-class
+citizens.
+
+The user-convenience analysis (HITL Round 1, F4 + Stealth UX): the original
+walked-through flow required users to `pip install cloakbrowser` and manage
+a sidecar process. That cross-ecosystem friction killed the casual
+audiobook-scraping scenario the wave was designed for. The redesign:
+each `WebReaper.Stealth.X` satellite handles the fork's binary lifecycle
+itself, downloading from upstream on first use (same legal model as
+`playwright install`, `winget`, `brew install --cask`), and exposes a
+one-line builder extension.
+
+## Decision
+
+### The pattern (the part future satellites mirror)
+
+A `WebReaper.Stealth.X` satellite consists of three pieces:
+
+1. **An `XLauncher` class** — finds the fork's binary on disk, optionally
+   downloads it from upstream, launches it with the fork's recommended
+   flags, returns a `LaunchedCdpEndpoint` (CDP URL + a `IAsyncDisposable`
+   teardown handle). Built on `WebReaper.Cdp.CdpLaunchHelpers`.
+2. **An `XInstaller` class** — `EnsureInstalledAsync(InstallOptions ct)`:
+   detect pre-installed binary at PATH and well-known paths; if absent,
+   download the upstream release artefact for the current RID
+   (`win-x64` / `linux-x64` / `osx-x64` / `osx-arm64` / …) with checksum
+   verification + resumable retry; cache under
+   `~/.webreaper/stealth/<fork-name>/`. Idempotent — no-op if the binary
+   is already cached.
+3. **A `WithXBackend()` extension method** on `ScraperEngineBuilder`,
+   living in `XBackendBuilderExtensions`. The body is exactly:
+
+   ```csharp
+   public static ScraperEngineBuilder WithCloakBrowser(
+       this ScraperEngineBuilder b,
+       CloakBrowserOptions? opts = null)
+   {
+       opts ??= new CloakBrowserOptions();
+       var path = CloakBrowserInstaller.EnsureInstalledAsync(opts.InstallOptions).GetAwaiter().GetResult();
+       var endpoint = CloakBrowserLauncher.LaunchAsync(path, opts).GetAwaiter().GetResult();
+       return b.WithCdpPageLoader(endpoint.CdpUrl);
+       // endpoint.DisposeAsync wired into the engine's teardown hook
+   }
+   ```
+
+   Sync-over-async at the builder boundary is consistent with the rest of
+   the builder surface; the work itself is async-internal.
+
+No shared `IStealthBackend` interface, no abstract base class. The
+*convention* is the spec — same packaging principle the existing data-store
+satellites follow (`WriteToMongoDb`/`WriteToCosmos` are extensions, not
+implementations of a shared `IDataStoreSatellite`).
+
+### The first concrete satellite — `WebReaper.Stealth.CloakBrowser`
+
+The CloakBrowser fork (v0.3.30 at draft-time, GitHub.com/CloakHQ/CloakBrowser,
+20.1k stars, active May 2026) handles invisible bot-checks via C++-level
+fingerprint patches:
+
+| Challenge | Handled |
+|---|---|
+| Cloudflare Turnstile, reCAPTCHA v3, FingerprintJS, BrowserScan | Silent pass via fingerprint patches |
+| reCAPTCHA v2 image grid, hCaptcha (interactive puzzles) | Not handled — separate concern, deferred to future captcha-solver wave |
+| DataDome on aggressive sites | Partial — vendor docs recommend headed mode + residential proxies (already wired via `IProxyProvider`) |
+
+**Launch shape:** `CloakBrowserLauncher.LaunchAsync(binaryPath, options)`
+spawns the binary with `--remote-debugging-port=0` plus the
+CloakBrowser-specific flags the vendor documents (`--user-data-dir`,
+`--disable-background-networking`, `--no-first-run`, …), waits for the
+port to be readable via `CdpLaunchHelpers.LaunchAsync`, returns the
+endpoint.
+
+**Install shape:** `CloakBrowserInstaller.EnsureInstalledAsync` reads the
+latest release manifest from CloakHQ's GitHub Releases API (or a pinned
+version when the consumer passes `InstallOptions.Version`), selects the
+artefact matching the current RID, downloads it to
+`~/.webreaper/stealth/cloakbrowser/<version>/`, verifies the SHA-256
+checksum the release manifest carries, untars/unzips, marks the binary
+executable on Unix. Resumable on partial download (HTTP `Range`).
+
+### License acknowledgment — two surfaces
+
+CloakBrowser's `BINARY-LICENSE.md` permits **use** but forbids
+**redistribution**. The legal model the satellite uses is identical to
+`playwright install` / `winget` / `brew install --cask`: WebReaper's CLI
+and library code is a *download mechanism on behalf of the user*, not a
+distributor. The binary is fetched from CloakHQ's own servers on the
+user's machine; nothing is rehosted.
+
+Two surface-level acknowledgments:
+
+- **Library surface (`.WithCloakBrowser()`).** On first-run install, the
+  installer **logs once** (via the wired `ILogger`) the license URL and
+  a one-line reminder ("By using CloakBrowser, you accept its binary
+  license terms — see https://github.com/CloakHQ/CloakBrowser/blob/main/BINARY-LICENSE.md").
+  No interactive prompt — would break headless library / CI scenarios.
+  Subsequent runs are silent (cached install).
+
+- **CLI surface (`webreaper stealth install`).** Interactive Y/n prompt on
+  the first install run that includes the license URL, install size, and
+  upstream source. Unattended use bypasses the prompt via `--yes` flag or
+  `WEBREAPER_AUTO_STEALTH=1` env var. See ADR-0055 for the full UX
+  contract.
+
+### Composition with existing seams
+
+- **`IProxyProvider`** — passed through the ADR-0050 4-arg factory; the
+  CloakBrowser launcher adds `--proxy-server=<url>` to the spawn args.
+  Headed-mode + residential-proxy is the vendor-recommended config for
+  the hardest sites (DataDome); the satellite supports both via
+  `CloakBrowserOptions.Headed` + the user's `WithProxy(...)` registration.
+- **`ICookiesStorage`** — handled by `CdpPageLoadTransport` itself (per
+  ADR-0052), not the satellite. The satellite is launch-only; once the
+  transport is wired the cookie projection runs through CDP.
+- **`IActionResolver`** (ADR-0050) — same path; the transport receives the
+  resolver, the satellite is invisible to it.
+- **`WebReaper.AI` `LlmActionResolver`** — composes naturally:
+  `.WithCloakBrowser().WithLlmActionResolver(chatClient)` is the
+  "stealth + semantic actions" pair that handles "click the obscured
+  download button on this protected page".
+
+### Recipe for community-contributed stealth satellites
+
+To add `WebReaper.Stealth.Patchright` (or Camoufox, undetected-chromedriver
+Chromium fork, …):
+
+1. New satellite project; `<PackageReference Include="WebReaper.Cdp" />`.
+2. `PatchrightInstaller` calling Patchright's release-manifest endpoint;
+   cache under `~/.webreaper/stealth/patchright/`; verify checksum.
+3. `PatchrightLauncher` calling `CdpLaunchHelpers.LaunchAsync` with
+   Patchright's documented flag set.
+4. `WithPatchright()` extension on `ScraperEngineBuilder`, body identical
+   in shape to `WithCloakBrowser()`.
+5. A satellite-specific `BINARY-LICENSE` acknowledgment in the README
+   plus the one-line `ILogger` log on first install.
+6. Submit PR to `WebReaper.Cli`'s `KnownStealthBackends` registry (per
+   ADR-0055) to opt the new satellite into the CLI's `webreaper stealth install`
+   UX. Library use does not require the CLI registration.
+
+Three classes + one extension + one README + one one-line PR to a
+hardcoded list. The pattern is shallow because the seam beneath it
+(`CdpLaunchHelpers` + `IPageLoadTransport`) is deep.
+
+## Considered options
+
+- **Per-backend satellites, shared utils in `WebReaper.Cdp`, convention
+  pattern (chosen).** Matches ADR-0009 per-technology packaging principle;
+  license isolation per fork; independent release cadence; zero dead code
+  in a user's binary when they only want one backend; `dotnet add package`
+  cost identical to umbrella.
+- **Umbrella `WebReaper.Stealth` satellite with N extension methods
+  (rejected).** Originally recommended in HITL Round 1, reversed during
+  grilling. License-muddling across forks; coupled release cadence
+  (CloakBrowser ships fast, Patchright may lag); dead-code for users who
+  only want one backend. NuGet discoverability — the umbrella's one
+  legitimate win — is solvable with README/docs.
+- **No satellite, documented pattern only (rejected).** Lean toward user
+  convenience was an explicit user constraint. A pattern + example
+  doc forces every user to write the same installer + launcher boilerplate;
+  the satellite-per-fork shape pays the cost once on our side and saves
+  every consumer N hours of integration work.
+- **`IStealthBackend` shared interface + DI-registered backends
+  (rejected).** New abstraction earning no rent in v11; doesn't match
+  existing satellite ecosystem; over-engineered. Consumers don't pick a
+  backend from a list at runtime — they pick at compile time by which
+  `WithXBackend()` extension they call. Future ADR may extract if a
+  legitimate runtime-selection use case appears.
+- **Bundle CloakBrowser binary in the NuGet package (rejected — legally
+  blocked).** CloakBrowser's `BINARY-LICENSE.md` explicitly forbids
+  redistribution. Even if it didn't, the binary is 220 MB per RID — six
+  RIDs would push a 1.3 GB NuGet package, dramatically outside the
+  community-acceptable size range.
+- **Auto-escalation in the library (vanilla Chrome → bot-check detected →
+  swap to CloakBrowser) (rejected — deferred).** This is the
+  `TransportRouter` pattern (F7 in Round 1 grilling), deferred to v12
+  pending demand. v11 library users pick a backend at build time;
+  the CLI surface (ADR-0055) implements escalation as a CLI-only feature.
+
+## Accepted cost
+
+- **One ADR-by-PR per CLI-integrated stealth backend.** A satellite ships
+  freely for library use; CLI integration via the
+  `KnownStealthBackends` curated list requires a small PR per backend.
+  Bottleneck on us merging; trade for the curated-quality bar on the CLI
+  surface.
+- **Cross-platform installer logic per fork.** Six RIDs × N forks × release-
+  manifest formats per upstream. Mitigation: `CdpLaunchHelpers` and a
+  forthcoming `StealthInstallerBase` (not in v11, planned for v12 once
+  the second satellite lands and the actual shared code is visible)
+  carry the cross-cutting work; per-fork code is the per-fork details.
+- **License-acknowledgment surface is per-satellite.** Each
+  `WebReaper.Stealth.X` README + first-run logger line names that fork's
+  binary license. Mechanical work; the precedent this ADR sets is what
+  future satellites copy.
+- **The audiobook scenario "just works" claim has an asterisk.** Most
+  trackers use Cloudflare or reCAPTCHA v3 — CloakBrowser handles those
+  silently. Trackers using interactive captchas (reCAPTCHA v2 image
+  grid, hCaptcha) still require an external captcha-solving service;
+  the v12+ captcha wave addresses that.
+
+## Deliberate consequences
+
+- **Stealth becomes a one-liner.** `.WithCloakBrowser()` replaces the
+  pre-wave alternative (no first-class stealth; users wired
+  PuppeteerExtraSharp plugins manually or fell back to a sidecar Python
+  process). The library positioning sharpens — "the .NET scraper that
+  ships first-class stealth backends".
+- **The `WebReaper.Stealth.*` namespace becomes a community-contribution
+  on-ramp.** ADR-0009's "core stays dependency-light; satellites are the
+  growth surface" extended to a new category. Each fork is one PR-ready
+  pattern away from a NuGet listing.
+- **CLI auto-escalation has a coherent target.** Per ADR-0055's Hybrid C
+  UX, `webreaper scrape ... --browser` detects a bot-check, prompts the
+  user to download CloakBrowser, runs `webreaper stealth install`,
+  retries. The "what backend does --stealth install" question has one
+  answer (CloakBrowser is the v11 default; community satellites added
+  via the registry PR over time).
+
+## SemVer
+
+**Minor (additive).** New satellite package in the lockstep wave; no core
+surface change. v11.0.0's major is owned by ADR-0053's Puppeteer deletion.

--- a/docs/adr/0055-cli-browser-stealth-policy.md
+++ b/docs/adr/0055-cli-browser-stealth-policy.md
@@ -1,0 +1,306 @@
+# `WebReaper.Cli` browser/stealth acquisition policy: layered auto-spawn, Hybrid C escalation UX, curated backend registry, AOT invariant preserved
+
+## Status
+
+**Proposed** (2026-05-24). Slice 4 of 4 in the **Transports wave** (v11.0.0
+target). The CLI's documented browser story. Pins the policy decisions
+the rest of the wave (ADR-0052..0054) imply but don't own.
+
+## Context
+
+ADR-0043 established `WebReaper.Cli` as a Native-AOT single binary
+published across six RIDs (`linux-x64`, `linux-arm64`, `osx-x64`,
+`osx-arm64`, `win-x64`, `win-arm64`) via `release.yml`. The AOT
+constraint is load-bearing: a single self-contained binary the user
+downloads from a GitHub release and runs without a .NET runtime install.
+
+Through v10, the CLI's relationship to browser-mode page loading is
+implicit: the CLI references core only, and Dynamic page loading throws
+the core's `BrowserNotConfiguredPageLoadTransport` error directing users
+to add the `WebReaper.Puppeteer` satellite — which an AOT-distributed CLI
+cannot bake (PuppeteerSharp is not AOT-clean). The CLI's `--browser` flag
+existed at the surface but had no working backing transport.
+
+The Transports wave gives the CLI three new options to choose between
+(ADR-0052 `WebReaper.Cdp`, ADR-0053 `WebReaper.Playwright`, ADR-0054
+`WebReaper.Stealth.X`). Picking one without a documented policy guarantees
+drift; a contributor's next CLI feature would silently bake whichever
+satellite was convenient. This ADR pins the picks before drift starts:
+
+1. The CLI bakes **only** `WebReaper.Cdp` for browser support — the
+   AOT-clean transport (ADR-0052's bedrock).
+2. Browser binaries (vanilla Chromium *and* stealth Chromium forks) are
+   acquired through documented CLI subcommands (`browser install`,
+   `stealth install`); never bundled.
+3. Stealth-backend selection on the CLI surface goes through a curated
+   `KnownStealthBackends` static registry — community-contributed
+   satellites get CLI integration via a small PR.
+4. The user-facing escalation flow (vanilla → stealth) is the Hybrid C
+   shape from HITL Round 1: auto-escalate by default with a Y/n prompt;
+   power-user `--stealth` flag skips the vanilla attempt; unattended
+   `--auto-stealth` / `WEBREAPER_AUTO_STEALTH=1` for CI.
+
+## Decision
+
+### What the CLI bakes
+
+```
+WebReaper.Cli
+└── PackageReference Include="WebReaper.Cdp"
+```
+
+That single browser-related dependency. **`Microsoft.Playwright` is never
+baked**; nor is `PuppeteerSharp` (already deleted in ADR-0053); nor is
+any `WebReaper.Stealth.X` satellite — those ship for library use only.
+The AOT smoke test (`WebReaper.AotSmokeTest`) extends to publish the CLI
+binary with `WebReaper.Cdp` linked, asserting zero IL/AOT warnings — a CI
+guardrail that fails the build if a contributor adds an AOT-unfriendly
+reference to the CLI in a future PR.
+
+### Layered auto-spawn — three rungs
+
+When the CLI needs a browser endpoint (any command path that involves
+dynamic page loading), it walks three rungs in order:
+
+1. **BYO** — if `--browser-cdp-url <url>` is passed, the CLI uses it
+   directly via `WithCdpPageLoader(url)`. No spawn, no detection. The
+   power-user / sidecar / stealth path. The user owns lifecycle.
+
+2. **System detection** — `CdpLaunchHelpers.FindOnPath(...)` searches for
+   `google-chrome`, `chromium`, `chrome`, `microsoft-edge`, `msedge` on
+   PATH and platform-conventional install locations
+   (`/Applications/Google Chrome.app/...`, `C:\Program Files\Google\Chrome\...`).
+   If found, the CLI spawns it with `--remote-debugging-port=0 --headless=new`
+   and connects via `WithCdpPageLoader(CdpLaunchOptions)` (ADR-0052's
+   launch-and-connect overload). Lifecycle owned by the CLI; teardown on
+   process exit.
+
+3. **Managed** — if no system browser is detected, the CLI fails with an
+   actionable message pointing at `webreaper browser install`. The user
+   runs the install command; subsequent invocations find the managed
+   binary in `~/.webreaper/browsers/chromium-<version>/` and treat it as a
+   "system" detection (rung 2 succeeds against the cached path).
+
+The order matters: BYO first means stealth scenarios (which always come
+in as BYO from `webreaper stealth install` then `--browser-cdp-url`)
+take priority over any system browser; system detection second avoids
+gratuitous downloads when Chrome is already there; managed last is the
+fallback for clean machines (CI, fresh dev box).
+
+### `webreaper browser install` — vanilla Chromium acquisition
+
+```
+$ webreaper browser install
+ℹ  Downloading Chromium 146 for darwin-arm64 (152 MB) from Microsoft Playwright CDN...
+✓  Installed to ~/.webreaper/browsers/chromium-146/
+```
+
+**Source: Microsoft's Playwright CDN.** The CDN hosts Chromium builds
+under `https://playwright.azureedge.net/builds/chromium/...`,
+versioned, signed, with checksums in the release manifest. Used by
+`playwright install` worldwide; high availability; ungated by API key.
+Mirrors are documented in the CLI's README for users in regions where
+the CDN is slow. The alternative (Chromium's own
+`commondatastorage.googleapis.com/chromium-browser-snapshots/` server)
+hosts every snapshot ever built — millions of revisions; navigation by
+build number is painful for a one-off-install UX. Playwright's CDN is the
+curated subset that matters.
+
+**Subcommand surface:**
+- `webreaper browser install` — install the latest stable known version
+- `webreaper browser install --version 146` — pin
+- `webreaper browser list` — show installed cached versions
+- `webreaper browser uninstall <version>` — remove a cached version
+- `webreaper browser path` — print the cached binary path (for scripting)
+
+### `webreaper stealth install` — stealth-fork acquisition
+
+```
+$ webreaper stealth install
+ℹ  Available stealth backends (downloaded from upstream; not bundled):
+   [1] CloakBrowser   v0.3.30   220 MB   58 fingerprint patches; recommended
+       License: https://github.com/CloakHQ/CloakBrowser/blob/main/BINARY-LICENSE.md
+   Choice [1]: ↵
+?  By using CloakBrowser you accept its binary license. Proceed? [Y/n] y
+↓  Downloading CloakBrowser v0.3.30 from CloakHQ GitHub releases... ✓
+✓  Installed to ~/.webreaper/stealth/cloakbrowser/0.3.30/
+```
+
+**The `KnownStealthBackends` registry** is the curated list. AOT-friendly
+static data in `WebReaper.Cli/Stealth/KnownStealthBackends.cs`:
+
+```csharp
+public static class KnownStealthBackends {
+    public static readonly StealthBackend[] All = [
+        new("cloakbrowser",
+            displayName: "CloakBrowser",
+            recommendedVersion: "0.3.30",
+            sizeBytes: 220 * 1024 * 1024,
+            description: "58 fingerprint patches; recommended",
+            licenseUrl: "https://github.com/CloakHQ/CloakBrowser/blob/main/BINARY-LICENSE.md",
+            releaseManifestUrl: "https://api.github.com/repos/CloakHQ/CloakBrowser/releases/...",
+            launchSpec: CloakBrowserLaunchSpec.Default),
+        // Future: Patchright, Camoufox, … added via PR
+    ];
+}
+```
+
+Adding a backend to the CLI's surface is one PR per backend; the library
+satellite ships independently. The registry's job is the *picker UX* and
+the *unattended-CI defaults* — not the launch logic (which lives in the
+satellite the CLI does not bake; the CLI re-implements a minimal launcher
+per registered backend using `CdpLaunchHelpers` directly).
+
+**Subcommand surface:**
+- `webreaper stealth install` — interactive picker + Y/n license prompt
+- `webreaper stealth install cloakbrowser --yes` — unattended, name-pinned
+- `webreaper stealth list` — show installed stealth backends + versions
+- `webreaper stealth uninstall cloakbrowser` — remove cached install
+- `webreaper stealth path cloakbrowser` — print binary path
+
+### Hybrid C escalation UX — the scrape flow
+
+The `webreaper scrape` command implements the three-rung escalation that
+emerged from HITL Round 1:
+
+```
+$ webreaper scrape <url> --browser
+↓  Spawning managed Chromium...  ✓
+⚠  Page returned no records; last response looks like a bot-check (Cloudflare).
+?  Download CloakBrowser stealth backend (220 MB) and retry? [Y/n] y
+↓  Running 'webreaper stealth install cloakbrowser --yes' inline... ✓
+↓  Retrying with CloakBrowser... ✓
+✓  Scraped 1247 records
+```
+
+**Three modes:**
+- **Default (`--browser`):** rung 1-3 escalation. Auto-prompt on detected
+  bot-check; user accepts → inline install → retry. Detection is a
+  conservative heuristic: HTTP 403/429/503 from the loader OR
+  zero-records-extracted on a non-empty page that contains
+  Cloudflare/DataDome/PerimeterX challenge markers. False positives are
+  cheap (extra prompt, user says no, scrape continues with vanilla).
+- **Power-user (`--browser --stealth`):** skip the vanilla attempt, go
+  straight to stealth on request 1. Requires the stealth backend
+  pre-installed (or the prompt fires immediately).
+- **Unattended (`--browser --stealth --auto-stealth` or
+  `WEBREAPER_AUTO_STEALTH=1`):** Y/n prompts are bypassed; the CI
+  path. Same install + retry flow, no prompts.
+
+### AOT invariant — the guardrail
+
+The wave introduces no AOT-unfriendly dependency to the CLI. Two
+CI checks:
+
+1. **`WebReaper.AotSmokeTest` extended.** A new smoke step publishes
+   `WebReaper.Cli` with `PublishAot=true` across all six RIDs and
+   asserts zero IL/AOT warnings. The existing smoke test publishes a
+   library consumer; this one publishes the actual CLI as a binary. Run
+   per PR; a regression that pulls Microsoft.Playwright or
+   PuppeteerSharp into the CLI graph fails the build immediately.
+2. **The CLI's `.csproj` is the gate.** Reviewers see additions to
+   `<PackageReference>` in PRs touching `WebReaper.Cli/*.csproj` and can
+   block additions of AOT-hostile satellites. The pattern is the same as
+   `WebReaper`'s own `.csproj` — `WarningsAsErrors=CS1591` (ADR-0023)
+   applied to AOT warnings via the smoke test.
+
+The invariant is also written down in this ADR (the part of the ADR
+discipline that future contributors actually grep for): *the CLI bakes
+only `WebReaper.Cdp` for browser support. Adding Microsoft.Playwright or
+any `WebReaper.Stealth.X` satellite to the CLI's references regresses
+the AOT guarantee and must be rejected; the install-from-upstream
+pattern is the alternative.*
+
+## Considered options
+
+- **Layered auto-spawn + Hybrid C + curated registry, AOT preserved
+  (chosen).** Convergent answer from the HITL forks: F3 picked layered
+  auto-spawn, F4 picked per-backend satellites, the stealth-UX redesign
+  picked Hybrid C, F8 folded the registry into this ADR. The shape is
+  the resolution of those forks.
+- **Pure BYO — CLI requires `--browser-cdp-url` always (rejected).** Was
+  one of three F3 options. Cleanest possible CLI; biggest friction. The
+  casual user with Chrome installed has to know the CDP launch incantation
+  before they can scrape a JS-rendered page. Killed the casual scenario.
+- **Auto-spawn only — CLI always finds-or-downloads its own Chromium, no
+  BYO path (rejected).** Forecloses pointing at a stealth Chromium fork
+  from the CLI surface. Forecloses CI scenarios where the user runs a
+  proxied browser farm. F3-rejected on convergent reasons.
+- **Two CLI binaries: AOT (no browser) + JIT (with Playwright)
+  (rejected).** Doubles RID count to 12; sheds ADR-0043's single-binary
+  guarantee; bifurcates the user-install story. F3-rejected.
+- **Hardcoded list with no registry abstraction (effectively chosen, but
+  the *registry abstraction* itself was reconsidered).** The
+  `KnownStealthBackends` static array is the simplest "registry" the
+  AOT-CLI can carry. F8 considered a dynamic manifest convention
+  (`~/.webreaper/stealth-backends/*.json` scanned at runtime) but the
+  AOT constraint plus NuGet's lack of post-install hooks killed
+  dynamic discovery; the curated list is the working answer.
+- **`webreaper stealth install` auto-running on first `--browser`
+  bot-check detection without prompt (rejected).** Implicit 220 MB
+  download is intrusive; Hybrid C's Y/n prompt was explicitly chosen for
+  the user-consent surface. `--auto-stealth` is the explicit opt-out for
+  unattended use; the default stays prompting.
+
+## Accepted cost
+
+- **Community stealth-backend integration with CLI requires a PR.** The
+  satellite ships freely on NuGet; CLI's `KnownStealthBackends` entry +
+  the minimal launcher need a small PR. Trade for the curated-quality
+  bar (no surprise stealth backends in the CLI's `--stealth` picker)
+  and the AOT-safe static registry shape.
+- **The CLI re-implements minimal launcher logic per backend.** Because
+  the CLI can't reference `WebReaper.Stealth.X` (AOT), each entry in
+  `KnownStealthBackends` carries the fork-specific launch flags + binary
+  layout the CLI needs. Duplication with the satellite; cheap to keep in
+  sync (one tested place + one tested place is still better than one
+  AOT-hostile dependency).
+- **Bot-check heuristic for auto-escalation has false positives.** The
+  HTTP-status + page-content-marker detector misfires on legitimately
+  empty pages and on sites that return 403 for non-bot reasons. False
+  positives surface as an extra prompt the user dismisses with `n`; the
+  scrape continues. Documented in `--help`; tunable via
+  `--no-auto-stealth` to disable the heuristic entirely.
+- **Subcommand surface grows from one verb (`scrape`) to four (`scrape`,
+  `map`, `init`, `browser`, `stealth`).** Already five with ADR-0043's
+  `init`. This ADR adds two more verb roots. The CLI's surface area is
+  still small (< 20 leaf subcommands); growth is on-pattern.
+
+## Deliberate consequences
+
+- **The CLI gets a coherent browser story end-to-end.** A new user
+  installs the CLI, runs `webreaper scrape <url>`, hits the
+  Cloudflare-blocked tracker, prompts to download CloakBrowser, runs it,
+  ships data to MongoDB — all WebReaper-native, no Python, no manual
+  sidecar. The audiobook scenario from HITL Round 1 walks end-to-end.
+- **AOT-as-policy, not aspiration.** The CLI's AOT publishability is a
+  smoke-tested CI invariant; ADR-0009's "AOT-clean is a core guarantee"
+  extends concretely to the CLI surface. Future "let's bake Playwright
+  into the CLI" proposals have this ADR to push back against.
+- **Stealth-backend installer is a documented capability surface.**
+  Future captcha-solver wave (deferred from F5) can layer onto the same
+  install pattern (`webreaper captcha install <service>`); the precedent
+  this ADR sets is the template.
+
+## SemVer
+
+**Minor (additive).** New CLI subcommands; no break to existing surface.
+`webreaper scrape ... --browser` *behaviour* changes (previously threw,
+now works via the auto-spawn path) — that's a bug-fix-shaped behaviour
+delta, not a contract break. v11.0.0's major is owned by ADR-0053.
+
+## v2 deferrals (named so they don't drift into v11)
+
+- **Captcha-solver install pattern** (`webreaper captcha install`) — F5
+  from Round 1, deferred to v12+.
+- **Library-level transport escalation** (`TransportRouter`, the
+  proposer-validator dock applied to transports) — F7 from Round 1,
+  deferred to v12 pending demand.
+- **CLI auto-update for cached browser/stealth binaries** — a separate UX
+  question (background updater? manual? periodic check?); not in v11.
+- **Mirror-CDN config for `webreaper browser install`** beyond the
+  README documentation — first-class CLI flag (`--cdn-base-url`)
+  deferred until users in restricted regions report blocking.
+- **Multi-platform CloakBrowser RID coverage** — depends on what
+  CloakBrowser publishes. v11 satellite covers the RIDs the upstream
+  ships; gaps documented in the satellite README.


### PR DESCRIPTION
**Design-pass-only PR.** Four ADRs + a CONTEXT.md sharpening — zero code. Status `Proposed` across all four. Implementation lands in a follow-up wave once the design is HITL-approved here.

HITL-grilled via `/grill-with-docs` across two rounds (F1..F8 forks resolved). The wave shape is the convergent answer.

## Wave shape

| ADR | Scope | SemVer impact |
|---|---|---|
| [0052](https://github.com/pavlovtech/WebReaper/blob/worktree-transports-wave/docs/adr/0052-cdp-direct-loader-satellite.md) | `WebReaper.Cdp` — raw CDP transport satellite. The **bedrock** for Browser backend swaps; the CLI's baked browser transport. | Minor (new satellite) |
| [0053](https://github.com/pavlovtech/WebReaper/blob/worktree-transports-wave/docs/adr/0053-playwright-satellite-puppeteer-deletion.md) | `WebReaper.Playwright` satellite + **clean-cut deletion** of `WebReaper.Puppeteer` in the same release. Carries the future ADR-0009 named two years ago. | **Major** (the v11 break) |
| [0054](https://github.com/pavlovtech/WebReaper/blob/worktree-transports-wave/docs/adr/0054-stealth-backend-pattern-cloakbrowser.md) | Stealth-backend convention pattern + `WebReaper.Stealth.CloakBrowser` first concrete satellite. Install-from-upstream (same legal model as `playwright install`). | Minor (new satellite) |
| [0055](https://github.com/pavlovtech/WebReaper/blob/worktree-transports-wave/docs/adr/0055-cli-browser-stealth-policy.md) | CLI bakes only `WebReaper.Cdp` (AOT preserved); layered auto-spawn; Hybrid C escalation UX; `KnownStealthBackends` curated registry. | Minor (additive CLI surface) |

**Release target:** v11.0.0 (lockstep across 11+ packages — existing + `WebReaper.Cdp` + `WebReaper.Playwright` + `WebReaper.Stealth.CloakBrowser`).

## Glossary sharpening (CONTEXT.md)

- **New term: Browser backend** — the Chromium binary a browser Load transport launches and drives (system Chrome, managed Chromium, or a stealth Chromium fork). Distinct axis from Load transport.
- **Load transport adapter list refreshed:** HTTP + Playwright + CDP-direct (was: HTTP + headless browser singleton).

## Key design decisions (HITL resolutions)

- **F1 ✓** CDP-direct is its own satellite (`WebReaper.Cdp`), not folded into stealth ADR.
- **F2 ✓** v11 clean-cut: ship Playwright, delete Puppeteer same release. Matches ADR-0009 precedent.
- **F3 ✓** CLI uses CDP-direct; layered auto-spawn (BYO → system → managed) preserves AOT across all 6 RIDs.
- **F4 ✓** Per-backend satellites (`WebReaper.Stealth.X`), shared utils in `WebReaper.Cdp`. Matches ADR-0009 per-technology principle.
- **F5 deferred** — captcha-solving belongs in its own wave (different mechanism, recurring cost, TOS surface).
- **F6 deferred** — commercial unblockers (Bright Data, Zyte, Scrapfly, ZenRows, Oxylabs) are a different problem class (HTTP API).
- **F7 deferred** — library-level TransportRouter pending demand; CLI gets hardcoded escalation ladder in v11.
- **F8 ✓** ADR-0055 absorbs the backend-fork detection registry (Hybrid C UX needs a backend list to enumerate).

## Migration footprint (when implementation lands)

- **Delete:** `WebReaper.Puppeteer/` (3 files) + `WebReaper.Tests/WebReaper.Puppeteer.Tests/` (3 files)
- **Migrate:** `Examples/WebReaper.ConsoleApplication`, `Examples/BrownsfashionScraper`, `WebReaper.IntegrationTests/{ScraperTests,RedisDistributedAdapterTests}.cs`, `WebReaper.UnitTests/{HttpOnlyDefaultPageLoaderTests,SemanticActDispatchTests}.cs`
- **Add:** `WebReaper.Cdp/` + `WebReaper.Playwright/` + `WebReaper.Stealth.CloakBrowser/` and their `.Tests` counterparts
- **Touch in core (one file):** `BrowserNotConfiguredPageLoadTransport` error message string
- **CI:** `WebReaper.AotSmokeTest` extended to publish the CLI binary asserting zero IL/AOT warnings

## Next steps after merge

1. Open the implementation-slice PR mirroring the ADR-0051 implementation shape (the 30-item wave PR pattern).
2. Per-ADR review + per-ADR status flip Proposed → Accepted as each slice lands.
3. CHANGELOG migration section for v11.0.0; README upgrade guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)