### PR TITLE
Drop stale WebReaper.Puppeteer reference from WebReaper.Mcp tool descriptions

### DIFF
--- a/WebReaper.Mcp/WebReaperTools.cs
+++ b/WebReaper.Mcp/WebReaperTools.cs
@@ -23,7 +23,7 @@ public static class WebReaperTools
         "into context.")]
     public static async Task<string> Scrape(
         [Description("The URL to scrape.")] string url,
-        [Description("Use the headless browser (for JS-rendered pages). Requires the WebReaper.Puppeteer satellite at run time. Default false.")] bool browser = false)
+        [Description("Use the headless browser (for JS-rendered pages). Default false.")] bool browser = false)
     {
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("URL is required.", nameof(url));
@@ -80,7 +80,7 @@ public static class WebReaperTools
     public static async Task<string> Extract(
         [Description("The URL to extract from.")] string url,
         [Description("The extraction schema as JSON. See the WebReaper docs for the shape.")] string schemaJson,
-        [Description("Use the headless browser (requires WebReaper.Puppeteer). Default false.")] bool browser = false)
+        [Description("Use the headless browser. Default false.")] bool browser = false)
     {
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("URL is required.", nameof(url));


### PR DESCRIPTION
## Why

Tool descriptions for `scrape` and `extract` in `WebReaper.Mcp` told MCP
clients (Cursor / Claude Desktop / Copilot Studio) that the `browser`
parameter *"requires the `WebReaper.Puppeteer` satellite."* The Puppeteer
satellite was **deleted in v10** ([ADR-0053](docs/adr/0053-playwright-satellite-puppeteer-deletion.md)).
Any MCP client introspecting tool metadata gets a false prerequisite — the
same root cause as the [SKILL.md staleness fixed in #121](https://github.com/pavlovtech/WebReaper/pull/121),
different audience (MCP tool-loader vs. Claude Code skill-loader).

## Diff

Two minimal description-only edits:

[WebReaper.Mcp/WebReaperTools.cs:26](WebReaper.Mcp/WebReaperTools.cs#L26)
\`\`\`diff
-[Description("Use the headless browser (for JS-rendered pages). Requires the WebReaper.Puppeteer satellite at run time. Default false.")]
+[Description("Use the headless browser (for JS-rendered pages). Default false.")]
\`\`\`

[WebReaper.Mcp/WebReaperTools.cs:83](WebReaper.Mcp/WebReaperTools.cs#L83)
\`\`\`diff
-[Description("Use the headless browser (requires WebReaper.Puppeteer). Default false.")]
+[Description("Use the headless browser. Default false.")]
\`\`\`

## Build

`dotnet build WebReaper.Mcp/WebReaper.Mcp.csproj` clean — 15 pre-existing
warnings, no new ones.

## Deeper issue flagged for a separate ADR (NOT in this PR)

While making this fix I observed:

**WebReaper.Mcp project-references only `WebReaper.csproj`.** No browser-transport
satellite ([`WebReaper.Cdp`](WebReaper.Cdp) or [`WebReaper.Playwright`](WebReaper.Playwright))
is referenced. Yet the tools expose a `browser` parameter that calls
`ScraperEngineBuilder.CrawlWithBrowser(url)` and builds the engine inline —
with no `WithCdpPageLoader()` / `WithPlaywrightPageLoader()` step. The CLI
([ADR-0055](docs/adr/0055-cli-browser-stealth-policy.md)) bakes `WebReaper.Cdp`
for exactly this reason; MCP currently does not.

So **\`browser=true\` in the MCP satellite is likely effectively broken at
runtime** (no transport to dispatch to). This is a behaviour bug, not a
description bug.

Possible fixes (each deserves its own ADR / discussion):

| Option | Trade-off |
|---|---|
| (a) Add `ProjectReference` to `WebReaper.Cdp` from `WebReaper.Mcp`; wire `WithCdpPageLoader()` inline (mirror the CLI's ADR-0055 pattern) | Browser mode actually works; heavier dependency tree for the MCP package (Chromium acquisition story); AOT not relevant since MCP isn't AOT'd |
| (b) Remove the `browser` parameter from the MCP tools until a transport story lands | Smaller surface; honest about current state; breaks the API for any MCP client that was passing `browser` (likely none since it doesn't work) |
| (c) Document the gap: keep the parameter, note in description that the MCP host needs a separately-installed CDP endpoint reachable to the MCP process | Awkward UX; only works for users who can already set up CDP — those users would use the CLI |

My read: **(a)** is the right answer for v10.0.0 if MCP is shipping in v10.0.0
anyway. But it's a separate decision, and this PR is just the false-claim fix.

Listed in the v10.0.0 launch hygiene queue alongside the README pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)