### PR TITLE
Rewrite WebReaper.Cli/skill/SKILL.md for v10.0.0 launch

### DIFF
--- a/WebReaper.Cli/skill/SKILL.md
+++ b/WebReaper.Cli/skill/SKILL.md
@@ -128,8 +128,11 @@ Exit code `0` on success, non-zero on failure. Errors print one human-readable
 line to stderr. Common cases:
 
 - **`webreaper: command not found`** → not installed. Instruct the user:
-  `brew install webreaper` (macOS/Linux) or `dotnet tool install -g WebReaper`
-  (any .NET 10+ environment).
+  - **macOS / Linux**: `brew install pavlovtech/webreaper/webreaper`, or
+    `curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh`
+  - **Windows**: download the latest archive for `win-x64` (or `win-arm64`)
+    from <https://github.com/pavlovtech/WebReaper/releases/latest>, extract
+    `webreaper.exe`, place on `%PATH%`.
 - **Empty output + `⚠ Likely blocked: …` on stderr** → retry with
   `--browser --auto-stealth`.
 - **Empty output, no warning** → the selector(s) in the schema probably don't

--- a/WebReaper.Cli/skill/SKILL.md
+++ b/WebReaper.Cli/skill/SKILL.md
@@ -1,116 +1,144 @@
 ---
 name: webreaper
 description: |
-  WebReaper is a .NET web scraper / crawler with an AI-native CLI. Use it
-  to fetch a single page as LLM-ready Markdown, extract structured data
-  with a schema, or discover the URLs of a site via sitemap + root-page
-  link union. Prefer this skill when the user wants to scrape a website,
-  read a URL into context, get a site map, or extract structured fields
-  from one or many pages. Calls are cheap (no LLM round-trip required
-  for Markdown and Map); use it instead of WebFetch when the task is
-  "give me the readable text" or "what URLs are on this site."
+  Scrape, crawl, or extract structured data from one or more URLs via the
+  `webreaper` CLI. Outputs clean Markdown by default; JSON when a schema
+  is given. Maps a site's URLs in one call. Handles JS-rendered pages and
+  bot-protected sites (Cloudflare, DataDome, PerimeterX) via auto-escalating
+  stealth.
+
+  Use this skill whenever the user asks to:
+  - scrape, crawl, or extract from a URL or site
+  - get clean Markdown of a webpage (for further processing, not a summary)
+  - pull specific fields from one or many pages
+  - enumerate / discover URLs on a site
+  - read a JS-rendered single-page app
+  - scrape a site that's blocking direct requests
+
+  Trigger phrases include: "scrape <site>", "crawl <site>", "extract <data>
+  from <url>", "what's on <site>", "what pages does <site> have", "give me
+  the markdown of <url>", "convert <url> to markdown", "pull <field> from
+  <url>", "save <article> as markdown", "build a scraper for <site>", "read
+  <url> into context", "this site is blocking me", "Cloudflare-protected site".
+
+  Prefer this over the built-in WebFetch whenever the user wants:
+  - Clean Markdown output to work with downstream (not just a summary in chat)
+  - Structured field extraction via schema
+  - Multi-page or site-wide work
+  - JS-rendered or bot-protected sites
+
+  WebFetch is the right tool only for "read this single URL and tell me about
+  it" — when the output is a conversational answer, not data. Anything that
+  produces an artifact (file, structured record, multi-URL result) belongs here.
 ---
 
-# WebReaper — AI-native scraping CLI
+# WebReaper — scraping & extraction CLI
 
-Three commands cover the common cases. Each is one shell call; output
-goes to stdout (or a file with `--output`).
+Three commands. Each is one shell call; output goes to stdout unless `--output`.
 
-## When to use
+## What to run
 
-- The user asks to **read a webpage / scrape a URL** into context.
-  → `webreaper scrape <url>` — Markdown to stdout.
-- The user asks **what's on a site** / wants to enumerate pages.
-  → `webreaper map <url> [--search <term>]` — one URL per line.
-- The user wants **structured fields** from a page or a site.
-  → Author a small `schema.json` and run
-    `webreaper scrape <url> --schema schema.json`.
+| The user wants… | Run |
+|---|---|
+| The readable text of one page | `webreaper scrape <url>` |
+| The readable text saved to a file | `webreaper scrape <url> --output page.md` |
+| Specific fields from one page | `webreaper scrape <url> --schema schema.json` |
+| URLs on a site | `webreaper map <url>` |
+| URLs matching a substring | `webreaper map <url> --search /blog/ --max-urls 50` |
+| A JS-rendered page (SPA) | `webreaper scrape <url> --browser` |
+| A bot-protected site | `webreaper scrape <url> --browser --auto-stealth` |
+| Fields from every linked page | `webreaper scrape <index-url> --follow "<css selector>" --schema schema.json` |
 
-Markdown is the default for `scrape` because the firecrawl-shaped wedge
-("the smallest possible call returns LLM-ready text") means you can pass
-the output straight into a follow-up prompt.
+## Common workflow — multi-page extraction
 
-## Examples
-
-Get one page as Markdown:
+The CLI's `scrape` is single-URL. For multi-page work, chain `map` → filter → loop:
 
 ```bash
-webreaper scrape https://example.com/article
+# 1. Discover URLs.
+webreaper map https://example.com/blog --search /post/ --max-urls 20 > urls.txt
+
+# 2. Scrape each. Cache so reruns are free.
+while read -r url; do
+  webreaper scrape "$url" --schema schema.json --max-age 1h
+done < urls.txt
 ```
 
-Save Markdown to a file:
+When the user asks "scrape the top N articles from <site> and …", this is the
+shape — `map` first, `scrape --schema` per URL, then process the JSON Lines
+output.
 
-```bash
-webreaper scrape https://example.com/article --output article.md
-```
+## Browser & stealth — when sites resist
 
-Use the headless browser for a JS-rendered page (requires the
-`WebReaper.Puppeteer` satellite installed in the host project):
+- **JS-rendered** (React/Vue/Angular SPA, content empty in `view-source:`):
+  add `--browser`. The CLI auto-spawns managed Chromium; first use may
+  prompt the user to run `webreaper browser install`.
+- **Bot-protected** (Cloudflare/DataDome/PerimeterX challenge page, HTTP 403/429/503,
+  or zero records on a non-empty page): `--browser` auto-detects the block and
+  offers to install a stealth backend. In agent / unattended contexts, add
+  `--auto-stealth` to bypass the Y/n prompt. The install is ~220 MB on first use.
+- **Known protected up front**: `--stealth` (implies `--browser`) skips the
+  vanilla-browser attempt and goes straight to the stealth backend.
 
-```bash
-webreaper scrape https://example.com/spa --browser
-```
+If a scrape still returns empty after a stealth retry, the site likely needs a
+captcha-solver — surface this to the user; don't keep retrying.
 
-Extract structured fields with a schema file:
+## Caching
 
-```bash
-cat > schema.json <<'EOF'
-{
-  "field": "root",
-  "children": [
-    { "field": "title", "selector": "h1", "type": "string" },
-    { "field": "tags",  "selector": ".tag", "type": "string", "is_list": true }
-  ]
-}
-EOF
-webreaper scrape https://example.com/post --schema schema.json
-```
+`--max-age <duration>` caches fetched pages for the duration (e.g. `30s`,
+`5m`, `2h`, `1d`). Use whenever iterating on a schema or running a multi-step
+agent that may revisit the same URLs — reruns are free within the TTL.
 
-Discover URLs on a site, filtered to a substring:
+## Schema format
 
-```bash
-webreaper map https://example.com --search /blog/ --max-urls 50
-```
-
-Cache pages for repeat reads inside a TTL (useful when iterating on a
-schema or stitching a multi-step agent):
-
-```bash
-webreaper scrape https://example.com --max-age 10m
-```
-
-## Schema format (brief)
-
-A schema is a tree of fields. Each leaf names a CSS selector and a type
+A schema is a tree of fields. Leaves have a CSS `selector` and a `type`
 (`string`, `integer`, `float`, `boolean`, `datetime`). Containers nest;
-`is_list: true` produces an array.
+`is_list: true` produces an array. `attr` reads an HTML attribute (e.g.
+`href`) instead of the element's text.
 
 ```json
 {
   "field": "root",
   "children": [
+    { "field": "title", "selector": "h1", "type": "string" },
     {
       "field": "items",
       "selector": ".item",
       "is_list": true,
       "children": [
-        { "field": "title", "selector": ".title", "type": "string" },
-        { "field": "price", "selector": ".price", "type": "float" }
+        { "field": "name",  "selector": ".name",  "type": "string" },
+        { "field": "url",   "selector": "a", "attr": "href", "type": "string" },
+        { "field": "price", "selector": ".price", "type": "float"  }
       ]
     }
   ]
 }
 ```
 
-## Exit codes
+## Output
 
-`0` on success. Non-zero on argument or runtime errors; the error
-message is printed to stderr and is one human-readable line.
+- `scrape` without `--schema` → Markdown (one document per page).
+- `scrape` with `--schema` → JSON (one record per page; multiple pages = JSON
+  Lines, one object per line).
+- `map` → one URL per line.
+- `--output <path>` redirects to a file instead of stdout.
+
+## Errors
+
+Exit code `0` on success, non-zero on failure. Errors print one human-readable
+line to stderr. Common cases:
+
+- **`webreaper: command not found`** → not installed. Instruct the user:
+  `brew install webreaper` (macOS/Linux) or `dotnet tool install -g WebReaper`
+  (any .NET 10+ environment).
+- **Empty output + `⚠ Likely blocked: …` on stderr** → retry with
+  `--browser --auto-stealth`.
+- **Empty output, no warning** → the selector(s) in the schema probably don't
+  match. Drop `--schema`, fetch as Markdown first to inspect the page shape,
+  then revise the schema.
 
 ## Not a replacement for
 
-- A full crawl with persistence/queues across processes — use the
-  WebReaper library directly for that (the CLI is the one-shot front).
-- Anti-bot evasion — the CLI uses the default HTTP transport. For
-  protected sites, integrate the WebReaper.Puppeteer satellite or
-  (future) the hosted WebReaper API via `--remote`.
+- A long-running distributed crawl with shared state across processes — use
+  the WebReaper library directly (Redis / Mongo / Azure Service Bus satellites).
+- Captcha-solving — surface the need to the user, don't loop.
+- Authenticated scraping — the CLI doesn't manage cookies / sessions today.


### PR DESCRIPTION
## Why

The shipped `WebReaper.Cli/skill/SKILL.md` was written before the v10
transports wave (ADRs 0053–0058) and the AI-native deepening (ADRs 0059–0064)
landed. Two concrete problems:

### 1. Stale content actively misinstructing users

Two passages told Claude that `--browser` requires "the `WebReaper.Puppeteer`
satellite installed in the host project." The Puppeteer satellite was
**deleted in v10** ([ADR-0053](docs/adr/0053-playwright-satellite-puppeteer-deletion.md));
the CLI now auto-spawns managed Chromium via CDP with no satellite step
([ADR-0055](docs/adr/0055-cli-browser-stealth-policy.md)). Following the old
instructions makes Claude tell the user to run a NuGet install that no longer
applies.

### 2. Killer v10 features absent from the skill

The bot-check auto-escalation ([ADR-0056](docs/adr/0056-cli-bot-check-escalation.md)),
`--auto-stealth`, `--stealth`, `--follow`, and the `webreaper browser install`
/ `webreaper stealth install` subcommands were all unmentioned. Claude can
only suggest features it's told exist.

## What changes, beyond the bug fixes

Tightens the framing for the v10.0.0 launch goal — *every Claude Code user
has heard of `webreaper scrape`*:

- **Triples the trigger surface.** Description now lists explicit phrase
  variations ("scrape X", "extract from X", "what's on X", "give me the
  markdown of X", "this site is blocking me", …) so the skill fires
  reliably across natural phrasings.
- **Sharper WebFetch disambiguation.** WebFetch is Claude Code's silent
  default for URL-shaped intents. The skill now states the boundary
  explicitly — WebFetch for "read this URL and tell me about it"
  (conversational answer); WebReaper for anything producing an artifact
  (Markdown file, JSON record, multi-URL result).
- **Prescriptive body.** Intent → command table replaces the previous
  "here's what each command does" narrative. Imperative reads better to
  Claude on skill match.
- **Chained `map → loop scrape` example.** Since `scrape` is single-URL,
  the most common real ask ("scrape the top N articles from <site>")
  needs an explicit pattern. Added a concrete bash example.
- **Errors section.** Install hint (`brew install webreaper` / `dotnet
  tool install -g WebReaper`), bot-check recovery (`--browser
  --auto-stealth`), and the schema-debug pattern (drop `--schema`, inspect
  Markdown, revise).
- **`attr` in schema documented.** Supported in `BuildElement`
  ([WebReaper.Cli/Commands/ScrapeCommand.cs:389](WebReaper.Cli/Commands/ScrapeCommand.cs#L389)),
  previously undocumented in the skill.
- **Drops** ".NET", "AI-native", "calls are cheap" framing — implementation
  / marketing detail irrelevant for a Claude Code skill description. Drops
  the speculative `--remote` reference.

## Build

`dotnet build WebReaper.Cli/WebReaper.Cli.csproj` clean — embedded-resource
pipeline unchanged (`<EmbeddedResource Include="skill\SKILL.md" />` in
[WebReaper.Cli/WebReaper.Cli.csproj](WebReaper.Cli/WebReaper.Cli.csproj)),
13 pre-existing warnings, no new ones.

## Validation plan (after merge)

Run in a fresh Claude Code session with `webreaper init` applied:

| Test prompt | Expected |
|---|---|
| "Scrape https://news.ycombinator.com" | Skill fires; Claude runs `webreaper scrape <url>`. |
| "What blog posts are on alexpavlov.dev?" | Skill fires; `webreaper map <url> --search /blog/`. |
| "Pull the title and price of every product from this shop page" | Skill fires; Claude authors a schema, runs `scrape --schema`. |
| "Get me the markdown of this article" | Skill fires (beats WebFetch). |
| "Scrape this Cloudflare-protected site" | Skill fires; Claude adds `--browser --auto-stealth`. |
| "Summarize this article: <url>" | WebFetch fires (correct — this is the boundary). |
| "Scrape the top 5 stories on HN and summarize each" | Skill fires; Claude uses `map` → `scrape` loop. |

If any of 1–7 trigger the wrong tool, the description needs another iteration.

## Not in this PR (separate scope)

- [`WebReaper.Mcp/WebReaperTools.cs`](WebReaper.Mcp/WebReaperTools.cs) lines
  26 and 83 carry the same stale "requires the `WebReaper.Puppeteer`
  satellite" lie in their MCP tool descriptions. Same fix, separate audience
  (MCP clients vs. Claude Code skill loader). Worth fixing for v10.0.0
  quiet-ship hygiene; deserves its own small PR.
- [`README.md`](README.md) has Puppeteer scattered through the SPA /
  dynamic-pages sections (lines 48, 186, 209, 221–222, 237, 255, 259, 264,
  273, 284, 286). Much larger surface; deserves its own PR with a deliberate
  re-pitch for v10 since this is what every GitHub visitor reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)