### PR TITLE
Fix Windows AOT publish: -p:PublishAot=true (was /p:, mangled by Git Bash MSYS)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,7 +357,7 @@ jobs:
         run: |
           dotnet publish WebReaper.Cli/WebReaper.Cli.csproj \
             -c Release -r ${{ matrix.rid }} \
-            --self-contained true /p:PublishAot=true \
+            --self-contained true -p:PublishAot=true \
             --nologo
         shell: bash
 


### PR DESCRIPTION
The cli-publish matrix's `win-x64` and `win-arm64` arms failed on the v10.0.0 release ([run 26480176267](https://github.com/pavlovtech/WebReaper/actions/runs/26480176267)) with:

> ```
> MSBUILD : error MSB1008: Only one project can be specified.
> ```

The rendered command line in the logs:

> ```
> ...WebReaper.Cli/WebReaper.Cli.csproj p:PublishAot=true -restore
> ```

Note the **literal** \`p:PublishAot=true\` (no leading slash). MSBuild parsed it as a second project file argument.

## Root cause

The [step](.github/workflows/release.yml#L352-L360) uses \`shell: bash\` on all platforms. On Windows runners that's **Git Bash**, which applies MSYS POSIX-to-Windows path conversion. When Git Bash sees \`/p:PublishAot=true\`, the leading \`/\` makes MSYS treat it as a Unix-style path; the conversion strips the slash, producing \`p:PublishAot=true\`.

## Fix

One character change: \`/p:PublishAot=true\` → \`-p:PublishAot=true\`. The single-dash form is accepted identically by dotnet CLI / MSBuild and is not subject to MSYS conversion. Works on Linux + macOS + Windows under the same \`shell: bash\`.

## Alternatives considered

| Option | Rejected because |
|---|---|
| \`--property:PublishAot=true\` (long form) | Works, longer than \`-p:\`, no other benefit |
| \`MSYS_NO_PATHCONV=1\` env var | Would also work but adds an environment dependency; the single-dash fix is the simpler shape |
| \`shell: pwsh\` on Windows arms only | Would require duplicating the step or per-platform conditional; current \`shell: bash\` is the cross-platform parity choice the workflow committed to |

## What was unaffected

Linux + macOS arms passed AOT publish fine (the `/p:` form works outside MSYS). The Linux binaries that did upload to the v10.0.0 GitHub Release will be re-uploaded with \`--clobber\` when the matrix re-runs; same content, no harm.

The macOS arms failed at a different step (cert import; tracking that separately as Apple cert refresh, not this PR).

## After merge

The recovery dance (delete v10.0.0 tag, recreate at new master tip, re-dispatch workflow) picks up where the failed run left off. NuGet is already published; cli-publish + checksums + homebrew-publish run cleanly when the matrix succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)