### PR TITLE
Examples: WebReaper.SchemaInferenceShowcase — covers ADR-0067/0068/0069

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 10.0.0 — `WebReaper.SchemaInferenceShowcase` example project
+
+Funnel-side companion to [`WebReaper.AiNativeShowcase`](Examples/WebReaper.AiNativeShowcase/)
+(PR #101, which covered the original AI-native wave ADR-0040..0049).
+Closes the documentation gap for the v10.0.0 schema-inference dock —
+three sub-commands, each the minimal viable demo of one new public API:
+
+- **`alacarte`** (ADR-0067) — à la carte registration via
+  `.ExtractInferred(goal).WithLlmSchemaInferrer(client)`.
+- **`useai`** (ADR-0068) — one-line policy via `.UseAi(client,
+  new AiOptions(Policy: AiPolicyMode.Inferred))`.
+- **`reinfer`** (ADR-0069) — validator-driven re-inference,
+  demonstrated with scripted stubs across three configurations
+  (default opt-out auto-heal, strict opt-out, cost cap).
+
+All three sub-commands use a deterministic in-process `StubChatClient`
+so the example runs offline; the production swap is any
+`Microsoft.Extensions.AI.IChatClient` adapter (OpenAI / Anthropic /
+Ollama / Azure AI / …). `alacarte` and `useai` actually crawl
+`example.com` end-to-end and print the extracted record.
+
+Also fixes one cref warning on `LearnedSchemaContentExtractor.cs`
+introduced by the ADR-0069 implementation (the satellite-side
+`LlmSchemaInferrer` type was referenced via `<see cref=>` from core
+where it cannot resolve; replaced with `<c>`).
+
 ## 10.0.0 — AI-native completion wave (ADR-0068 + ADR-0069)
 
 Two paired ADRs closing the named v1 deferrals on ADR-0067 (the schema

--- a/Examples/WebReaper.SchemaInferenceShowcase/Program.cs
+++ b/Examples/WebReaper.SchemaInferenceShowcase/Program.cs
@@ -1,0 +1,237 @@
+// ADR-0067 + ADR-0068 + ADR-0069 — the v10.0.0 schema-inference dock on
+// display. Each sub-command exercises one public API on the new surface:
+//
+//   dotnet run --project Examples/WebReaper.SchemaInferenceShowcase -- alacarte
+//   dotnet run --project Examples/WebReaper.SchemaInferenceShowcase -- useai
+//   dotnet run --project Examples/WebReaper.SchemaInferenceShowcase -- reinfer
+//
+// Network: `alacarte` and `useai` hit `example.com` (a single page;
+// the inference call goes to a deterministic in-process StubChatClient
+// so no API key is required). `reinfer` constructs the wrapper
+// directly with synthetic stubs and never touches the network.
+
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using WebReaper.AI;
+using WebReaper.AI.Llm;
+using WebReaper.Builders;
+using WebReaper.Core.Parser.Abstract;
+using WebReaper.Core.Parser.Concrete;
+using WebReaper.Domain.Parsing;
+using WebReaper.SchemaInferenceShowcase;
+
+string command = args.Length == 0 ? "alacarte" : args[0];
+
+switch (command)
+{
+    case "alacarte": await AlaCarte();    break;
+    case "useai":    await UseAiPolicy(); break;
+    case "reinfer":  await ReInfer();     break;
+    default:
+        Console.Error.WriteLine($"Unknown subcommand '{command}'. " +
+            "Expected one of: alacarte, useai, reinfer.");
+        Environment.Exit(2);
+        break;
+}
+
+// ADR-0067 — `.ExtractInferred(goal?)` is the third `ICrawlSeed`
+// terminal. The inferrer proposes a Schema on the first page; the
+// deterministic fold consumes it on every subsequent page. À la carte
+// via `.WithLlmSchemaInferrer(client, options?)`.
+static async Task AlaCarte()
+{
+    // Stub returns a flat field-name → CSS-selector map. In production
+    // this is one round-trip to OpenAI / Anthropic / Ollama / etc.
+    var stub = new StubChatClient(
+        """{"fields": {"title": "h1", "summary": "p"}}""");
+
+    var engine = await ScraperEngineBuilder
+        .Crawl("https://example.com/")
+        .ExtractInferred(goal: "page title and summary")
+        .WithLlmSchemaInferrer(stub)
+        .WriteToConsole()
+        .PageCrawlLimit(1)
+        .BuildAsync();
+
+    await engine.RunAsync();
+    Console.WriteLine(
+        $"(à la carte: inferred a schema once via {stub.Calls} LLM call; " +
+        "every subsequent page would run the deterministic fold against " +
+        "the cached schema.)");
+}
+
+// ADR-0068 — `AiPolicyMode.Inferred` makes `.ExtractInferred(goal?)`
+// a one-liner via `.UseAi(client, AiOptions(Policy: Inferred))`. The
+// policy wires `WithLlmSchemaInferrer + WithLlmActionResolver`
+// (the orthogonal action surface). Mutually exclusive with
+// Recommended / LlmPrimary / ExtractionOnly — those register an
+// IContentExtractor that would shadow LearnedSchemaContentExtractor.
+static async Task UseAiPolicy()
+{
+    var stub = new StubChatClient(
+        """{"fields": {"title": "h1", "summary": "p"}}""");
+
+    var engine = await ScraperEngineBuilder
+        .Crawl("https://example.com/")
+        .ExtractInferred(goal: "page title and summary")
+        .UseAi(stub, new AiOptions(Policy: AiPolicyMode.Inferred))
+        .WriteToConsole()
+        .PageCrawlLimit(1)
+        .BuildAsync();
+
+    await engine.RunAsync();
+    Console.WriteLine(
+        "(one-line policy: .UseAi(client, Inferred) wires the inferrer " +
+        "AND the action resolver in one call. The synthesised inferrer " +
+        "options inherit CachePolicy.Hinted from AiOptions for the " +
+        "Anthropic cost benefit.)");
+}
+
+// ADR-0069 — validator-driven re-inference. The LearnedSchemaContentExtractor
+// wrapper consults the registered ISchemaValidator (ADR-0062 default:
+// SchemaSatisfiedValidator) on every inner-extractor output; N
+// consecutive invalid verdicts drop the cached inferred schema and
+// trigger re-inference on the next call. Default N = 3; opt out with
+// ReInferAfterFailures = 0; cost cap via MaxReInferencesPerInstance.
+//
+// Demonstrated by constructing the wrapper directly with scripted
+// stubs — easier to see the count progression than driving a real
+// multi-page crawl. The unit tests (LearnedSchemaReInferenceTests)
+// pin the same mechanics across the full matrix.
+static async Task ReInfer()
+{
+    // Stub inferrer cycles through two schemas: the first one points
+    // at selectors that produce empty content (triggers validator
+    // failures); the second one is correct (passes validation).
+    var inferrer = new ScriptedInferrer(
+        new Schema { new SchemaElement("title", "#bad-selector") },
+        new Schema { new SchemaElement("title", "h1") });
+
+    // Inner extractor: empty-content for the first cached schema,
+    // valid content for the second. Drives the validator's verdict.
+    var inner = new ScriptedExtractor(usesSecondSchemaAfter: 1);
+
+    // Default behaviour — ReInferAfterFailures = 3.
+    var wrapper = new LearnedSchemaContentExtractor(
+        inferrer, inner,
+        goal: "page title",
+        logger: NullLogger.Instance,
+        validator: SchemaSatisfiedValidator.Instance,
+        reInferAfterFailures: 3,
+        maxReInferencesPerInstance: int.MaxValue);
+
+    Console.WriteLine("--- default (ReInferAfterFailures: 3) ---");
+    for (var i = 1; i <= 7; i++)
+    {
+        var result = await wrapper.ExtractAsync($"<page{i}/>", null);
+        var title = result["title"]?.GetValue<string>() ?? "(empty)";
+        Console.WriteLine(
+            $"  page {i}: title='{title}' " +
+            $"(inferrer.Calls={inferrer.Calls}, " +
+            $"wrapper.ReInferencesUsed={wrapper.ReInferencesUsed})");
+    }
+    await wrapper.DisposeAsync();
+
+    // Opt-out — ReInferAfterFailures = 0 preserves the ADR-0067 v1
+    // trust-the-cache behaviour. The wrapper never drops the cached
+    // schema regardless of validator verdicts.
+    Console.WriteLine();
+    Console.WriteLine("--- opt-out (ReInferAfterFailures: 0) ---");
+    var inferrerOptOut = new ScriptedInferrer(
+        new Schema { new SchemaElement("title", "#bad-selector") },
+        new Schema { new SchemaElement("title", "h1") });
+    var innerOptOut = new ScriptedExtractor(usesSecondSchemaAfter: 1);
+    var wrapperOptOut = new LearnedSchemaContentExtractor(
+        inferrerOptOut, innerOptOut,
+        goal: "page title",
+        validator: SchemaSatisfiedValidator.Instance,
+        reInferAfterFailures: 0);
+    for (var i = 1; i <= 5; i++)
+        await wrapperOptOut.ExtractAsync($"<page{i}/>", null);
+    Console.WriteLine(
+        $"  after 5 always-failing pages: " +
+        $"inferrer.Calls={inferrerOptOut.Calls}, " +
+        $"wrapper.ReInferencesUsed={wrapperOptOut.ReInferencesUsed} " +
+        "(strict ADR-0067 v1 trust-the-cache preserved)");
+    await wrapperOptOut.DisposeAsync();
+
+    // Cost cap — MaxReInferencesPerInstance bounds total LLM spend.
+    Console.WriteLine();
+    Console.WriteLine("--- cost cap (MaxReInferencesPerInstance: 1) ---");
+    var inferrerCap = new ScriptedInferrer(
+        new Schema { new SchemaElement("title", "#bad") },
+        new Schema { new SchemaElement("title", "#also-bad") },
+        new Schema { new SchemaElement("title", "h1") });
+    var innerCap = new ScriptedExtractor(usesSecondSchemaAfter: int.MaxValue);
+    var wrapperCap = new LearnedSchemaContentExtractor(
+        inferrerCap, innerCap,
+        goal: "page title",
+        validator: SchemaSatisfiedValidator.Instance,
+        reInferAfterFailures: 3,
+        maxReInferencesPerInstance: 1);
+    for (var i = 1; i <= 10; i++)
+        await wrapperCap.ExtractAsync($"<page{i}/>", null);
+    Console.WriteLine(
+        $"  after 10 always-failing pages: " +
+        $"inferrer.Calls={inferrerCap.Calls}, " +
+        $"wrapper.ReInferencesUsed={wrapperCap.ReInferencesUsed} " +
+        "(cap honoured — second drop kept stale schema, logged at Warning)");
+    await wrapperCap.DisposeAsync();
+
+    Console.WriteLine();
+    Console.WriteLine(
+        "(re-inference: same proposer-validator wedge as ADR-0046/0047/0050/0051, " +
+        "now applied to schema lifecycle. The wrapper's ReInferencesUsed property " +
+        "is the cost-observability surface.)");
+}
+
+// Stub inferrer that cycles through a list of schemas — first call
+// returns the first; each subsequent call returns the next (or the
+// last forever).
+internal sealed class ScriptedInferrer : ISchemaInferrer
+{
+    private readonly Schema[] _schemas;
+    private int _calls;
+    public int Calls => _calls;
+
+    public ScriptedInferrer(params Schema[] schemas) => _schemas = schemas;
+
+    public Task<Schema> InferAsync(string document, string? goal = null,
+        CancellationToken cancellationToken = default)
+    {
+        var idx = Math.Min(_calls, _schemas.Length - 1);
+        Interlocked.Increment(ref _calls);
+        return Task.FromResult(_schemas[idx]);
+    }
+}
+
+// Stub extractor: returns empty content until N successful
+// re-inferences have happened (then returns valid content). Used to
+// drive the validator's verdict from invalid → valid.
+internal sealed class ScriptedExtractor : IContentExtractor
+{
+    private readonly int _flipAfter;
+    private int _calls;
+
+    public ScriptedExtractor(int usesSecondSchemaAfter) => _flipAfter = usesSecondSchemaAfter;
+
+    public Task<JsonObject> ExtractAsync(string document, Schema? schema)
+    {
+        Interlocked.Increment(ref _calls);
+        // The extractor returns content based on the field's selector.
+        // We simulate by reading the cached schema's first child selector;
+        // selectors starting with "#" we treat as "produces empty content"
+        // (the bad-selector path), anything else as "produces real content."
+        var firstChild = schema?.Children.FirstOrDefault() as SchemaElement;
+        var selector = firstChild?.Selector ?? string.Empty;
+        var produces = selector.StartsWith('#') ? string.Empty : "Example Domain";
+
+        // The flipAfter trick: after _flipAfter empty-extractions, the
+        // demo wrapper switches to the "good" cached schema (the
+        // inferrer's second response), and this extractor produces
+        // content because that schema's selector doesn't start with '#'.
+        // No state across calls beyond the counter.
+        return Task.FromResult(new JsonObject { ["title"] = produces });
+    }
+}

--- a/Examples/WebReaper.SchemaInferenceShowcase/Program.cs
+++ b/Examples/WebReaper.SchemaInferenceShowcase/Program.cs
@@ -110,7 +110,7 @@ static async Task ReInfer()
 
     // Inner extractor: empty-content for the first cached schema,
     // valid content for the second. Drives the validator's verdict.
-    var inner = new ScriptedExtractor(usesSecondSchemaAfter: 1);
+    var inner = new ScriptedExtractor();
 
     // Default behaviour — ReInferAfterFailures = 3.
     var wrapper = new LearnedSchemaContentExtractor(
@@ -141,7 +141,7 @@ static async Task ReInfer()
     var inferrerOptOut = new ScriptedInferrer(
         new Schema { new SchemaElement("title", "#bad-selector") },
         new Schema { new SchemaElement("title", "h1") });
-    var innerOptOut = new ScriptedExtractor(usesSecondSchemaAfter: 1);
+    var innerOptOut = new ScriptedExtractor();
     var wrapperOptOut = new LearnedSchemaContentExtractor(
         inferrerOptOut, innerOptOut,
         goal: "page title",
@@ -163,7 +163,7 @@ static async Task ReInfer()
         new Schema { new SchemaElement("title", "#bad") },
         new Schema { new SchemaElement("title", "#also-bad") },
         new Schema { new SchemaElement("title", "h1") });
-    var innerCap = new ScriptedExtractor(usesSecondSchemaAfter: int.MaxValue);
+    var innerCap = new ScriptedExtractor();
     var wrapperCap = new LearnedSchemaContentExtractor(
         inferrerCap, innerCap,
         goal: "page title",
@@ -206,32 +206,19 @@ internal sealed class ScriptedInferrer : ISchemaInferrer
     }
 }
 
-// Stub extractor: returns empty content until N successful
-// re-inferences have happened (then returns valid content). Used to
-// drive the validator's verdict from invalid → valid.
+// Stub extractor whose output is purely a function of the cached
+// schema's first selector — selectors starting with `#` produce
+// empty content (drives the validator to "invalid"); anything else
+// produces "Example Domain" (validator "valid"). Stateless; the demo
+// flips behaviour by having the inferrer swap to a non-`#` selector
+// after the wrapper drops the cache.
 internal sealed class ScriptedExtractor : IContentExtractor
 {
-    private readonly int _flipAfter;
-    private int _calls;
-
-    public ScriptedExtractor(int usesSecondSchemaAfter) => _flipAfter = usesSecondSchemaAfter;
-
     public Task<JsonObject> ExtractAsync(string document, Schema? schema)
     {
-        Interlocked.Increment(ref _calls);
-        // The extractor returns content based on the field's selector.
-        // We simulate by reading the cached schema's first child selector;
-        // selectors starting with "#" we treat as "produces empty content"
-        // (the bad-selector path), anything else as "produces real content."
         var firstChild = schema?.Children.FirstOrDefault() as SchemaElement;
         var selector = firstChild?.Selector ?? string.Empty;
         var produces = selector.StartsWith('#') ? string.Empty : "Example Domain";
-
-        // The flipAfter trick: after _flipAfter empty-extractions, the
-        // demo wrapper switches to the "good" cached schema (the
-        // inferrer's second response), and this extractor produces
-        // content because that schema's selector doesn't start with '#'.
-        // No state across calls beyond the counter.
         return Task.FromResult(new JsonObject { ["title"] = produces });
     }
 }

--- a/Examples/WebReaper.SchemaInferenceShowcase/README.md
+++ b/Examples/WebReaper.SchemaInferenceShowcase/README.md
@@ -1,0 +1,110 @@
+# WebReaper.SchemaInferenceShowcase
+
+Showcase example for the v10.0.0 schema-inference dock — ADR-0067 (the
+seam + wrapper + seed terminal), ADR-0068 (`.UseAi(...)` one-line
+policy), and ADR-0069 (validator-driven re-inference).
+
+Funnel-side companion to [`WebReaper.AiNativeShowcase`](../WebReaper.AiNativeShowcase/)
+(which covers ADR-0040..0049 from the original AI-native wave).
+
+## Run
+
+All three scenarios use a deterministic in-process `StubChatClient` so
+the example runs offline; the production swap is any
+[`Microsoft.Extensions.AI.IChatClient`](https://learn.microsoft.com/dotnet/ai/microsoft-extensions-ai)
+adapter — OpenAI, Anthropic, Ollama, Azure AI, …
+
+```bash
+# ADR-0067 — à la carte: .ExtractInferred(goal).WithLlmSchemaInferrer(client)
+dotnet run --project Examples/WebReaper.SchemaInferenceShowcase -- alacarte
+
+# ADR-0068 — one-line policy: .ExtractInferred(goal).UseAi(client, Inferred)
+dotnet run --project Examples/WebReaper.SchemaInferenceShowcase -- useai
+
+# ADR-0069 — validator-driven re-inference: default / opt-out / cost cap
+dotnet run --project Examples/WebReaper.SchemaInferenceShowcase -- reinfer
+```
+
+## What each scenario demonstrates
+
+### `alacarte` (ADR-0067)
+
+The à la carte registration shape:
+
+```csharp
+var engine = await ScraperEngineBuilder
+    .Crawl("https://example.com/")
+    .ExtractInferred(goal: "page title and summary")
+    .WithLlmSchemaInferrer(chatClient)
+    .WriteToConsole()
+    .BuildAsync();
+```
+
+First page pays the LLM once; the proposed `Schema` caches on the
+[`LearnedSchemaContentExtractor`](../../WebReaper/Core/Parser/Concrete/LearnedSchemaContentExtractor.cs)
+wrapper; every subsequent page runs the deterministic
+[`SchemaFold`](../../WebReaper/Core/Parser/Concrete/SchemaFold.cs)
+against the cached schema. The cheapest dock of the project-level
+proposer-validator pattern — one LLM call per crawl.
+
+### `useai` (ADR-0068)
+
+The one-line policy equivalent:
+
+```csharp
+var engine = await ScraperEngineBuilder
+    .Crawl("https://example.com/")
+    .ExtractInferred(goal: "page title and summary")
+    .UseAi(chatClient, new AiOptions(Policy: AiPolicyMode.Inferred))
+    .WriteToConsole()
+    .BuildAsync();
+```
+
+`AiPolicyMode.Inferred` is the fifth canned arm. It wires
+`WithLlmSchemaInferrer + WithLlmActionResolver` (the orthogonal
+action surface — useful regardless of extraction strategy).
+Mutually exclusive with `Recommended` / `LlmPrimary` /
+`ExtractionOnly` (those register an `IContentExtractor` that would
+shadow `LearnedSchemaContentExtractor`).
+
+On the agent builder `.UseAi(Inferred)` throws actionably — the
+brain proposes its own schemas per `AgentDecision.Extract(schema)`,
+so a separate inferrer is structurally redundant.
+
+### `reinfer` (ADR-0069)
+
+The wrapper's validator-driven re-inference, demonstrated by
+constructing `LearnedSchemaContentExtractor` directly with scripted
+stubs (easier to see the count progression than driving a real
+multi-page crawl — the unit tests pin the same mechanics across the
+full matrix). Three sub-demos:
+
+1. **Default** (`ReInferAfterFailures: 3`): three consecutive
+   validator failures drop the cached schema; the next call
+   re-infers. A wrong first-page inference auto-heals — the crawl
+   stops producing empty records.
+2. **Opt-out** (`ReInferAfterFailures: 0`): preserves the ADR-0067
+   v1 trust-the-cache behaviour. The wrapper never drops the cached
+   schema regardless of validator verdicts. The strict no-extra-LLM-
+   spend posture.
+3. **Cost cap** (`MaxReInferencesPerInstance: 1`): bounds total LLM
+   spend on one wrapper instance. After the cap, further failures
+   keep the stale schema and log at Warning. The unattended / CI /
+   cron guardrail.
+
+The wrapper's public
+[`ReInferencesUsed`](../../WebReaper/Core/Parser/Concrete/LearnedSchemaContentExtractor.cs)
+property is the cost-observability surface.
+
+## How the funnel composes
+
+| Strategy | Seed terminal | Policy one-liner |
+|---|---|---|
+| Schema-driven | `.Extract(schema)` | `.UseAi(client)` |
+| LLM-primary  | `.Extract(schema)` | `.UseAi(client, new AiOptions(Policy: LlmPrimary))` |
+| Extraction-only | `.Extract(schema)` | `.UseAi(client, new AiOptions(Policy: ExtractionOnly))` |
+| Markdown | `.AsMarkdown()` | (no `.UseAi(...)` needed) |
+| Inferred | `.ExtractInferred(goal?)` | `.UseAi(client, new AiOptions(Policy: Inferred))` |
+
+`WebReaper.AiNativeShowcase` covers the first four;
+`WebReaper.SchemaInferenceShowcase` is the fifth row.

--- a/Examples/WebReaper.SchemaInferenceShowcase/StubChatClient.cs
+++ b/Examples/WebReaper.SchemaInferenceShowcase/StubChatClient.cs
@@ -1,0 +1,44 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+
+namespace WebReaper.SchemaInferenceShowcase;
+
+// Minimal IChatClient stub — returns a canned response per call (cycling
+// through a list when more than one is supplied). The real DI point in
+// production is an OpenAI / Anthropic / Ollama / Azure-AI IChatClient
+// adapter from the Microsoft.Extensions.AI ecosystem; the consumer
+// brings their own.
+internal sealed class StubChatClient : IChatClient
+{
+    private readonly string[] _responses;
+    private int _calls;
+
+    public StubChatClient(params string[] responses) => _responses = responses;
+    public int Calls => _calls;
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var idx = Math.Min(_calls, _responses.Length - 1);
+        Interlocked.Increment(ref _calls);
+        var msg = new ChatMessage(ChatRole.Assistant, _responses[idx]);
+        return Task.FromResult(new ChatResponse(msg));
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default) => Empty(cancellationToken);
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> Empty(
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+    public void Dispose() { }
+}

--- a/Examples/WebReaper.SchemaInferenceShowcase/WebReaper.SchemaInferenceShowcase.csproj
+++ b/Examples/WebReaper.SchemaInferenceShowcase/WebReaper.SchemaInferenceShowcase.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    Showcase example for the v10.0.0 schema-inference ADRs (0067 / 0068 /
+    0069). One project, one Program.cs that dispatches by sub-command:
+    `dotnet run` then `alacarte`, `useai`, or `reinfer`. Each sub-command
+    is the minimal viable demo of one public API on the new surface — the
+    funnel-side companion to WebReaper.AiNativeShowcase (PR #101), which
+    covered the original AI-native wave (ADR-0040..0049).
+
+    Why one project, not three: a consumer scanning Examples/ should see
+    "à la carte registration → one-line .UseAi(Inferred) policy →
+    runtime auto-recovery via re-inference" together, with the same shape
+    of stub IChatClient swap-in across each. Three tiny projects would
+    fragment that story.
+
+    All three sub-commands use a deterministic in-process StubChatClient
+    so the example runs offline; the production swap is an OpenAI /
+    Anthropic / Ollama / Azure-AI IChatClient adapter from the
+    Microsoft.Extensions.AI ecosystem.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WebReaper\WebReaper.csproj" />
+    <ProjectReference Include="..\..\WebReaper.AI\WebReaper.AI.csproj" />
+  </ItemGroup>
+</Project>

--- a/WebReaper.sln
+++ b/WebReaper.sln
@@ -80,6 +80,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.Stealth.CloakBrow
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.Cdp.Tests", "WebReaper.Tests\WebReaper.Cdp.Tests\WebReaper.Cdp.Tests.csproj", "{9EB0063B-5B41-43FE-A100-C0536A83D586}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.SchemaInferenceShowcase", "Examples\WebReaper.SchemaInferenceShowcase\WebReaper.SchemaInferenceShowcase.csproj", "{75F812A2-98D1-42CD-885E-2496F614667C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -474,6 +476,18 @@ Global
 		{9EB0063B-5B41-43FE-A100-C0536A83D586}.Release|x64.Build.0 = Release|Any CPU
 		{9EB0063B-5B41-43FE-A100-C0536A83D586}.Release|x86.ActiveCfg = Release|Any CPU
 		{9EB0063B-5B41-43FE-A100-C0536A83D586}.Release|x86.Build.0 = Release|Any CPU
+		{75F812A2-98D1-42CD-885E-2496F614667C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75F812A2-98D1-42CD-885E-2496F614667C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75F812A2-98D1-42CD-885E-2496F614667C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{75F812A2-98D1-42CD-885E-2496F614667C}.Debug|x64.Build.0 = Debug|Any CPU
+		{75F812A2-98D1-42CD-885E-2496F614667C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{75F812A2-98D1-42CD-885E-2496F614667C}.Debug|x86.Build.0 = Debug|Any CPU
+		{75F812A2-98D1-42CD-885E-2496F614667C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75F812A2-98D1-42CD-885E-2496F614667C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75F812A2-98D1-42CD-885E-2496F614667C}.Release|x64.ActiveCfg = Release|Any CPU
+		{75F812A2-98D1-42CD-885E-2496F614667C}.Release|x64.Build.0 = Release|Any CPU
+		{75F812A2-98D1-42CD-885E-2496F614667C}.Release|x86.ActiveCfg = Release|Any CPU
+		{75F812A2-98D1-42CD-885E-2496F614667C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -496,6 +510,7 @@ Global
 		{1C6D3A0A-B364-4B82-A6D3-E8FC340D9912} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
 		{B0F5F3BE-EFEF-48C9-8B7C-5C96AFD674FA} = {75C97094-26FC-484A-A354-E33BBD6355A8}
 		{9EB0063B-5B41-43FE-A100-C0536A83D586} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
+		{75F812A2-98D1-42CD-885E-2496F614667C} = {75C97094-26FC-484A-A354-E33BBD6355A8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8413198B-8D26-4E30-A5E2-E0FBC4DCEA59}

--- a/WebReaper/Core/Parser/Concrete/LearnedSchemaContentExtractor.cs
+++ b/WebReaper/Core/Parser/Concrete/LearnedSchemaContentExtractor.cs
@@ -80,7 +80,7 @@ public sealed class LearnedSchemaContentExtractor : IContentExtractor, IAsyncDis
     /// <param name="reInferAfterFailures">Number of consecutive validator
     /// failures before dropping the cached schema (ADR-0069). Default
     /// <c>0</c> = never re-infer (preserves ADR-0067 v1 trust-the-cache
-    /// behaviour). The satellite <see cref="LlmSchemaInferrer"/> ships
+    /// behaviour). The satellite <c>LlmSchemaInferrer</c> ships
     /// <c>3</c> as the per-role default via
     /// <c>LlmSchemaInferrerOptions.ReInferAfterFailures</c>.</param>
     /// <param name="maxReInferencesPerInstance">Cost cap — once the


### PR DESCRIPTION
Funnel-side companion to [`WebReaper.AiNativeShowcase`](https://github.com/pavlovtech/WebReaper/tree/master/Examples/WebReaper.AiNativeShowcase) (PR [#101](https://github.com/pavlovtech/WebReaper/pull/101), which covered ADR-0040..0049 from the original AI-native wave). Closes the documentation gap for the v10.0.0 schema-inference dock — three sub-commands, each the minimal viable demo of one new public API.

**Base:** `feat/v10-ai-completion` (the [PR #118](https://github.com/pavlovtech/WebReaper/pull/118) branch) so this PR's diff stays focused on the new example. GitHub will auto-retarget to `master` when #117 + #118 merge in order.

## What this PR ships

- **`Examples/WebReaper.SchemaInferenceShowcase/`** — new example project added to `WebReaper.sln` (CI builds it as part of the whole-solution sweep). Same shape as the existing `WebReaper.AiNativeShowcase`: one csproj, one `Program.cs` dispatching by `args[0]`, local `StubChatClient.cs`. ~430 lines + README.
- **One-line cref warning fix** on `WebReaper/Core/Parser/Concrete/LearnedSchemaContentExtractor.cs` (the ADR-0069 impl referenced the satellite-side `LlmSchemaInferrer` via `<see cref=>` from core where it cannot resolve; replaced with `<c>`).

## Subcommands

```bash
# ADR-0067 — à la carte: .ExtractInferred(goal).WithLlmSchemaInferrer(client)
dotnet run --project Examples/WebReaper.SchemaInferenceShowcase -- alacarte

# ADR-0068 — one-line policy: .ExtractInferred(goal).UseAi(client, Inferred)
dotnet run --project Examples/WebReaper.SchemaInferenceShowcase -- useai

# ADR-0069 — validator-driven re-inference: default / opt-out / cost cap
dotnet run --project Examples/WebReaper.SchemaInferenceShowcase -- reinfer
```

All three subcommands use a deterministic in-process `StubChatClient` so the example runs offline. Verified-end-to-end output:

### `alacarte` (ADR-0067)

```
{
  "title": "Example Domain",
  "summary": "This domain is for use in documentation examples without needing permission. Avoid use in operations.",
  "url": "https://example.com/"
}
(à la carte: inferred a schema once via 1 LLM call; every subsequent page would run the deterministic fold against the cached schema.)
```

### `useai` (ADR-0068)

Same record (the stub returns the same canned `{"fields": {"title": "h1", "summary": "p"}}`). Demonstrates the policy equivalence — `.UseAi(client, Inferred)` is exactly equivalent to `.WithLlmSchemaInferrer(client).WithLlmActionResolver(client)`.

### `reinfer` (ADR-0069)

```
--- default (ReInferAfterFailures: 3) ---
  page 1: title='' (inferrer.Calls=1, wrapper.ReInferencesUsed=0)
  page 2: title='' (inferrer.Calls=1, wrapper.ReInferencesUsed=0)
  page 3: title='' (inferrer.Calls=1, wrapper.ReInferencesUsed=1)
  page 4: title='Example Domain' (inferrer.Calls=2, wrapper.ReInferencesUsed=1)
  page 5: title='Example Domain' (inferrer.Calls=2, wrapper.ReInferencesUsed=1)
  …

--- opt-out (ReInferAfterFailures: 0) ---
  after 5 always-failing pages: inferrer.Calls=1, wrapper.ReInferencesUsed=0
  (strict ADR-0067 v1 trust-the-cache preserved)

--- cost cap (MaxReInferencesPerInstance: 1) ---
  after 10 always-failing pages: inferrer.Calls=2, wrapper.ReInferencesUsed=1
  (cap honoured — second drop kept stale schema, logged at Warning)
```

The 3rd page triggers the re-inference (3 consecutive failures); the 4th page succeeds with the fresh schema. The wrapper's public `ReInferencesUsed` property is the cost-observability surface.

## Guardrails

- `dotnet build WebReaper.sln`: **0 errors**, 20 pre-existing warnings (none new from this PR).
- `WebReaper.UnitTests`: **409 / 409** pass (no regressions).
- `WebReaper.AI.Tests`: **240 / 240** pass (no regressions).
- All three subcommands actually run end-to-end against the offline stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)