### PR TITLE
Pre-tag finalize follow-up: CHANGELOG markers + README ADR range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 10.0.0 (in progress) — v10.x transports cleanup wave (ADR-0056..0058)
+## 10.0.0 — v10.x transports cleanup wave (ADR-0056..0058)
 
 The deliberate post-Transports-wave follow-ups named in ADRs 0052..0055 — the
 cleanup queue that the original wave shipped with documented gaps. Three new
@@ -49,7 +49,7 @@ Also in this wave:
   `WEBREAPER_STEALTH_SMOKE=1`. Vacuously passes when unset (CI stays
   hermetic). Handoff item #5.
 
-## 10.0.0 (in progress) — AI-native deepening campaign (ADR-0059..0064)
+## 10.0.0 — AI-native deepening campaign (ADR-0059..0064)
 
 Post-AI-native-wave architecture deepening surfaced by the post-wave review.
 Six interlocking ADRs that take the friction (four LLM adapters

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ That example is pure HTTP — no browser, no extra packages. For JavaScript-rend
 
 ### AI-native — the smallest possible call
 
-Since **10.0.0** (the AI-native wave, ADR-0040..0049), the funnel's no-schema wedge — one page,
+Since **10.0.0** (the AI-native wave + deepening, ADR-0040..0064), the funnel's no-schema wedge — one page,
 LLM-ready Markdown, no boilerplate:
 
 ```C#
@@ -195,7 +195,7 @@ dotnet add package WebReaper.Sqlite           # SQLite local durable scheduler +
 
 All eleven NuGet packages are versioned in lockstep at **`10.0.0`** (1 core + 10 satellites).
 Core and the satellites move together in release waves (ADR-0022 → `8.0.0`, ADR-0023 → `9.0.0`,
-ADR-0025 + ADR-0040..0049 → `10.0.0`); `WebReaper.Sqlite`, added at `7.1.0`, joined the lockstep
+ADR-0025 + ADR-0040..0064 → `10.0.0`); `WebReaper.Sqlite`, added at `7.1.0`, joined the lockstep
 from `8.0.0`; `WebReaper.AI`, `WebReaper.Mcp`, `WebReaper.Extraction.Attributes`, and
 `WebReaper.Extraction.Generators` joined at `10.0.0` (the AI-native wave). All packages are
 **MIT-licensed** (ADR-0017; relicensed from GPL-3.0-or-later in the 10.0.0 wave), and every


### PR DESCRIPTION
Small follow-up to PR #105 (the original pre-tag finalize). Two leftover `(in progress)` markers in CHANGELOG.md and two stale ADR-range references in README.md, all introduced by the two waves that landed after PR #105.

## Changes

**CHANGELOG.md** — strip `(in progress)` from two headings:
- `## 10.0.0 (in progress) — v10.x transports cleanup wave (ADR-0056..0058)` → `## 10.0.0 — …`
- `## 10.0.0 (in progress) — AI-native deepening campaign (ADR-0059..0064)` → `## 10.0.0 — …`

**README.md** — sweep the ADR range from `ADR-0040..0049` to `ADR-0040..0064`:
- Line 52 (AI-native section description)
- Line 198 (version-lockstep paragraph)

## Why

PR #105 stripped the original `(in progress)` markers and made master tag-ready at `31d5c87`. Two waves landed after that — transports cleanup (PR #113) and AI-native deepening (PR #114) — and each added its own section with a fresh `(in progress)` marker. This PR closes both, plus updates README's `0040..0049` (the original AI-native wave's range) to `0040..0064` (the wave + the deepening).

## Validation

- `dotnet build WebReaper.sln` — 0 errors. (Docs-only changes; no test impact.)

Master is tag-ready at the merge SHA — `v10.0.0` can be tagged immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)