### PR TITLE
ADR-0070/0071 implementation: install.sh + Homebrew formula + release.yml automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,7 +362,7 @@ jobs:
       # content-based, identifier-bound, filename-independent).
       - name: Import Developer ID Application certificate (macOS)
         if: startsWith(matrix.rid, 'osx-')
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@v7
         with:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,6 +355,62 @@ jobs:
             --nologo
         shell: bash
 
+      # ADR-0071: codesign + notarize + staple, macOS arms only. Operates
+      # on the publish-output binary (still named WebReaper.Cli at this
+      # point); the rename to `webreaper` happens in the next staging step
+      # and does not invalidate the signature (Mach-O signatures are
+      # content-based, identifier-bound, filename-independent).
+      - name: Import Developer ID Application certificate (macOS)
+        if: startsWith(matrix.rid, 'osx-')
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      - name: Codesign + notarize + staple (macOS)
+        if: startsWith(matrix.rid, 'osx-')
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+          APPLE_DEVELOPER_ID: ${{ vars.APPLE_DEVELOPER_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PUB="WebReaper.Cli/bin/Release/net10.0/${{ matrix.rid }}/publish"
+          BIN="$PUB/WebReaper.Cli"
+
+          echo "→ codesigning ${BIN}..."
+          codesign \
+            --sign "$APPLE_DEVELOPER_ID" \
+            --options runtime \
+            --timestamp \
+            --identifier "io.highcraft.webreaper" \
+            --force \
+            "$BIN"
+
+          echo "→ submitting to Apple notary (notarytool)..."
+          # notarytool requires a container (zip or pkg/dmg). The submitted
+          # zip is throwaway — the ticket is stapled to the binary itself.
+          NOTARIZE_ZIP="$RUNNER_TEMP/notarize-${{ matrix.rid }}.zip"
+          (cd "$PUB" && zip -j "$NOTARIZE_ZIP" "$(basename "$BIN")")
+
+          xcrun notarytool submit "$NOTARIZE_ZIP" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_NOTARIZATION_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+          echo "→ stapling ticket onto binary..."
+          xcrun stapler staple "$BIN"
+
+          echo "→ Gatekeeper verification (spctl -a -t exec)..."
+          # CI quality gate: a regression that produces a Gatekeeper-rejected
+          # binary fails here before reaching a Release asset.
+          spctl -a -t exec -vvv "$BIN"
+
+          echo "✓ signed + notarized + stapled"
+
       - name: Stage + archive (Linux + macOS)
         if: runner.os != 'Windows'
         shell: bash
@@ -417,3 +473,150 @@ jobs:
           set -euo pipefail
           TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           gh release upload "$TAG" "$ASSET_PATH" --clobber
+
+  checksums:
+    # ADR-0070 §3: SHA256SUMS Release asset — consumed by scripts/install.sh
+    # and by the homebrew-publish job below. Runs after cli-publish has
+    # uploaded every per-RID archive; downloads them via `gh release
+    # download` so it's robust against partial cli-publish re-runs (only
+    # the assets currently on the release are hashed).
+    #
+    # `fail-fast: false` in cli-publish means an arm can be missing. The
+    # manifest reflects "what's on the release right now," which is the
+    # correct denotation for the install.sh consumer (a manifest that
+    # promises a hash for a file that doesn't exist is worse than a
+    # manifest with fewer entries).
+    name: SHA256SUMS manifest
+    needs: [pack, cli-publish]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run == false }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Download release archives + compute SHA256SUMS
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          rm -rf checksum-stage && mkdir checksum-stage
+          # Download every webreaper-* asset on the release. Skip SHA256SUMS
+          # itself so re-runs are idempotent (gh release download won't
+          # overwrite the manifest from a prior run before we recompute).
+          gh release download "$TAG" --dir checksum-stage --pattern 'webreaper-*'
+          cd checksum-stage
+          # Sort by filename so output is deterministic across re-runs.
+          sha256sum webreaper-* | sort -k2 > SHA256SUMS
+          echo "--- SHA256SUMS ---"
+          cat SHA256SUMS
+
+      - name: Upload SHA256SUMS as release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          gh release upload "$TAG" checksum-stage/SHA256SUMS --clobber
+
+  homebrew-publish:
+    # ADR-0070 §1: render Formula/webreaper.rb from the template in this
+    # repo, push to pavlovtech/homebrew-webreaper using a tap-scoped
+    # fine-grained PAT (GH_TOKEN_HOMEBREW_TAP). Runs after `checksums`
+    # because it reads SHA256 values from SHA256SUMS.
+    #
+    # Failure here does NOT roll back the GitHub Release or NuGet push
+    # (runbook one-way-on-tag). Recovery: re-dispatch the workflow against
+    # the same tag once the cause is addressed; the git commit + push is
+    # idempotent (skip if no diff in the rendered formula).
+    name: Publish to Homebrew tap
+    needs: [pack, cli-publish, checksums]
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Download SHA256SUMS
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          gh release download "$TAG" --pattern SHA256SUMS --dir .
+
+      - name: Render formula from template
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          VERSION="${{ needs.pack.outputs.version }}"
+
+          # Extract per-RID SHA256 from the manifest.
+          sha_osx_arm64=$(awk -v f="webreaper-${TAG}-osx-arm64.zip"     '$2==f{print $1}' SHA256SUMS)
+          sha_osx_x64=$(awk   -v f="webreaper-${TAG}-osx-x64.zip"       '$2==f{print $1}' SHA256SUMS)
+          sha_linux_x64=$(awk -v f="webreaper-${TAG}-linux-x64.tar.gz"  '$2==f{print $1}' SHA256SUMS)
+          sha_linux_arm64=$(awk -v f="webreaper-${TAG}-linux-arm64.tar.gz" '$2==f{print $1}' SHA256SUMS)
+
+          # All four are required — Homebrew formula must have a bottle
+          # for every declared `on_macos`/`on_linux` arm. A missing SHA
+          # is a release defect, not a publish-time concern.
+          for pair in "osx-arm64:$sha_osx_arm64" "osx-x64:$sha_osx_x64" \
+                      "linux-x64:$sha_linux_x64" "linux-arm64:$sha_linux_arm64"; do
+            rid="${pair%%:*}"
+            sha="${pair##*:}"
+            if [ -z "$sha" ]; then
+              echo "::error::SHA256SUMS missing entry for ${rid} archive at ${TAG}"
+              exit 1
+            fi
+          done
+
+          # Render. `sed -i` is portable enough between GNU + BSD when we
+          # avoid the in-place form; here we just write to a new file.
+          sed \
+            -e "s|{{VERSION}}|${VERSION}|g" \
+            -e "s|{{TAG}}|${TAG}|g" \
+            -e "s|{{SHA256_OSX_ARM64}}|${sha_osx_arm64}|g" \
+            -e "s|{{SHA256_OSX_X64}}|${sha_osx_x64}|g" \
+            -e "s|{{SHA256_LINUX_X64}}|${sha_linux_x64}|g" \
+            -e "s|{{SHA256_LINUX_ARM64}}|${sha_linux_arm64}|g" \
+            homebrew/webreaper.rb.template > webreaper.rb.full
+
+          # Strip the leading template-header comment block (the
+          # developer-facing prose about placeholders + render shape).
+          # The tap repo's formula stays clean — formula begins at `class`.
+          awk '/^class / { found=1 } found { print }' webreaper.rb.full > webreaper.rb
+
+          echo "--- rendered Formula/webreaper.rb ---"
+          cat webreaper.rb
+
+      - name: Push to pavlovtech/homebrew-webreaper
+        env:
+          GH_TOKEN_HOMEBREW_TAP: ${{ secrets.GH_TOKEN_HOMEBREW_TAP }}
+        run: |
+          set -euo pipefail
+          [ -n "${GH_TOKEN_HOMEBREW_TAP:-}" ] \
+            || { echo "::error::GH_TOKEN_HOMEBREW_TAP secret is empty"; exit 1; }
+          VERSION="${{ needs.pack.outputs.version }}"
+
+          git clone --depth 1 \
+            "https://x-access-token:${GH_TOKEN_HOMEBREW_TAP}@github.com/pavlovtech/homebrew-webreaper.git" \
+            tap
+          mkdir -p tap/Formula
+          cp webreaper.rb tap/Formula/webreaper.rb
+
+          cd tap
+          git config user.name "webreaper-release-bot"
+          git config user.email "webreaper-release-bot@users.noreply.github.com"
+          git add Formula/webreaper.rb
+          # Idempotent re-run: nothing to do if the rendered formula is
+          # byte-identical to what's already in the tap.
+          if git diff --staged --quiet; then
+            echo "no changes — formula already up to date"
+            exit 0
+          fi
+          git commit -m "WebReaper ${VERSION}"
+          git push

--- a/homebrew/webreaper.rb.template
+++ b/homebrew/webreaper.rb.template
@@ -1,0 +1,58 @@
+# Homebrew formula template (ADR-0070).
+#
+# Rendered into the pavlovtech/homebrew-webreaper tap repo by the
+# `homebrew-publish` job in this repo's .github/workflows/release.yml,
+# after `cli-publish` succeeds. Placeholders are sed-substituted:
+#
+#   {{VERSION}}            — semver without the `v` (e.g. 10.0.0)
+#   {{TAG}}                — tag with `v` (e.g. v10.0.0)
+#   {{SHA256_OSX_ARM64}}   — SHA256 of webreaper-{{TAG}}-osx-arm64.zip
+#   {{SHA256_OSX_X64}}     — SHA256 of webreaper-{{TAG}}-osx-x64.zip
+#   {{SHA256_LINUX_X64}}   — SHA256 of webreaper-{{TAG}}-linux-x64.tar.gz
+#   {{SHA256_LINUX_ARM64}} — SHA256 of webreaper-{{TAG}}-linux-arm64.tar.gz
+#
+# The four supported bottles match the RIDs in release.yml's cli-publish
+# matrix. Windows is not a Homebrew platform; Windows users install via the
+# GitHub Releases page directly (v10.0.0) or winget (v10.1+, ADR-TBD).
+
+class Webreaper < Formula
+  desc "Declarative .NET web scraper / crawler — AI-native CLI"
+  homepage "https://github.com/pavlovtech/WebReaper"
+  version "{{VERSION}}"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/pavlovtech/WebReaper/releases/download/{{TAG}}/webreaper-{{TAG}}-osx-arm64.zip"
+      sha256 "{{SHA256_OSX_ARM64}}"
+    end
+    on_intel do
+      url "https://github.com/pavlovtech/WebReaper/releases/download/{{TAG}}/webreaper-{{TAG}}-osx-x64.zip"
+      sha256 "{{SHA256_OSX_X64}}"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/pavlovtech/WebReaper/releases/download/{{TAG}}/webreaper-{{TAG}}-linux-x64.tar.gz"
+      sha256 "{{SHA256_LINUX_X64}}"
+    end
+    on_arm do
+      url "https://github.com/pavlovtech/WebReaper/releases/download/{{TAG}}/webreaper-{{TAG}}-linux-arm64.tar.gz"
+      sha256 "{{SHA256_LINUX_ARM64}}"
+    end
+  end
+
+  def install
+    bin.install "webreaper"
+    # The archive ships LICENSE.txt + README.md alongside the binary —
+    # `bin.install "webreaper"` ignores them, which is the desired shape.
+    # Homebrew's auto-generated caveats include `webreaper help`.
+  end
+
+  test do
+    # Smoke test — the binary must run and print a version string.
+    # ADR-0024: version is tag-derived; matches the formula's `version`.
+    assert_match version.to_s, shell_output("#{bin}/webreaper version")
+  end
+end

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -164,9 +164,7 @@ info "installing ${BOLD}webreaper ${VERSION}${RESET} for ${RID}"
 # ----- choose install location ---------------------------------------------
 
 if [ -z "$PREFIX_INPUT" ]; then
-  if [ -w "$DEFAULT_PREFIX" ] 2>/dev/null; then
-    PREFIX_DIR="$DEFAULT_PREFIX"
-  elif [ -d "$DEFAULT_PREFIX" ] && [ -w "$(dirname "$DEFAULT_PREFIX")" ] 2>/dev/null; then
+  if [ -w "$DEFAULT_PREFIX" ]; then
     PREFIX_DIR="$DEFAULT_PREFIX"
   else
     PREFIX_DIR="$FALLBACK_PREFIX"
@@ -195,10 +193,17 @@ if EXISTING=$(command -v webreaper 2>/dev/null); then
 fi
 
 if [ -x "$TARGET" ]; then
+  # WebReaper.Cli's `version` command prints the
+  # AssemblyInformationalVersion (see WebReaper.Cli/Commands/VersionCommand.cs);
+  # under ADR-0024 tag-derived versioning this formats as `<semver>+<sha>`
+  # (e.g. `10.0.0+abc123`). Strip the `+<metadata>` suffix so the
+  # idempotency/upgrade comparison works against the bare semver.
   EXISTING_VER=$("$TARGET" version 2>/dev/null | head -1 | awk '{print $NF}' || true)
   if [ -n "${EXISTING_VER:-}" ]; then
     WANT_VER="${VERSION#v}"
+    WANT_VER="${WANT_VER%%+*}"
     EXISTING_VER_NORM="${EXISTING_VER#v}"
+    EXISTING_VER_NORM="${EXISTING_VER_NORM%%+*}"
     if [ "$EXISTING_VER_NORM" = "$WANT_VER" ]; then
       if [ -n "$FORCE" ]; then
         info "${VERSION} already installed at ${TARGET}; --force → reinstalling"
@@ -264,8 +269,15 @@ EXTRACTED_DIR="${TMP}/webreaper-${VERSION}-${RID}"
 }
 
 info "installing to ${TARGET}..."
-cp -f "${EXTRACTED_DIR}/webreaper" "$TARGET"
-chmod 0755 "$TARGET"
+# Atomic install: stage next to the target then `mv` (atomic on the same
+# filesystem). cp+chmod in-place would let a concurrent reader observe the
+# binary mid-write or post-write-but-pre-chmod. Staging next to the target
+# (rather than from $TMP) also sidesteps cross-filesystem mv non-atomicity
+# when /usr/local/bin lives on a different volume than mktemp's default.
+TMP_TARGET="${TARGET}.new.$$"
+cp -f "${EXTRACTED_DIR}/webreaper" "$TMP_TARGET"
+chmod 0755 "$TMP_TARGET"
+mv -f "$TMP_TARGET" "$TARGET"
 
 # ----- post-install --------------------------------------------------------
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,286 @@
+#!/bin/sh
+# install.sh — WebReaper CLI installer (ADR-0070).
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh
+#   # or with flags:
+#   curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh -s -- --force
+#
+# Environment variables:
+#   WEBREAPER_VERSION         — pin to a specific tag (e.g. v10.0.0). Default: latest release.
+#   PREFIX                    — install directory. Default: /usr/local/bin → ~/.local/bin fallback.
+#   WEBREAPER_FORCE=1         — overwrite existing install (same as --force).
+#   WEBREAPER_INSTALL_VERBOSE=1 — verbose output (set -x + curl -v).
+#   NO_COLOR=1                — disable ANSI colour.
+#
+# Flags:
+#   --force      — overwrite without confirmation, even if same version is installed
+#   --upgrade    — overwrite only if installing a strictly newer version
+#   --help, -h   — print this usage block
+#
+# Exit codes:
+#   0 — success (installed, upgraded, or already-current)
+#   1 — generic / unexpected error
+#   2 — unsupported OS / architecture
+#   3 — missing required tool (curl/wget, sha256sum/shasum, tar, unzip)
+#   4 — network failure after retries
+#   5 — SHA256 verification failed
+#   6 — conflicting webreaper found elsewhere on PATH (rerun with --force)
+#   7 — same/older version already at target (rerun with --force or --upgrade)
+#   8 — install location not writable
+
+set -eu
+
+REPO="pavlovtech/WebReaper"
+DEFAULT_PREFIX="/usr/local/bin"
+FALLBACK_PREFIX="${HOME}/.local/bin"
+
+VERSION="${WEBREAPER_VERSION:-}"
+FORCE="${WEBREAPER_FORCE:-}"
+UPGRADE=""
+PREFIX_INPUT="${PREFIX:-}"
+CURL_VERBOSE=""
+if [ "${WEBREAPER_INSTALL_VERBOSE:-}" = "1" ]; then set -x; CURL_VERBOSE="-v"; fi
+
+# ----- colour (tty-only) ---------------------------------------------------
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  RED=$(printf '\033[0;31m'); GREEN=$(printf '\033[0;32m')
+  YELLOW=$(printf '\033[1;33m'); BLUE=$(printf '\033[0;34m')
+  BOLD=$(printf '\033[1m'); RESET=$(printf '\033[0m')
+else
+  RED=""; GREEN=""; YELLOW=""; BLUE=""; BOLD=""; RESET=""
+fi
+
+err()  { printf "%s✗%s %s\n" "$RED"   "$RESET" "$*" >&2; }
+warn() { printf "%s⚠%s %s\n" "$YELLOW" "$RESET" "$*" >&2; }
+info() { printf "%s→%s %s\n" "$BLUE"   "$RESET" "$*"; }
+ok()   { printf "%s✓%s %s\n" "$GREEN"  "$RESET" "$*"; }
+
+usage() {
+  sed -n '2,/^$/p' <<'USAGE_END' | sed 's/^# \{0,1\}//'
+# install.sh — WebReaper CLI installer
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh
+#
+# Flags: --force, --upgrade, --help.
+# See script header for env vars and exit codes.
+USAGE_END
+}
+
+# ----- args -----------------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --force)        FORCE=1 ;;
+    --upgrade)      UPGRADE=1 ;;
+    --help|-h)      usage; exit 0 ;;
+    *)              err "unknown argument: $1"; usage; exit 1 ;;
+  esac
+  shift
+done
+
+# ----- preflight ------------------------------------------------------------
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+if   have curl; then DL="curl"
+elif have wget; then DL="wget"
+else err "need 'curl' or 'wget' on PATH"; exit 3
+fi
+
+if   have sha256sum; then SHA_CMD="sha256sum"
+elif have shasum;    then SHA_CMD="shasum -a 256"
+else err "need 'sha256sum' or 'shasum'"; exit 3
+fi
+
+have tar   || { err "need 'tar' on PATH"; exit 3; }
+have unzip || { err "need 'unzip' on PATH"; exit 3; }
+
+# ----- OS + arch detection --------------------------------------------------
+
+UNAME_S=$(uname -s); UNAME_M=$(uname -m)
+case "${UNAME_S}-${UNAME_M}" in
+  Linux-x86_64)   RID="linux-x64";   ARCHIVE_EXT="tar.gz" ;;
+  Linux-aarch64)  RID="linux-arm64"; ARCHIVE_EXT="tar.gz" ;;
+  Darwin-x86_64)  RID="osx-x64";     ARCHIVE_EXT="zip" ;;
+  Darwin-arm64)   RID="osx-arm64";   ARCHIVE_EXT="zip" ;;
+  *)
+    err "unsupported platform: ${UNAME_S} ${UNAME_M}"
+    err "supported: Linux x86_64/aarch64, Darwin x86_64/arm64"
+    err "Windows: download from https://github.com/${REPO}/releases/latest"
+    exit 2 ;;
+esac
+
+# ----- download helpers (with retry + exponential backoff) ------------------
+
+dl_to_file() {
+  _url="$1"; _out="$2"
+  if [ "$DL" = "curl" ]; then curl -fsSL ${CURL_VERBOSE} "$_url" -o "$_out"
+  else                        wget -q -O "$_out" "$_url"
+  fi
+}
+
+dl_to_stdout() {
+  if [ "$DL" = "curl" ]; then curl -fsSL ${CURL_VERBOSE} "$1"
+  else                        wget -q -O - "$1"
+  fi
+}
+
+retry_download() {
+  _url="$1"; _out="$2"; _what="$3"
+  _delays="2 5 10"
+  _attempt=1
+  for _d in $_delays X; do
+    if dl_to_file "$_url" "$_out" 2>/dev/null; then return 0; fi
+    [ "$_d" = "X" ] && break
+    warn "${_what} download failed (attempt ${_attempt}); retrying in ${_d}s..."
+    sleep "$_d"
+    _attempt=$((_attempt + 1))
+  done
+  err "could not download ${_what} from ${_url} after 3 attempts"
+  exit 4
+}
+
+# ----- resolve version ------------------------------------------------------
+
+if [ -z "$VERSION" ]; then
+  info "resolving latest release..."
+  TAG=$(dl_to_stdout "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
+        | grep '"tag_name"' \
+        | head -1 \
+        | sed -E 's/.*"tag_name"[^"]*"([^"]+)".*/\1/' || true)
+  if [ -z "${TAG:-}" ]; then
+    err "could not resolve latest release from api.github.com (rate-limited? offline?)"
+    err "pin a version explicitly: WEBREAPER_VERSION=v10.0.0"
+    exit 4
+  fi
+  VERSION="$TAG"
+fi
+
+info "installing ${BOLD}webreaper ${VERSION}${RESET} for ${RID}"
+
+# ----- choose install location ---------------------------------------------
+
+if [ -z "$PREFIX_INPUT" ]; then
+  if [ -w "$DEFAULT_PREFIX" ] 2>/dev/null; then
+    PREFIX_DIR="$DEFAULT_PREFIX"
+  elif [ -d "$DEFAULT_PREFIX" ] && [ -w "$(dirname "$DEFAULT_PREFIX")" ] 2>/dev/null; then
+    PREFIX_DIR="$DEFAULT_PREFIX"
+  else
+    PREFIX_DIR="$FALLBACK_PREFIX"
+    info "no write access to ${DEFAULT_PREFIX}; falling back to ${PREFIX_DIR}"
+    mkdir -p "$PREFIX_DIR"
+  fi
+else
+  PREFIX_DIR="$PREFIX_INPUT"
+  mkdir -p "$PREFIX_DIR" 2>/dev/null || true
+  [ -w "$PREFIX_DIR" ] || { err "PREFIX=${PREFIX_DIR} is not writable"; exit 8; }
+fi
+
+TARGET="${PREFIX_DIR}/webreaper"
+
+# ----- conflict + idempotency check -----------------------------------------
+
+if EXISTING=$(command -v webreaper 2>/dev/null); then
+  if [ "$EXISTING" != "$TARGET" ]; then
+    warn "another webreaper found at ${EXISTING} (installing to ${TARGET})"
+    if [ -z "$FORCE" ]; then
+      err "refusing to install — multiple webreaper binaries would be on PATH"
+      err "rerun with --force (or WEBREAPER_FORCE=1) to override"
+      exit 6
+    fi
+  fi
+fi
+
+if [ -x "$TARGET" ]; then
+  EXISTING_VER=$("$TARGET" version 2>/dev/null | head -1 | awk '{print $NF}' || true)
+  if [ -n "${EXISTING_VER:-}" ]; then
+    WANT_VER="${VERSION#v}"
+    EXISTING_VER_NORM="${EXISTING_VER#v}"
+    if [ "$EXISTING_VER_NORM" = "$WANT_VER" ]; then
+      if [ -n "$FORCE" ]; then
+        info "${VERSION} already installed at ${TARGET}; --force → reinstalling"
+      else
+        ok "webreaper ${VERSION} is already installed at ${TARGET}"
+        info "rerun with --force to reinstall"
+        exit 0
+      fi
+    elif [ -n "$UPGRADE" ]; then
+      if printf '%s\n%s\n' "$EXISTING_VER_NORM" "$WANT_VER" | sort -V >/dev/null 2>&1; then
+        NEWEST=$(printf '%s\n%s\n' "$EXISTING_VER_NORM" "$WANT_VER" | sort -V | tail -1)
+        if [ "$NEWEST" = "$EXISTING_VER_NORM" ]; then
+          ok "${EXISTING_VER} already installed; ${VERSION} is not strictly newer (--upgrade is no-op)"
+          exit 0
+        fi
+      fi
+      info "upgrading ${EXISTING_VER} → ${VERSION}"
+    elif [ -z "$FORCE" ]; then
+      warn "webreaper ${EXISTING_VER} is at ${TARGET}; installing ${VERSION} would overwrite"
+      err "refusing to overwrite — pass --force or --upgrade"
+      exit 7
+    fi
+  fi
+fi
+
+# ----- download + verify + extract + install -------------------------------
+
+TMP=$(mktemp -d -t webreaper-install.XXXXXX)
+# shellcheck disable=SC2064
+trap "rm -rf '$TMP'" EXIT INT TERM
+
+ASSET_NAME="webreaper-${VERSION}-${RID}.${ARCHIVE_EXT}"
+ASSET_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET_NAME}"
+SUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/SHA256SUMS"
+
+info "downloading ${ASSET_NAME}..."
+retry_download "$ASSET_URL" "${TMP}/${ASSET_NAME}" "binary archive"
+
+info "downloading SHA256SUMS..."
+retry_download "$SUMS_URL" "${TMP}/SHA256SUMS" "checksum manifest"
+
+EXPECTED=$(awk -v f="${ASSET_NAME}" '$2 == f { print $1; exit }' "${TMP}/SHA256SUMS" || true)
+[ -n "${EXPECTED:-}" ] || { err "SHA256SUMS has no entry for ${ASSET_NAME}"; exit 5; }
+ACTUAL=$(cd "$TMP" && $SHA_CMD "$ASSET_NAME" | awk '{print $1}')
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+  err "SHA256 mismatch for ${ASSET_NAME}"
+  err "  expected: ${EXPECTED}"
+  err "  actual:   ${ACTUAL}"
+  exit 5
+fi
+ok "SHA256 verified"
+
+info "extracting..."
+case "$ARCHIVE_EXT" in
+  tar.gz) tar -xzf "${TMP}/${ASSET_NAME}" -C "$TMP" ;;
+  zip)    unzip -q -o "${TMP}/${ASSET_NAME}" -d "$TMP" ;;
+esac
+
+EXTRACTED_DIR="${TMP}/webreaper-${VERSION}-${RID}"
+[ -x "${EXTRACTED_DIR}/webreaper" ] || {
+  err "expected binary at ${EXTRACTED_DIR}/webreaper not found in archive"
+  exit 1
+}
+
+info "installing to ${TARGET}..."
+cp -f "${EXTRACTED_DIR}/webreaper" "$TARGET"
+chmod 0755 "$TARGET"
+
+# ----- post-install --------------------------------------------------------
+
+INSTALLED_VER=$("$TARGET" version 2>/dev/null | head -1 || echo "$VERSION")
+ok "installed: ${BOLD}${INSTALLED_VER}${RESET}"
+ok "location:  ${TARGET}"
+
+case ":${PATH}:" in
+  *":${PREFIX_DIR}:"*) ;;
+  *)
+    warn "${PREFIX_DIR} is not on your \$PATH"
+    warn "add to your shell rc:"
+    printf "    %sexport PATH=\"%s:\$PATH\"%s\n" "$BOLD" "$PREFIX_DIR" "$RESET" >&2
+    ;;
+esac
+
+printf '\n%sNext:%s        webreaper init && webreaper scrape https://example.com\n' "$BOLD" "$RESET"
+printf '%sUninstall:%s   rm %s\n\n'                                                  "$BOLD" "$RESET" "$TARGET"


### PR DESCRIPTION
**Draft** until [PR #123](https://github.com/pavlovtech/WebReaper/pull/123) merges and the user-side setup steps below are complete. Opens in parallel with #123 so you can pre-review the implementation against the design.

Implementation companion to PR #123's design pass. Three new artifacts on top of the existing [`release.yml` `cli-publish` job](.github/workflows/release.yml#L291-L419):

## What's new

### `scripts/install.sh` — hardened POSIX-sh installer (286 lines)

Per [ADR-0070 §2](docs/adr/0070-cli-distribution-channels.md). Curl-piped install:

\`\`\`bash
curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh
\`\`\`

| Failure mode | Exit code | Handling |
|---|---|---|
| Missing tool (curl/wget, sha256sum/shasum, tar, unzip) | 3 | Explicit error naming the missing tool |
| Unsupported OS/arch (not Linux/Darwin × x86_64/arm64) | 2 | Error names what's supported + points Windows users to GitHub Releases |
| Network failure | 4 | 3 attempts with 2s/5s/10s exponential back-off |
| SHA256 mismatch vs. release-side `SHA256SUMS` | 5 | Prints expected vs. actual |
| Different webreaper elsewhere on PATH | 6 | Warns location; `--force` overrides |
| Same version at target | 0 | No-op; `--force` reinstalls |
| Different version at target without `--force`/`--upgrade` | 7 | Refuses; explains the flags |
| Install location not writable | 8 | Falls back to `~/.local/bin`; respects explicit `PREFIX` |

Plus: `WEBREAPER_VERSION` pinning, `NO_COLOR` + tty-guard, `WEBREAPER_INSTALL_VERBOSE=1` → `set -x`, `--help` / `-h`, post-install PATH check + uninstall hint, tmpdir trap-cleanup on every exit.

POSIX-portable; tested with `sh -n` (shellcheck unavailable in this dev env — to be run in CI as a precommit-style check in a follow-up).

### `homebrew/webreaper.rb.template` — formula source

Per [ADR-0070 §1](docs/adr/0070-cli-distribution-channels.md). Six `{{...}}` placeholders substituted by the new `homebrew-publish` job. Four bottles (osx-arm64 / osx-x64 / linux-x64 / linux-arm64) via modern Homebrew 4.x `on_macos { on_arm / on_intel }` block style. `test do` block runs `webreaper version` and asserts the formula's version appears.

### `.github/workflows/release.yml` — three additions

**1. Codesign + notarize + staple steps in cli-publish's `osx-*` matrix arms** ([ADR-0071](docs/adr/0071-macos-codesigning-and-notarization.md)):

- `apple-actions/import-codesign-certs@v3` imports the .p12 to a temporary keychain (destroyed at job teardown)
- \`codesign --sign "$APPLE_DEVELOPER_ID" --options runtime --timestamp --identifier "io.highcraft.webreaper" --force\`
- \`xcrun notarytool submit --wait\` (throwaway zip; the staple goes on the binary itself, not the zip)
- \`xcrun stapler staple\`
- \`spctl -a -t exec -vvv\` as the Gatekeeper-acceptance gate

Operates on the publish-output binary (still named `WebReaper.Cli`); the existing rename → `webreaper` in the next staging step does not invalidate the signature (Mach-O signatures are content-based, identifier-bound, filename-independent).

**2. New `checksums` job** (after cli-publish):

- `gh release download` every `webreaper-*` asset
- `sha256sum | sort -k2` → `SHA256SUMS` (deterministic across re-runs)
- `gh release upload SHA256SUMS --clobber` (idempotent)

Robust against cli-publish partial-success: hashes only what's currently on the release.

**3. New `homebrew-publish` job** (after checksums):

- Downloads `SHA256SUMS`, extracts per-RID hashes via awk
- sed-renders the template; strips the developer-facing header comments so the tap's formula stays clean (begins at `class`)
- git clones the tap with `GH_TOKEN_HOMEBREW_TAP`, commits + pushes
- Idempotent: skips push if rendered formula is byte-identical (re-run safety)

## Failure semantics

Match the runbook's one-way-on-tag philosophy:
- Any new step or job that fails does NOT roll back NuGet / GitHub Release
- Recovery is `gh workflow run release.yml --ref vX.Y.Z` re-dispatch
- Re-dispatch is safe: every step is idempotent (`--clobber`, skip-if-same)

## Prerequisites to take out of DRAFT and merge

| # | Prereq | Owner | Status |
|---|---|---|---|
| 1 | [PR #123](https://github.com/pavlovtech/WebReaper/pull/123) (ADRs 0070+0071 design pass) MERGED | You | Pending review |
| 2 | `pavlovtech/homebrew-webreaper` repo created on GitHub (empty is fine; the homebrew-publish job populates `Formula/webreaper.rb`) | You | — |
| 3 | `GH_TOKEN_HOMEBREW_TAP` fine-grained PAT generated (scope: `contents: write` on the tap repo only) and added as a repo secret here | You | — |
| 4 | `APPLE_CERTIFICATE_P12_BASE64`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_NOTARIZATION_PASSWORD` added as repo secrets | You | — |
| 5 | `APPLE_TEAM_ID`, `APPLE_DEVELOPER_ID` added as repo variables (non-secret) | You | — |
| 6 | Joint integration gate: dry-run on `v10.0.0-rc1` prerelease tag → verify all channels install cleanly on fresh macOS, Ubuntu, Windows | Both | After 1–5 |

Once steps 1–5 are green, this PR moves out of draft. Step 6 is the gate before tagging v10.0.0 proper.

## Not in this PR

- `homebrew-core` graduation — post-traction (ADR-0070 §considered).
- winget / Scoop / Docker / `webreaper.dev` vanity URL — v10.1+.
- `dotnet tool install` — permanently deferred (ADR-0070 §considered).
- Linux sigstore / cosign — deferred.
- Windows EV codesigning — deferred (ADR-0071 §considered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)