### PR TITLE
ADRs 0070 + 0071: CLI distribution channels + macOS codesigning — design pass

### DIFF
--- a/docs/adr/0070-cli-distribution-channels.md
+++ b/docs/adr/0070-cli-distribution-channels.md
@@ -88,8 +88,13 @@ curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install
 The script is the maximum-care version — ~120 lines, every failure-mode
 handled, no surprises. Specifically:
 
-- `set -euo pipefail` plus an `ERR` trap that prints which step failed and
-  how to retry
+- `set -eu` plus explicit `err`/`warn`/`info`/`ok` helper functions for
+  diagnostic output. The script targets POSIX `/bin/sh` for distribution
+  portability — bash extensions (`pipefail`, `ERR` trap, `$LINENO`,
+  `[[`) are intentionally avoided so the one-liner runs cleanly under
+  `dash`, `ash`, and `bash` alike. `set -e` covers the "fail loudly on
+  any unhandled error" goal; tmpdir cleanup runs from a single `EXIT`
+  trap.
 - OS + arch detection via `uname -sm` → RID, with an explicit, copy-pasteable
   error for unsupported combinations (e.g. FreeBSD, illumos)
 - Latest-release resolution via `https://api.github.com/repos/pavlovtech/WebReaper/releases/latest`;

--- a/docs/adr/0070-cli-distribution-channels.md
+++ b/docs/adr/0070-cli-distribution-channels.md
@@ -1,0 +1,231 @@
+# `webreaper` CLI distribution channels for v10.0.0 — Homebrew tap + install.sh
+
+## Status
+
+**Proposed** (2026-05-26; targets the v10.0.0 launch).
+
+Pairs with [ADR-0071](0071-macos-codesigning-and-notarization.md) — install.sh
+UX on macOS depends on codesigned + notarized binaries. The decisions split
+because cert rotation, Notary API breaks, and signing-cert revocation each
+warrant their own revisit cadence; bundling them obscures that.
+
+## Context
+
+[ADR-0043](0043-cli-and-agent-skill.md) shipped `WebReaper.Cli` as the
+Native-AOT single-binary primitive. The existing
+[`release.yml` `cli-publish` job](../../.github/workflows/release.yml#L291-L419)
+already produces AOT binaries for six RIDs (linux-x64, linux-arm64, osx-x64,
+osx-arm64, win-x64, win-arm64), renames `WebReaper.Cli` → `webreaper`, bundles
+LICENSE + README, and attaches each as a GitHub Release asset on every tagged
+push.
+
+That is the **distribution mechanism**. What is missing is the **distribution
+UX**.
+
+The v10.0.0 launch goal — *every Claude Code user has heard of `webreaper
+scrape`* — depends on the install command being **one short line a
+landing-page reader can copy and run**. Today the user has to:
+
+1. Open the GitHub Releases page
+2. Identify the correct RID for their platform
+3. Download the archive, extract it, `chmod +x`, move into `$PATH`
+
+Each step is a drop-off point. The viral install must collapse them into one
+line per platform.
+
+`dotnet tool install -g WebReaper` is out of scope: `PackAsTool=true` is
+structurally incompatible with `PublishAot=true` on a single target
+(`release.yml:53–55`, RELEASE-RUNBOOK §1.48 — settled). Surrendering AOT
+cold-start to gain .NET-dev convenience is the wrong trade for the audience
+this launch targets (Claude Code users, who lean mac/Linux generalist). The
+runbook's existing v10.x revisit note stands; this ADR does not reopen it.
+
+## Decision
+
+Two channels are added on top of the existing GitHub Releases automation:
+
+### 1. Homebrew tap — `pavlovtech/homebrew-webreaper`
+
+A separate repo per the Homebrew tap convention, containing a single
+`Formula/webreaper.rb`. End-user install path:
+
+```bash
+brew install pavlovtech/webreaper/webreaper
+```
+
+(The shorter `brew install webreaper` requires graduation to `homebrew-core`,
+which has a non-trivial acceptance bar — notability, version maturity, a
+visible maintenance track record. Out of scope for v10.0.0; worth attempting
+in v10.x once distribution proves traction.)
+
+A new `homebrew-publish` job in `release.yml`, gated on `cli-publish`
+success:
+
+1. Downloads the four mac + Linux artifacts uploaded by `cli-publish`
+   (`osx-arm64`, `osx-x64`, `linux-x64`, `linux-arm64`)
+2. Reads the per-artifact SHA256 from the `SHA256SUMS` Release asset (see §2)
+3. Renders `Formula/webreaper.rb` from a checked-in
+   `homebrew/webreaper.rb.template`
+4. Pushes the rendered formula to the tap repo using a fine-grained PAT
+   scoped only to that repo
+
+The formula declares four bottles (mac arm64, mac x64, linux x64, linux
+arm64) each pointing at the matching GitHub Release asset URL. Windows is not
+a Homebrew platform.
+
+Per-release work in the tap repo is one auto-commit ("WebReaper 10.0.0") —
+no manual intervention. The formula template lives in **this** repo so its
+history is auditable here, not split across two repositories.
+
+### 2. install.sh — bash one-liner served from raw.githubusercontent.com
+
+A `scripts/install.sh` checked into this repo. Install command:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh
+```
+
+The script is the maximum-care version — ~120 lines, every failure-mode
+handled, no surprises. Specifically:
+
+- `set -euo pipefail` plus an `ERR` trap that prints which step failed and
+  how to retry
+- OS + arch detection via `uname -sm` → RID, with an explicit, copy-pasteable
+  error for unsupported combinations (e.g. FreeBSD, illumos)
+- Latest-release resolution via `https://api.github.com/repos/pavlovtech/WebReaper/releases/latest`;
+  prints the resolved tag (`Installing webreaper v10.0.0…`) before extracting;
+  `WEBREAPER_VERSION=v10.0.0` env override for reproducibility / pinning
+- Download with retry on network failure (three attempts, exponential
+  back-off — 2s, 5s, 10s)
+- SHA256 verification against the `SHA256SUMS` Release asset (see §3); failure
+  aborts the install with the expected vs. actual hashes printed
+- Install to `${PREFIX:-/usr/local/bin}` if writable, fall back to
+  `${HOME}/.local/bin` with a clear note about PATH; honour an explicit
+  `PREFIX` env override before either default
+- Idempotent: existing `webreaper` at the target compared by `--version`; the
+  default is "abort, ask the user" — `--force` / `WEBREAPER_FORCE=1`
+  overwrites; `--upgrade` overwrites only if the new version is strictly
+  newer (semver compare)
+- Conflict detection: `command -v webreaper` reveals a different existing
+  binary; the script warns with both locations and aborts unless `--force`
+- Uninstall instructions printed at the end alongside the
+  first-command hint (`webreaper init`)
+- `WEBREAPER_INSTALL_VERBOSE=1` enables `set -x` and verbose `curl`
+- Exit code documentation in the header comment block
+
+### 3. SHA256 manifest
+
+A new `checksums` job in `release.yml` runs after `cli-publish` succeeds.
+For every binary archive produced by the matrix, the job computes a SHA256
+and writes a single `SHA256SUMS` file in the standard format:
+
+```
+<hash>  webreaper-v10.0.0-osx-arm64.zip
+<hash>  webreaper-v10.0.0-osx-x64.zip
+…
+```
+
+`SHA256SUMS` is uploaded to the Release as a separate asset (not embedded in
+each archive — verifiable independently, addressable by URL). Both
+`install.sh` and `homebrew-publish` read from it.
+
+### Trust model — bash-from-curl
+
+The `curl … | sh` install is a remote-execution surface. Three layers of
+mitigation:
+
+1. **Auditable source.** `install.sh` lives at `master`/`scripts/install.sh`;
+   its history is in git, reviewable by anyone. Same trust model as
+   Homebrew's own `brew.sh/install.sh`.
+2. **Binary verification.** The script verifies SHA256 against the
+   release-side `SHA256SUMS` manifest. A tampered binary on GitHub Releases
+   CDN cannot pass verification unless `SHA256SUMS` is also tampered, and
+   the manifest is generated inside the same CI job that produces the
+   binaries — a single point of trust, not two.
+3. **Visible release tag.** Before extracting, the script prints the
+   resolved tag so the user sees what version is being installed.
+
+The remaining trust window: anyone with push access to `master` can swap
+`install.sh`. That is the same trust model as every `curl | sh` installer in
+production today — accepted as the cost of the one-line UX. Mitigated by
+branch protection on `master` (the project already enforces this).
+
+## Considered & rejected
+
+**(a) `dotnet tool install -g WebReaper`** — deferred to v10.x per
+RELEASE-RUNBOOK §1.48. `PackAsTool` × `PublishAot` incompatibility is
+structural; the cold-start claim outranks .NET-dev convenience for this
+audience. A future parallel framework-dependent package (`WebReaper.Tool`?)
+is the v10.x escape hatch if real demand surfaces.
+
+**(b) `winget install webreaper`** — deferred to v10.1. Windows users get the
+AOT binary from GitHub Releases at launch. winget requires a per-release PR
+to `microsoft/winget-pkgs` (manifest validation + external review cycle); the
+pipeline addition is real but not launch-blocking.
+
+**(c) `scoop install webreaper`** — deferred to v10.1. Smaller Windows
+audience than winget; bucket repo would mirror the Homebrew tap shape,
+addable in its own ADR.
+
+**(d) Docker image (`docker run pavlovtech/webreaper`)** — deferred
+post-launch. Container distribution adds CVE-scan + base-image-refresh
+maintenance that isn't justified by the launch audience. CI users can pull
+the Linux binary from the Release page directly.
+
+**(e) Homebrew formula directly in `homebrew-core`** — deferred
+post-traction. The acceptance bar (notability, maintenance commitments) is
+incompatible with a day-one launch. A tap is the standard first step.
+
+**(f) `webreaper.dev/install.sh` vanity URL** — deferred to v10.1 with the
+landing page. Requires owning a domain + a static-hosting + CDN story.
+`raw.githubusercontent.com` has the same trust model and zero infrastructure.
+
+**(g) Sigstore / cosign for Linux binaries** — deferred. The Linux ecosystem
+does not gate on signatures the way macOS Gatekeeper does. Add when the
+binary acquires enough distribution that signature gives a meaningful trust
+signal.
+
+**(h) Minimal install.sh (`uname → curl → tar → install`, ~40 lines)** —
+rejected. Saves an evening of work but leaks every failure mode (network
+flap, partial download, conflicting install, no PATH) into raw error
+output. The launch UX bar is "no surprises"; the hardened script is the
+right cost.
+
+**(i) Bundle codesigning into this ADR** — rejected per HITL decision.
+Codesigning has its own setup, failure modes, and revisit cadence (cert
+rotation, Notary API breaks) that warrant a separate decision document.
+See [ADR-0071](0071-macos-codesigning-and-notarization.md).
+
+## Consequences
+
+- **New repo to create**: `pavlovtech/homebrew-webreaper` (one-time setup).
+- **New files in this repo**:
+  - `homebrew/webreaper.rb.template` — source of the rendered formula.
+  - `scripts/install.sh` — the hardened ~120-line installer.
+- **New `release.yml` jobs**: `checksums`, `homebrew-publish`. Both gated on
+  `cli-publish` success.
+- **New repo secret**: `GH_TOKEN_HOMEBREW_TAP` (fine-grained PAT scoped to the
+  tap repo only — least privilege).
+- **Failure semantics**: a failed `homebrew-publish` does NOT roll back the
+  GitHub Release / NuGet release — matches the runbook's one-way-on-tag
+  philosophy. Recovery is `gh workflow run release.yml --ref vX.Y.Z` re-dispatch
+  against the same tag.
+- **v10.1 distribution queue (deferred from this ADR)**: winget, Scoop,
+  Docker image, `webreaper.dev` vanity URL + landing page.
+- **v10.x potential revisit**: framework-dependent `dotnet tool` package if
+  real .NET-dev demand surfaces.
+
+## Implementation slices
+
+| # | Slice | Blocks on |
+|---|---|---|
+| 1 | Create `pavlovtech/homebrew-webreaper` repo with an empty placeholder Formula | — |
+| 2 | Generate `GH_TOKEN_HOMEBREW_TAP` (fine-grained PAT, contents: write on tap repo only) and add to this repo's secrets | step 1 |
+| 3 | `homebrew/webreaper.rb.template` checked into this repo | — |
+| 4 | `release.yml` — new `checksums` job producing the `SHA256SUMS` Release asset | — |
+| 5 | `release.yml` — new `homebrew-publish` job | steps 1–4 |
+| 6 | `scripts/install.sh` (hardened) | step 4 (`SHA256SUMS` shape) |
+| 7 | Dry-run end-to-end on a prerelease tag `v10.0.0-rc1` → throwaway release → verify all channels install cleanly on fresh macOS, Ubuntu, and Windows | steps 4–6 + [ADR-0071](0071-macos-codesigning-and-notarization.md) |
+
+Slices 1, 3, 4, 6 can land in parallel PRs; 5 depends on the tap repo +
+secret existing; 7 is the integration gate before tagging v10.0.0 proper.

--- a/docs/adr/0071-macos-codesigning-and-notarization.md
+++ b/docs/adr/0071-macos-codesigning-and-notarization.md
@@ -1,0 +1,229 @@
+# macOS codesigning + notarization for the AOT `webreaper` CLI
+
+## Status
+
+**Proposed** (2026-05-26; targets the v10.0.0 launch).
+
+Pairs with [ADR-0070](0070-cli-distribution-channels.md) — both Homebrew and
+install.sh distribution paths on macOS depend on this being in place.
+
+## Context
+
+The AOT-published `webreaper` binaries for `osx-arm64` and `osx-x64`
+produced by the existing
+[`release.yml` `cli-publish` job](../../.github/workflows/release.yml#L291-L419)
+are unsigned. macOS Gatekeeper blocks unsigned binaries downloaded from the
+internet with:
+
+> *"webreaper" cannot be opened because the developer cannot be verified.*
+
+The block applies to **every distribution path** in [ADR-0070](0070-cli-distribution-channels.md):
+
+- **Homebrew install** — Homebrew binaries are quarantined; first run hits
+  Gatekeeper unless the binary is signed and notarized.
+- **install.sh** — the `curl` download path applies the `com.apple.quarantine`
+  extended attribute; Gatekeeper blocks the first invocation.
+- **Manual download from Releases** — same quarantine, same block.
+
+The user's escape paths are: right-click → Open → "Open Anyway" (clicked once
+per binary, never sticks across versions); or System Settings → Privacy &
+Security → "Allow Anyway" (one click but requires navigating settings).
+Either kills the *agent picks up `webreaper` and runs it* flow in unattended
+scenarios, and tanks the "10-second install" pitch in attended ones.
+
+The Apple-approved fix: sign with a Developer ID Application certificate and
+notarize with Apple's notary service.
+
+The project owner is enrolled in the Apple Developer Program; the cost is
+already paid.
+
+## Decision
+
+`release.yml`'s `osx-arm64` and `osx-x64` matrix arms gain three new steps
+after AOT publish, before the archive step:
+
+### 1. Codesign
+
+```bash
+codesign \
+  --sign "$APPLE_DEVELOPER_ID" \
+  --options runtime \
+  --timestamp \
+  --identifier "io.highcraft.webreaper" \
+  --force \
+  webreaper
+```
+
+- **Identity** — `Developer ID Application: <Registered Name> (<TEAM_ID>)`.
+  Confirmed (HITL) as the correct cert type for binaries distributed outside
+  the Mac App Store. Mac App Store would require "Apple Development" +
+  sandbox entitlements + a fundamentally different distribution path; not
+  relevant here.
+- **Hardened runtime** (`--options runtime`) — required by Apple notarization
+  since 2019. Adds JIT / library-loading restrictions; a Native-AOT binary
+  needs none of those entitlements, so no `--entitlements` plist is supplied.
+- **Timestamp** — required so the signature remains verifiable after the cert
+  expires. Without `--timestamp`, an expired cert invalidates all binaries
+  signed under it.
+- **Identifier** — `io.highcraft.webreaper`, a stable bundle identifier
+  reserved on the project owner's contact domain (`business@highcraft.io`).
+  Not Mac App Store-scoped; the namespace is project-controlled.
+- **Force** — overwrites a prior signature if one is present. Idempotent
+  re-runs of CI must not fail because of a stale signature.
+
+### 2. Notarize
+
+```bash
+# Zip the binary (notarytool requires a container, not a raw Mach-O).
+zip notarize-input.zip webreaper
+
+xcrun notarytool submit notarize-input.zip \
+  --apple-id "$APPLE_ID" \
+  --password "$APPLE_NOTARIZATION_PASSWORD" \
+  --team-id "$APPLE_TEAM_ID" \
+  --wait
+```
+
+- `notarytool` is the modern API; `altool` is deprecated (removed by
+  Apple in late 2023). No fallback path.
+- `--wait` blocks until Apple returns a verdict — typically 1–5 minutes per
+  binary; the long tail is ~30 minutes if Apple's notary service is under load.
+- A failed verdict (hardened-runtime issue, malware signal, infra flap) fails
+  the CI step loudly with the Apple ticket UUID. Logs are pulled with
+  `xcrun notarytool log <uuid> --apple-id … --password … --team-id …` for
+  diagnosis.
+- `--password` is the app-specific password (generated at
+  appleid.apple.com), NOT the Apple ID password. Standard Apple-side guidance.
+
+### 3. Staple + verify
+
+```bash
+xcrun stapler staple webreaper
+spctl -a -t exec -vvv webreaper
+```
+
+- `stapler` writes the notarization ticket onto the binary itself so
+  Gatekeeper verifies offline on first run, without contacting Apple. Faster
+  user UX; works on air-gapped machines.
+- `spctl -a -t exec -vvv` is the verification gate. The CI step fails if
+  Gatekeeper would reject the binary — turning a notarization regression into
+  a CI failure before a single user sees a broken binary.
+
+The stapled, signed binary is the artifact that proceeds to the archive +
+upload steps in the existing `cli-publish` flow.
+
+### Required setup
+
+| Item | Storage | Notes |
+|---|---|---|
+| Developer ID Application certificate (.p12) | Repo secret `APPLE_CERTIFICATE_P12_BASE64` | Base64-encoded .p12 export from a Keychain; standard CI ingestion shape |
+| .p12 password | Repo secret `APPLE_CERTIFICATE_PASSWORD` | The password set when exporting the .p12 |
+| App-specific password for notarytool | Repo secret `APPLE_NOTARIZATION_PASSWORD` | Generated at appleid.apple.com → Sign-In and Security → App-Specific Passwords. NOT the Apple ID password. |
+| Apple ID (notarization submitter) | Repo secret `APPLE_ID` | The email of the Apple Developer account |
+| Apple Team ID | Repo variable `APPLE_TEAM_ID` | Non-secret; visible at developer.apple.com → Membership |
+| Developer ID label | Repo variable `APPLE_DEVELOPER_ID` | Non-secret. E.g. `Developer ID Application: Alex Pavlov (XXXXXXXXXX)` — exact string from `security find-identity -v -p codesigning` |
+
+The CI pre-step imports the .p12 into a temporary keychain created with a
+random password; the keychain is destroyed at job teardown so the cert does
+not persist on the runner. Standard pattern; community action
+`apple-actions/import-codesign-certs@v3` implements it correctly.
+
+## Considered & rejected
+
+**(a) Ad-hoc signing (`codesign -s -`)** — rejected. Ad-hoc signing satisfies
+the executable-format requirement but does NOT pass Gatekeeper for
+internet-downloaded binaries. Same broken UX as unsigned for the user.
+
+**(b) Self-signed certificate** — rejected. Gatekeeper trusts only
+Apple-issued Developer ID certs in the public chain; a self-signed cert is
+treated as unsigned for the end user. (It would work in a fleet under MDM,
+which is not our distribution model.)
+
+**(c) Sign without notarizing** — rejected. Signing alone passes Gatekeeper
+on macOS 10.14 (Mojave) but is **blocked on macOS 10.15 (Catalina) and later**
+for binaries downloaded from the internet. Catalina is from 2019; "blocked on
+every supported macOS" is not a viable launch.
+
+**(d) `altool`** (older notarization CLI) — rejected. Deprecated by Apple,
+removed by late 2023. `notarytool` is the only supported path.
+
+**(e) Notarize the .zip archive, not the inner binary; rely on archive-level
+notarization** — rejected. Apple supports zip submission, but the staple
+attaches to the contained binary — not the zip — when the zip is opened.
+Notarizing the archive without stapling onto the binary forces Gatekeeper to
+re-check over the network on first run, which is slower and breaks on
+air-gapped or restricted-network installations.
+
+**(f) `--keychain-profile` for notarytool credentials** — deferred. Profile-based
+auth (`notarytool store-credentials …` once, then `notarytool submit
+--keychain-profile <name>`) is cleaner than passing `--apple-id`/`--password`
+per call but requires an additional one-time setup step inside the CI
+keychain. Adopt in a hardening pass; not a launch blocker.
+
+**(g) Sign Linux binaries via sigstore/cosign** — out of scope (see
+[ADR-0070](0070-cli-distribution-channels.md) §considered). Linux distribution
+does not gate on signature.
+
+**(h) Sign Windows binaries with an EV / OV code-signing cert** — deferred.
+Windows SmartScreen warns on unsigned binaries but does not block; the UX
+hit is real but smaller than macOS Gatekeeper, and EV certs are non-trivial
+to acquire and rotate. Revisit in v10.x with SmartScreen reputation data
+from the launch.
+
+**(i) Bundle this ADR into ADR-0070 ("CLI distribution channels")** —
+rejected. The decisions have different revisit cadences: distribution
+channels evolve when audiences grow (winget, Scoop, Docker), codesigning
+evolves when Apple changes the rules (notary API, cert types, hardened
+runtime requirements). Pinned together in a single ADR, each revisit
+churns the other's content.
+
+## Consequences
+
+- **Annual cost**: $99 Apple Developer Program membership — already paid.
+- **Per-release CI cost**: 1–5 minutes added per macOS arm (×2 = up to 10
+  minutes total); occasional 30-minute tail when Apple's notary service is
+  loaded. Tractable for any reasonable release cadence.
+- **Cert rotation**: Developer ID Application certs are valid for five years.
+  Binaries signed under an expired cert remain verifiable thanks to
+  `--timestamp` (Gatekeeper accepts the signature; the cert's expiry does
+  not invalidate the past signature). New binaries need to be re-signed with
+  a fresh cert. **Calendar reminder belongs on the maintainer**; the rotation
+  procedure (issue new cert, export, re-encode `APPLE_CERTIFICATE_P12_BASE64`,
+  update `APPLE_DEVELOPER_ID` if the cert label changes, dry-run a tag)
+  belongs in [RELEASE-RUNBOOK.md](../RELEASE-RUNBOOK.md) as a follow-up doc
+  task.
+- **Notarization failure recovery**: if Apple's notary service is down or
+  returns a soft rejection, the macOS arms of `cli-publish` fail loudly with
+  the ticket UUID. Linux + Windows arms remain unaffected (they don't depend
+  on the macOS jobs). Recovery is `gh workflow run release.yml --ref vX.Y.Z`
+  once Apple is back; the upload step's `--clobber` makes the rerun
+  idempotent.
+- **Secrets surface**: four new secrets + two new variables (table above).
+  `APPLE_CERTIFICATE_P12_BASE64` is the most sensitive — a leak lets an
+  attacker sign binaries under this identity. Revocation path: Apple
+  Developer portal → certificates → revoke; the revocation propagates to
+  Gatekeeper via the CRL within ~24h. Standard CI-secret threat model.
+- **`spctl -a` verify step** acts as a quality gate — a regression that
+  produces a Gatekeeper-rejected binary fails CI before the binary reaches
+  a Release asset.
+- **Bundle identifier reserved**: `io.highcraft.webreaper` becomes the
+  project's reserved namespace. Future Mac-related artifacts (e.g. a hypothetical
+  v11+ desktop companion) should fit under `io.highcraft.webreaper.*` or pick
+  a sibling namespace deliberately; an identifier collision with another
+  signed binary on a user's system is undefined behaviour under Gatekeeper.
+
+## Implementation slices
+
+| # | Slice | Blocks on |
+|---|---|---|
+| 1 | Generate Developer ID Application certificate at developer.apple.com → Certificates | — (Apple Developer enrollment is already complete) |
+| 2 | Export the cert as a .p12 from Keychain Access; base64-encode the file (`base64 -i cert.p12 \| pbcopy`) | step 1 |
+| 3 | Generate an app-specific password at appleid.apple.com for `notarytool` | — |
+| 4 | Look up Team ID and the exact Developer ID label string (`security find-identity -v -p codesigning`) | step 1 |
+| 5 | Add the four secrets + two variables to this repo's settings | steps 2–4 |
+| 6 | `release.yml` — codesign + notarize + staple + `spctl -a` verify steps in `osx-arm64` and `osx-x64` matrix arms | step 5 |
+| 7 | Smoke test: dry-run on prerelease tag `v10.0.0-rc1` → download from the throwaway Release on a clean macOS user account → confirm Gatekeeper accepts and binary runs without warning | step 6 + [ADR-0070](0070-cli-distribution-channels.md) §7 |
+
+Step 1 is single-threaded for the project owner; steps 2–5 follow in ~30
+minutes. Step 6 is the CI work, parallel to ADR-0070's implementation. Step
+7 is the joint integration gate before tagging v10.0.0 proper.


### PR DESCRIPTION
Two paired design-pass ADRs targeting the v10.0.0 launch goal:
*every Claude Code user has heard of `webreaper scrape`*.

The launch's bottleneck is **install UX**. The existing
[`release.yml` `cli-publish` job](.github/workflows/release.yml#L291-L419)
already ships AOT binaries for six RIDs, but the user has to find the right
archive, download, extract, `chmod`, and on macOS click through Gatekeeper
before getting to `webreaper init`. Each step is a drop-off point.

The decisions are **split** because their revisit cadences differ:
distribution channels churn when audiences grow (winget, Scoop, Docker);
codesigning churns when Apple changes the rules (notary API, cert types,
hardened-runtime requirements). Pinned together in one ADR, each revisit
would churn the other's content.

## [ADR-0070](docs/adr/0070-cli-distribution-channels.md) — CLI distribution channels

Two new channels on top of GitHub Releases:

- **Homebrew tap** (`pavlovtech/homebrew-webreaper`) — separate tap repo;
  new `homebrew-publish` job in `release.yml` renders
  `Formula/webreaper.rb` from a checked-in template after `cli-publish`
  succeeds. End-user: `brew install pavlovtech/webreaper/webreaper`.
  Graduation to `homebrew-core` deferred post-traction.

- **install.sh** — `curl … | sh` one-liner from
  `raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh`, with
  SHA256 verification against a new `SHA256SUMS` Release asset.
  Maximum-care version (~120 lines): `set -euo pipefail` + `ERR` trap,
  OS+arch → RID, latest-release resolution with `WEBREAPER_VERSION`
  override, download retry, SHA256 verify, `PREFIX`/`HOME`-fallback
  install, idempotent re-install, conflict detection, uninstall
  instructions, `WEBREAPER_INSTALL_VERBOSE`.

Trust model for `curl … | sh` documented: auditable source on `master`,
SHA256 verification against a release-side manifest, visible release tag
printed before extract. Same shape as `brew.sh`'s installer.

Deferred to v10.1+: winget, Scoop, Docker, `webreaper.dev` vanity URL.

Permanently out of scope: `dotnet tool install -g WebReaper` —
`PackAsTool` × `PublishAot` incompatibility ([release.yml:53](.github/workflows/release.yml#L53);
RELEASE-RUNBOOK §1.48). The runbook's existing v10.x revisit note stands;
this ADR does not reopen it.

## [ADR-0071](docs/adr/0071-macos-codesigning-and-notarization.md) — macOS codesigning + notarization

Three new steps in `release.yml`'s `osx-arm64` + `osx-x64` matrix arms:

1. `codesign --sign "$APPLE_DEVELOPER_ID" --options runtime --timestamp --identifier "io.highcraft.webreaper" --force webreaper`
2. `xcrun notarytool submit … --wait` (modern API; `altool` is deprecated)
3. `xcrun stapler staple` + `spctl -a -t exec -vvv` verify (CI fails if
   Gatekeeper would reject)

Identity: **Developer ID Application** certificate (confirmed correct for
out-of-Mac-App-Store distribution). Bundle identifier
`io.highcraft.webreaper` reserved on the project owner's contact domain
(`business@highcraft.io`). Apple Developer Program already enrolled.

Required setup: four repo secrets (`APPLE_CERTIFICATE_P12_BASE64`,
`APPLE_CERTIFICATE_PASSWORD`, `APPLE_NOTARIZATION_PASSWORD`, `APPLE_ID`) +
two non-secret variables (`APPLE_TEAM_ID`, `APPLE_DEVELOPER_ID`). Standard
CI keychain pattern; cert destroyed at job teardown.

Without this, Gatekeeper blocks the binary on macOS 10.15+ for **every**
distribution path in ADR-0070 (Homebrew, install.sh, manual download).
Sign-without-notarize and ad-hoc signing rejected with reasons in the
"Considered & rejected" section.

## Implementation queue (separate PRs)

These ADRs are **launch-blockers for v10.0.0**; the release stays deferred
until the joint integration gate (§slice 7 of both ADRs) passes.

Parallelizable:
- **ADR-0070 slices 1–4, 6** — tap repo + secret + template + checksums job + install.sh
- **ADR-0071 slices 1–6** — Apple cert generation + secrets + release.yml codesign steps

Sequential gate:
- **Joint slice 7** — dry-run on `v10.0.0-rc1` prerelease tag → verify all channels install cleanly on fresh macOS, Ubuntu, Windows user accounts → only then tag v10.0.0 proper.

## Not in this PR

- No code changes; design-pass only, per [WebReaper working style](https://github.com/pavlovtech/WebReaper) (ADR-driven design-pass-first, HITL grilling, implementation in follow-up PRs).
- `README.md` Puppeteer staleness (~12 mentions in the SPA / dynamic-pages sections) — separate launch-hygiene pass, ideally bundled with the v10 re-pitch tied to the landing page work.
- The MCP `browser=true` wiring gap flagged in [#122](https://github.com/pavlovtech/WebReaper/pull/122) — separate ADR, not launch-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)