### PR TITLE
Fix release.yml CANDIDATES list — drop deleted WebReaper.Puppeteer, add v10 transport satellites

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,18 +53,24 @@ env:
   # with PublishAot=true on one target, so the CLI ships as a Native-AOT
   # single-binary via GitHub Releases (ADR-0043), not via NuGet. Revisit in a
   # 10.x if there is real consumer demand for the framework-dependent tool.
+  # WebReaper.Puppeteer was deleted in v10 (ADR-0053) and replaced by the
+  # three transports satellites listed at the bottom of the block. Adding
+  # them deliberately, matching the runbook discipline (explicit set, core
+  # first, never a glob).
   CANDIDATES: >-
     WebReaper
     WebReaper.Cosmos
     WebReaper.Mongo
     WebReaper.Redis
     WebReaper.AzureServiceBus
-    WebReaper.Puppeteer
     WebReaper.Sqlite
     WebReaper.AI
     WebReaper.Extraction.Attributes
     WebReaper.Extraction.Generators
     WebReaper.Mcp
+    WebReaper.Cdp
+    WebReaper.Playwright
+    WebReaper.Stealth.CloakBrowser
 
 jobs:
   pack:


### PR DESCRIPTION
## Why

The v10.0.0 tag-push run ([26472764357](https://github.com/pavlovtech/WebReaper/actions/runs/26472764357)) failed at the **Resolve version + select the package set** step with:

> ```
> Error: WebReaper.Puppeteer/WebReaper.Puppeteer.csproj missing
> ```

[ADR-0053](docs/adr/0053-playwright-satellite-puppeteer-deletion.md) deleted the `WebReaper.Puppeteer` satellite as part of the transports cleanup wave; the directory no longer exists on master. The `CANDIDATES` list in [release.yml:56–67](.github/workflows/release.yml#L56-L67) was never updated to match, so the existence-check on `\$p/\$p.csproj` (a runbook guardrail) trips on the very first run through the list.

## What changes

- **Removes** `WebReaper.Puppeteer` from `CANDIDATES`.
- **Adds** the three v10 transport satellites that replaced it:
  - `WebReaper.Cdp` ([ADR-0052](docs/adr/0052-cdp-direct-loader-satellite.md): raw CDP transport)
  - `WebReaper.Playwright` ([ADR-0053](docs/adr/0053-playwright-satellite-puppeteer-deletion.md): Microsoft.Playwright)
  - `WebReaper.Stealth.CloakBrowser` ([ADR-0054](docs/adr/0054-stealth-backend-pattern-cloakbrowser.md): first stealth backend)
- Adds a header comment naming the replacement so future readers don't reintroduce Puppeteer or wonder why three new entries sit at the bottom.

All three new satellites inherit \`<Version>10.0.0</Version>\` from [Directory.Build.props](Directory.Build.props) (no local override), have proper \`<PackageId>\` tags, and lack \`<IsPackable>false</IsPackable>\` — so they pack and publish like every other satellite.

## After merge

The existing \`v10.0.0\` tag points at the broken commit (\`6806c81\`) and can't be reused via \`workflow_dispatch\` (which checks out the tag ref, not master). Recovery:

\`\`\`bash
# Delete the broken tag locally and on origin
git tag -d v10.0.0
git push origin :refs/tags/v10.0.0

# Recreate at the new master tip (after this PR merges)
git fetch origin master
git tag -a v10.0.0 origin/master -m "WebReaper 10.0.0"
git push origin v10.0.0
\`\`\`

The tag push fires release.yml fresh; \`pack\` succeeds this time and the rest of the pipeline runs through.

**Safe to delete-and-recreate**: the failed run never created the GitHub Release (the \`release\` job depends on \`publish\` which never approved), and \`cli-publish\` never ran. No consumer has downloaded a half-baked v10.0.0. NuGet untouched. Tap repo untouched.

## YAML validation

\`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"\` parses OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)