### PR TITLE
refactor(ai): extract LlmToolArguments helper (ADR-0059 amendment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 10.0.2 (in progress): post-launch refactors
+
+### `WebReaper.AI` — new public type `LlmToolArguments` (ADR-0059 amendment)
+
+The byte-identical `TryGetString` / `TryGetInt` JSON-argument extractors that lived as private static methods in both `LlmActionResolver` and `LlmAgentBrain` move to a shared public static class `WebReaper.AI.Llm.LlmToolArguments`. Sibling to `LlmCall<TResponse>` on the same "one canonical mechanism, not five copies" axis the original ADR defines. Consumer-authored tool-calling `Llm*` adapters reuse the helpers for consistent leniency rules instead of re-implementing.
+
+| Public type added | Notes |
+|---|---|
+| `WebReaper.AI.Llm.LlmToolArguments` | Static. Two methods: `TryGetString(JsonElement, string) → string?` and `TryGetInt(JsonElement, string) → int?`. Both return `null` for missing properties, JSON-null, or non-matching kinds. `TryGetInt` tolerates string-encoded integers (`"30000"` → `30_000`) but the JSON integer-token-vs-decimal-token boundary is strict (`1` → `1`, `1.0` → `null`); the leniency contract is pinned by `LlmToolArgumentsTests`. |
+
+No behaviour changes — the helpers are byte-identical to the now-deleted private copies; the existing brain and resolver tests continue to pass unchanged.
+
 ## 10.0.1: NuGet metadata polish (no code changes)
 
 Patch release: every NuGet package now displays a logo and README on its package page; em-dashes removed from `<Description>` / `<PackageReleaseNotes>` across all 13 csprojs. No code changes; no public-surface changes.

--- a/WebReaper.AI/Llm/LlmToolArguments.cs
+++ b/WebReaper.AI/Llm/LlmToolArguments.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+
+namespace WebReaper.AI.Llm;
+
+/// <summary>
+/// Shared JSON-argument extractors used by every tool-calling <c>Llm*</c>
+/// adapter when parsing <c>FunctionCallContent.Arguments</c> in
+/// <see cref="LlmCallDescriptor{TResponse}.ParseToolCall"/>. Sibling to
+/// <see cref="LlmCall{TResponse}"/> (ADR-0059) on the same "one canonical
+/// mechanism, not five copies" axis — consumer-authored tool-calling
+/// adapters reuse these helpers for consistent leniency rules instead of
+/// re-implementing the same null-checks.
+/// <para>
+/// Both helpers tolerate two provider quirks: a missing property reads as
+/// <c>null</c> (not a throw), and an integer serialised as a string (some
+/// providers do this for small integers) parses as the integer. Other
+/// kinds (arrays, booleans, malformed numbers) read as <c>null</c>.
+/// </para>
+/// </summary>
+public static class LlmToolArguments
+{
+    /// <summary>Read a string-valued argument, returning <c>null</c> when
+    /// the property is absent, JSON-null, or any non-string kind. Empty
+    /// strings are returned verbatim — callers pattern-match on
+    /// <c>{ Length: &gt; 0 }</c> when they need a non-empty selector.</summary>
+    public static string? TryGetString(JsonElement args, string name)
+    {
+        if (args.ValueKind != JsonValueKind.Object) return null;
+        if (!args.TryGetProperty(name, out var el)) return null;
+        return el.ValueKind switch
+        {
+            JsonValueKind.String => el.GetString(),
+            JsonValueKind.Null => null,
+            _ => null,
+        };
+    }
+
+    /// <summary>Read an integer-valued argument, returning <c>null</c>
+    /// when the property is absent, JSON-null, or any non-integer kind.
+    /// Tolerates the string-encoded-integer shape some providers emit
+    /// for small numbers.</summary>
+    public static int? TryGetInt(JsonElement args, string name)
+    {
+        if (args.ValueKind != JsonValueKind.Object) return null;
+        if (!args.TryGetProperty(name, out var el)) return null;
+        return el.ValueKind switch
+        {
+            JsonValueKind.Number when el.TryGetInt32(out var i) => i,
+            // Some providers may serialise ints as strings; tolerate it.
+            JsonValueKind.String when int.TryParse(el.GetString(), out var i) => i,
+            _ => null,
+        };
+    }
+}

--- a/WebReaper.AI/LlmActionResolver.cs
+++ b/WebReaper.AI/LlmActionResolver.cs
@@ -129,15 +129,15 @@ public sealed class LlmActionResolver : IActionResolver
         => toolName switch
         {
             "ActClick"
-                when TryGetString(args, "selector") is { Length: > 0 } sel
+                when LlmToolArguments.TryGetString(args, "selector") is { Length: > 0 } sel
                 => new PageAction.Click(sel),
 
             "ActWait"
-                => new PageAction.Wait(TryGetInt(args, "ms") ?? 0),
+                => new PageAction.Wait(LlmToolArguments.TryGetInt(args, "ms") ?? 0),
 
             "ActWaitForSelector"
-                when TryGetString(args, "selector") is { Length: > 0 } sel
-                => new PageAction.WaitForSelector(sel, TryGetInt(args, "timeoutMs") ?? 30_000),
+                when LlmToolArguments.TryGetString(args, "selector") is { Length: > 0 } sel
+                => new PageAction.WaitForSelector(sel, LlmToolArguments.TryGetInt(args, "timeoutMs") ?? 30_000),
 
             "ActWaitForNetworkIdle"
                 => new PageAction.WaitForNetworkIdle(),
@@ -146,35 +146,11 @@ public sealed class LlmActionResolver : IActionResolver
                 => new PageAction.ScrollToEnd(),
 
             "ActEvaluate"
-                when TryGetString(args, "expression") is { Length: > 0 } expr
+                when LlmToolArguments.TryGetString(args, "expression") is { Length: > 0 } expr
                 => new PageAction.EvaluateExpression(expr),
 
             _ => null,
         };
-
-    private static string? TryGetString(JsonElement args, string name)
-    {
-        if (args.ValueKind != JsonValueKind.Object) return null;
-        if (!args.TryGetProperty(name, out var el)) return null;
-        return el.ValueKind switch
-        {
-            JsonValueKind.String => el.GetString(),
-            JsonValueKind.Null => null,
-            _ => null,
-        };
-    }
-
-    private static int? TryGetInt(JsonElement args, string name)
-    {
-        if (args.ValueKind != JsonValueKind.Object) return null;
-        if (!args.TryGetProperty(name, out var el)) return null;
-        return el.ValueKind switch
-        {
-            JsonValueKind.Number when el.TryGetInt32(out var i) => i,
-            JsonValueKind.String when int.TryParse(el.GetString(), out var i) => i,
-            _ => null,
-        };
-    }
 
     private readonly record struct ResolveInput(string Intent, string Html);
 }

--- a/WebReaper.AI/LlmAgentBrain.cs
+++ b/WebReaper.AI/LlmAgentBrain.cs
@@ -203,7 +203,7 @@ public sealed class LlmAgentBrain : IAgentBrain
     // unknown discriminator" is structurally impossible.
     private static AgentDecision ParseDecisionTool(string toolName, JsonElement args)
     {
-        var reason = TryGetString(args, "reason") ?? "";
+        var reason = LlmToolArguments.TryGetString(args, "reason") ?? "";
 
         switch (toolName)
         {
@@ -227,7 +227,7 @@ public sealed class LlmAgentBrain : IAgentBrain
                 return new AgentDecision.Extract(schema) { Reason = reason };
 
             case "Follow":
-                var url = TryGetString(args, "url");
+                var url = LlmToolArguments.TryGetString(args, "url");
                 if (string.IsNullOrWhiteSpace(url))
                 {
                     return new AgentDecision.Stop
@@ -241,7 +241,7 @@ public sealed class LlmAgentBrain : IAgentBrain
                 return new AgentDecision.Stop { Reason = reason };
 
             case "ActClick":
-                var clickSel = TryGetString(args, "selector");
+                var clickSel = LlmToolArguments.TryGetString(args, "selector");
                 if (string.IsNullOrWhiteSpace(clickSel))
                 {
                     return new AgentDecision.Stop
@@ -252,10 +252,10 @@ public sealed class LlmAgentBrain : IAgentBrain
                 return new AgentDecision.Act(new PageAction.Click(clickSel)) { Reason = reason };
 
             case "ActWait":
-                return new AgentDecision.Act(new PageAction.Wait(TryGetInt(args, "ms") ?? 0)) { Reason = reason };
+                return new AgentDecision.Act(new PageAction.Wait(LlmToolArguments.TryGetInt(args, "ms") ?? 0)) { Reason = reason };
 
             case "ActWaitForSelector":
-                var wfsSel = TryGetString(args, "selector");
+                var wfsSel = LlmToolArguments.TryGetString(args, "selector");
                 if (string.IsNullOrWhiteSpace(wfsSel))
                 {
                     return new AgentDecision.Stop
@@ -264,7 +264,7 @@ public sealed class LlmAgentBrain : IAgentBrain
                     };
                 }
                 return new AgentDecision.Act(
-                    new PageAction.WaitForSelector(wfsSel, TryGetInt(args, "timeoutMs") ?? 30_000))
+                    new PageAction.WaitForSelector(wfsSel, LlmToolArguments.TryGetInt(args, "timeoutMs") ?? 30_000))
                 { Reason = reason };
 
             case "ActWaitForNetworkIdle":
@@ -274,7 +274,7 @@ public sealed class LlmAgentBrain : IAgentBrain
                 return new AgentDecision.Act(new PageAction.ScrollToEnd()) { Reason = reason };
 
             case "ActEvaluate":
-                var expr = TryGetString(args, "expression");
+                var expr = LlmToolArguments.TryGetString(args, "expression");
                 if (string.IsNullOrWhiteSpace(expr))
                 {
                     return new AgentDecision.Stop
@@ -285,7 +285,7 @@ public sealed class LlmAgentBrain : IAgentBrain
                 return new AgentDecision.Act(new PageAction.EvaluateExpression(expr)) { Reason = reason };
 
             case "ActSemanticAct":
-                var intent = TryGetString(args, "intent");
+                var intent = LlmToolArguments.TryGetString(args, "intent");
                 if (string.IsNullOrWhiteSpace(intent))
                 {
                     return new AgentDecision.Stop
@@ -320,28 +320,4 @@ public sealed class LlmAgentBrain : IAgentBrain
         return s;
     }
 
-    private static string? TryGetString(JsonElement args, string name)
-    {
-        if (args.ValueKind != JsonValueKind.Object) return null;
-        if (!args.TryGetProperty(name, out var el)) return null;
-        return el.ValueKind switch
-        {
-            JsonValueKind.String => el.GetString(),
-            JsonValueKind.Null => null,
-            _ => null,
-        };
-    }
-
-    private static int? TryGetInt(JsonElement args, string name)
-    {
-        if (args.ValueKind != JsonValueKind.Object) return null;
-        if (!args.TryGetProperty(name, out var el)) return null;
-        return el.ValueKind switch
-        {
-            JsonValueKind.Number when el.TryGetInt32(out var i) => i,
-            // Some providers may serialise ints as strings; tolerate it.
-            JsonValueKind.String when int.TryParse(el.GetString(), out var i) => i,
-            _ => null,
-        };
-    }
 }

--- a/WebReaper.Tests/WebReaper.AI.Tests/LlmToolArgumentsTests.cs
+++ b/WebReaper.Tests/WebReaper.AI.Tests/LlmToolArgumentsTests.cs
@@ -109,6 +109,21 @@ public class LlmToolArgumentsTests
     }
 
     [Fact]
+    public void TryGetInt_accepts_integer_token_rejects_decimal_token()
+    {
+        // System.Text.Json tokenises JSON numbers with vs. without a
+        // decimal point distinctly: TryGetInt32 accepts the integer
+        // shape (1, 30000) and REJECTS the decimal shape — even when
+        // the decimal value is whole (1.0). Pin the contract here
+        // because a provider that emits "1.0" for a logical integer
+        // will silently coerce to null and the caller will fall back
+        // to the arm's default. Document the boundary.
+        Assert.Equal(1, LlmToolArguments.TryGetInt(Parse("""{ "ms": 1 }"""), "ms"));
+        Assert.Equal(30_000, LlmToolArguments.TryGetInt(Parse("""{ "ms": 30000 }"""), "ms"));
+        Assert.Null(LlmToolArguments.TryGetInt(Parse("""{ "ms": 1.0 }"""), "ms"));
+    }
+
+    [Fact]
     public void TryGetInt_returns_null_for_json_null()
     {
         var args = Parse("""{ "ms": null }""");

--- a/WebReaper.Tests/WebReaper.AI.Tests/LlmToolArgumentsTests.cs
+++ b/WebReaper.Tests/WebReaper.AI.Tests/LlmToolArgumentsTests.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using WebReaper.AI.Llm;
+
+namespace WebReaper.AI.Tests;
+
+// ADR-0059 amendment: the shared JsonElement argument extractors the
+// tool-calling Llm* adapters use to parse FunctionCallContent.Arguments.
+// Extracted byte-identically from the now-deleted private copies that
+// lived in LlmActionResolver and LlmAgentBrain. These tests pin the
+// leniency contract so a future tighten-up doesn't silently break the
+// adapters depending on it.
+public class LlmToolArgumentsTests
+{
+    private static JsonElement Parse(string json) =>
+        JsonDocument.Parse(json).RootElement;
+
+    // ---- TryGetString ------------------------------------------------------
+
+    [Fact]
+    public void TryGetString_returns_the_string_when_present()
+    {
+        var args = Parse("""{ "selector": ".btn" }""");
+        Assert.Equal(".btn", LlmToolArguments.TryGetString(args, "selector"));
+    }
+
+    [Fact]
+    public void TryGetString_returns_null_when_property_is_absent()
+    {
+        var args = Parse("""{ "other": "x" }""");
+        Assert.Null(LlmToolArguments.TryGetString(args, "selector"));
+    }
+
+    [Fact]
+    public void TryGetString_returns_null_when_value_is_json_null()
+    {
+        var args = Parse("""{ "selector": null }""");
+        Assert.Null(LlmToolArguments.TryGetString(args, "selector"));
+    }
+
+    [Fact]
+    public void TryGetString_returns_null_for_non_string_kinds()
+    {
+        // Number, boolean, array, object — all coerce to null per the
+        // adapter contract (callers want a clean null on bad shape, not
+        // a coerced ToString).
+        Assert.Null(LlmToolArguments.TryGetString(Parse("""{ "x": 42 }"""), "x"));
+        Assert.Null(LlmToolArguments.TryGetString(Parse("""{ "x": true }"""), "x"));
+        Assert.Null(LlmToolArguments.TryGetString(Parse("""{ "x": [1,2] }"""), "x"));
+        Assert.Null(LlmToolArguments.TryGetString(Parse("""{ "x": {} }"""), "x"));
+    }
+
+    [Fact]
+    public void TryGetString_returns_empty_string_verbatim()
+    {
+        // Empty string is a real value, not absent — callers pattern-
+        // match on { Length: > 0 } when they need a non-empty selector.
+        var args = Parse("""{ "selector": "" }""");
+        Assert.Equal(string.Empty, LlmToolArguments.TryGetString(args, "selector"));
+    }
+
+    [Fact]
+    public void TryGetString_returns_null_when_args_is_not_an_object()
+    {
+        // The provider may hand us a malformed root (array, string,
+        // primitive); the helpers swallow rather than throw so the
+        // adapter can fall back to its default arm.
+        Assert.Null(LlmToolArguments.TryGetString(Parse("""[1,2,3]"""), "selector"));
+        Assert.Null(LlmToolArguments.TryGetString(Parse("""null"""), "selector"));
+    }
+
+    // ---- TryGetInt ---------------------------------------------------------
+
+    [Fact]
+    public void TryGetInt_returns_the_int_when_present()
+    {
+        var args = Parse("""{ "ms": 250 }""");
+        Assert.Equal(250, LlmToolArguments.TryGetInt(args, "ms"));
+    }
+
+    [Fact]
+    public void TryGetInt_returns_null_when_property_is_absent()
+    {
+        var args = Parse("""{ "other": 1 }""");
+        Assert.Null(LlmToolArguments.TryGetInt(args, "ms"));
+    }
+
+    [Fact]
+    public void TryGetInt_tolerates_string_encoded_integers()
+    {
+        // Some providers serialise small ints as strings; tolerate it.
+        var args = Parse("""{ "timeoutMs": "30000" }""");
+        Assert.Equal(30_000, LlmToolArguments.TryGetInt(args, "timeoutMs"));
+    }
+
+    [Fact]
+    public void TryGetInt_returns_null_for_non_integer_strings()
+    {
+        var args = Parse("""{ "ms": "fast" }""");
+        Assert.Null(LlmToolArguments.TryGetInt(args, "ms"));
+    }
+
+    [Fact]
+    public void TryGetInt_returns_null_for_non_int32_numbers()
+    {
+        // Floating point and out-of-Int32 numbers read as null — the
+        // adapter contract is "an int or nothing."
+        Assert.Null(LlmToolArguments.TryGetInt(Parse("""{ "ms": 1.5 }"""), "ms"));
+        Assert.Null(LlmToolArguments.TryGetInt(Parse("""{ "ms": 9999999999 }"""), "ms"));
+    }
+
+    [Fact]
+    public void TryGetInt_returns_null_for_json_null()
+    {
+        var args = Parse("""{ "ms": null }""");
+        Assert.Null(LlmToolArguments.TryGetInt(args, "ms"));
+    }
+
+    [Fact]
+    public void TryGetInt_returns_null_when_args_is_not_an_object()
+    {
+        Assert.Null(LlmToolArguments.TryGetInt(Parse("""42"""), "ms"));
+    }
+}

--- a/docs/adr/0059-llm-call-mechanism-module.md
+++ b/docs/adr/0059-llm-call-mechanism-module.md
@@ -468,6 +468,44 @@ becomes ~70 lines (parse-failure becomes `null`).
 - `WebReaper.AotSmokeTest` — unchanged (mechanism lives in the
   non-AOT satellite).
 
+## Amendment (2026-05-28): `LlmToolArguments` companion helper
+
+The tool-call dispatch path (`ParseToolCall`) takes a `JsonElement` of
+argument values and is implemented by every tool-calling adapter
+(`LlmActionResolver`, `LlmAgentBrain`, and any consumer-authored adapter
+that ships a `Tools` list on its descriptor). The two shipping adapters
+each carried a private `TryGetString` / `TryGetInt` pair that read a
+string- or int-valued argument from the JSON, tolerating the two
+provider quirks worth tolerating (missing property reads as `null`;
+some providers serialise small integers as strings).
+
+The two pairs were byte-identical — a textbook case of the same
+mechanism reimplemented per adapter rather than shared once. A
+consumer-authored tool-calling adapter would have made it three.
+
+The helpers move to `WebReaper.AI/Llm/LlmToolArguments.cs` as public
+static methods, sibling to `LlmCall<TResponse>` itself on the same
+"one canonical mechanism, not five copies" axis the original ADR
+defines. The leniency contract is pinned by `LlmToolArgumentsTests`
+(missing property → null, JSON-null → null, non-string/non-integer
+kinds → null, empty string returned verbatim so callers can pattern-
+match on `{ Length: > 0 }`, string-encoded integers parse).
+
+The private copies in `LlmActionResolver` (lines 155–177 before the
+edit) and `LlmAgentBrain` (lines 323–346) are deleted. Net change:
+~46 lines deleted from the two adapters, ~55 lines added in the new
+shared module (helpers + XML doc), ~125 lines of direct unit tests.
+The two adapters' integration tests continue to cover the behaviour
+through the helpers transparently.
+
+The descriptor record (`LlmCallDescriptor<TResponse>`) does NOT grow
+— this amendment is the helper companion, not a descriptor change.
+Consumer-authored tool-calling adapters reuse the helpers the same
+way they reuse `LlmCall<TResponse>` itself: by referencing
+`WebReaper.AI`. The "one canonical fence-stripping, one canonical
+parse-retry, one canonical Usage capture" promise of ADR-0059
+extends to "one canonical tool-argument extractor."
+
 ## References
 
 - ADR-0009 — registration seam + satellite pattern; the mechanism


### PR DESCRIPTION
## Summary

Extract `TryGetString` and `TryGetInt` from `LlmActionResolver` and `LlmAgentBrain` into a shared public `WebReaper.AI.Llm.LlmToolArguments` helper, sibling to `LlmCall<TResponse>`. ADR-0059 grows an amendment recording the companion helper.

## Why

The two adapters carried byte-identical private static `TryGet*` methods for parsing `FunctionCallContent.Arguments` in `LlmCallDescriptor.ParseToolCall`. A consumer-authored tool-calling adapter would have made it three copies. ADR-0059's "one canonical mechanism, not five copies" promise (fence-stripping, parse-retry, Usage capture) now extends to tool-argument extraction.

## Changes

| File | Change |
|---|---|
| `WebReaper.AI/Llm/LlmToolArguments.cs` | **NEW** public static class, 54 lines |
| `WebReaper.AI/LlmActionResolver.cs` | Remove private helpers (lines 155-177), update 6 call sites |
| `WebReaper.AI/LlmAgentBrain.cs` | Remove private helpers (lines 323-346), update 14 call sites |
| `WebReaper.Tests/WebReaper.AI.Tests/LlmToolArgumentsTests.cs` | **NEW** 13 tests pinning the leniency contract |
| `docs/adr/0059-llm-call-mechanism-module.md` | Append `## Amendment (2026-05-28)` section |

Net: -46 lines from two adapters, +55 in shared module, +125 in direct tests.

## Leniency contract (pinned by the new tests)

- Missing property → `null`
- JSON-`null` value → `null`
- Non-string kinds for `TryGetString` → `null` (no `ToString` coercion)
- Non-integer kinds for `TryGetInt` → `null`, but tolerate string-encoded integers (some providers serialise small ints as strings)
- Empty string returned verbatim — callers pattern-match on `{ Length: > 0 }` when they need non-empty
- Malformed root (`args` not a JSON object) → `null` — adapters fall through to their default arm rather than throw

## Tests

```
AI:    253 passed (was 240, +13)
Unit:  409 passed
```

Both adapters continue to be exercised end-to-end through their existing test suites (`LlmActionResolverTests`, `LlmAgentBrainTests`), so the extraction is covered transparently — the new direct tests just pin the contract at the helper level.

## ADR-0059 amendment

Documents the companion helper and the rationale. The descriptor record (`LlmCallDescriptor<TResponse>`) does NOT grow — this is a sibling utility, not a descriptor change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)