### PR TITLE
Make GitHub release creation idempotent so workflow re-dispatches don't crash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,8 +291,19 @@ jobs:
           if [ "$(grep -c '^## ' /tmp/notes.md)" != "1" ]; then
             echo "::error::CHANGELOG has no single '## $VERSION' section"; exit 1
           fi
-          gh release create "$TAG" --verify-tag \
-            --title "WebReaper $VERSION" --notes-file /tmp/notes.md
+          # Idempotent: create on first run, update title + notes on re-runs.
+          # The runbook's "tag = release decision" stays one-way; this just
+          # makes the workflow safe to re-dispatch when downstream steps
+          # (cli-publish matrix arms, homebrew-publish) fail and need a retry
+          # without forcing a CHANGELOG-or-tag dance.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists; updating title + notes"
+            gh release edit "$TAG" --title "WebReaper $VERSION" --notes-file /tmp/notes.md
+          else
+            echo "creating release $TAG"
+            gh release create "$TAG" --verify-tag \
+              --title "WebReaper $VERSION" --notes-file /tmp/notes.md
+          fi
 
   cli-publish:
     # ADR-0043: the WebReaper.Cli is intentionally NOT a NuGet package


### PR DESCRIPTION
The v10.0.0 release pipeline has been re-dispatched several times during its first end-to-end run as different fragilities surfaced (stale CANDIDATES list, CHANGELOG section parsing, Windows AOT flag mangling, macOS cert import). Each re-dispatch re-runs the entire flow, including the \`release\` job, which calls \`gh release create\` without idempotency.

After the first re-dispatch that gets past \`verify\`, the release object already exists, and the bare \`gh release create\` returns:

> ```
> HTTP 422: Validation Failed (https://api.github.com/repos/pavlovtech/WebReaper/releases)
> Release.tag_name already exists
> ```

That cascades: cli-publish (which depends on \`release\`) re-runs but can't proceed because release is red; checksums + homebrew-publish never fire.

## Fix

Make the release step idempotent: check whether the release exists, edit it if so, create it otherwise. First run creates the release with CHANGELOG notes; subsequent re-dispatches refresh title + notes (cheap no-op if identical).

The runbook's "tag = release decision" philosophy is preserved (a tag push still commits to a release). What changes is the workflow can now safely retry after downstream failures without manual cleanup of the partially-created release object.

## Audit of the rest of the workflow for re-dispatch resilience

| Job/step | Idempotent? | Notes |
|---|---|---|
| \`pack\` | ✓ | Rebuilds artifacts each run |
| \`publish\` (NuGet) | ✓ | \`--skip-duplicate\` → 409 as no-op |
| \`release\` → verify-indexed | ✓ | Polls; passes when indexed |
| \`release\` → \`gh release create\` | was ✗ | **FIXED by this commit** |
| \`cli-publish\` (matrix × 6 RIDs) | ✓ | \`gh release upload --clobber\` |
| \`checksums\` | ✓ | \`gh release upload --clobber\` |
| \`homebrew-publish\` | ✓ | git push skips if no diff |

After this PR's merge, only \`release-create\` was the lingering non-idempotent step. The workflow should be safe to re-dispatch any number of times after this.

## After merge

No retag needed. Dispatch the workflow with \`--ref master\` so the new release.yml takes effect. The workflow's checkout step uses \`inputs.tag\` for source code, while the workflow YAML itself can come from any ref:

\`\`\`bash
gh workflow run release.yml --ref master -f tag=v10.0.0 -f dry_run=false
\`\`\`

The release already exists with the CHANGELOG notes from a previous successful \`release\` run; the new code will detect that and \`gh release edit\` to refresh (idempotent). Then \`cli-publish\` (with the Windows \`-p:\` fix from #129 and the macOS cert from the secret update) should go 6/6 green, \`checksums\` runs, \`homebrew-publish\` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)