### PR TITLE
refactor(ai): arm-local tool projection (ADR-0060 amendment)

### DIFF
--- a/WebReaper.AI/LlmActionResolver.cs
+++ b/WebReaper.AI/LlmActionResolver.cs
@@ -120,35 +120,25 @@ public sealed class LlmActionResolver : IActionResolver
         "Intent: " + input.Intent + "\n\n" +
         "Page (HTML, may be truncated):\n" + input.Html;
 
-    // ADR-0060 fork 8: the resolver's tool list has six arms; the closed
-    // sum is closed structurally (no ActSemanticAct ever, so the model
-    // cannot loop). Unknown tool name (the model invented one or called
-    // a brain-only arm) -> null; the transport surfaces a typed
-    // SemanticActResolutionException.
+    // ADR-0060 fork 8 + 2026-05-28 amendment: the resolver's tool list has
+    // six arms; the closed sum is closed structurally (no ActSemanticAct
+    // ever, so the model cannot loop). Each per-arm case dispatches to the
+    // arm-local FromArguments factory (in PageActionTools.cs). Unknown
+    // tool name (the model invented one or called the brain-only
+    // ActSemanticAct arm) -> null; the transport surfaces a typed
+    // SemanticActResolutionException. A factory failure (FromArguments
+    // returned a FailureReason) also reads as null — the resolver's
+    // contract is "concrete arm, or nothing", no per-failure diagnostics
+    // beyond what the transport's exception carries.
     private static PageAction? ParseActionTool(string toolName, JsonElement args)
         => toolName switch
         {
-            "ActClick"
-                when LlmToolArguments.TryGetString(args, "selector") is { Length: > 0 } sel
-                => new PageAction.Click(sel),
-
-            "ActWait"
-                => new PageAction.Wait(LlmToolArguments.TryGetInt(args, "ms") ?? 0),
-
-            "ActWaitForSelector"
-                when LlmToolArguments.TryGetString(args, "selector") is { Length: > 0 } sel
-                => new PageAction.WaitForSelector(sel, LlmToolArguments.TryGetInt(args, "timeoutMs") ?? 30_000),
-
-            "ActWaitForNetworkIdle"
-                => new PageAction.WaitForNetworkIdle(),
-
-            "ActScrollToEnd"
-                => new PageAction.ScrollToEnd(),
-
-            "ActEvaluate"
-                when LlmToolArguments.TryGetString(args, "expression") is { Length: > 0 } expr
-                => new PageAction.EvaluateExpression(expr),
-
+            PageActionTools.Click.Name => PageActionTools.Click.FromArguments(args).Value,
+            PageActionTools.Wait.Name => PageActionTools.Wait.FromArguments(args).Value,
+            PageActionTools.WaitForSelector.Name => PageActionTools.WaitForSelector.FromArguments(args).Value,
+            PageActionTools.WaitForNetworkIdle.Name => PageActionTools.WaitForNetworkIdle.FromArguments(args).Value,
+            PageActionTools.ScrollToEnd.Name => PageActionTools.ScrollToEnd.FromArguments(args).Value,
+            PageActionTools.EvaluateExpression.Name => PageActionTools.EvaluateExpression.FromArguments(args).Value,
             _ => null,
         };
 

--- a/WebReaper.AI/LlmAgentBrain.cs
+++ b/WebReaper.AI/LlmAgentBrain.cs
@@ -194,130 +194,59 @@ public sealed class LlmAgentBrain : IAgentBrain
         _ => "Unknown"
     };
 
-    // ADR-0060: ParseToolCall delegate. Switches on the model's tool name,
-    // constructs the matching AgentDecision arm with the SDK-validated
-    // arguments. Unknown tool name -> Stop with structural reason; missing
-    // required property -> Stop with structural reason. The closed sum is
-    // load-bearing at the LLM boundary — the model picked from a list of
-    // ten arm-shaped tools; "the model emitted a JSON object with an
-    // unknown discriminator" is structurally impossible.
+    // ADR-0060 amendment (2026-05-28): ParseToolCall delegate. Each per-arm
+    // case dispatches to the arm-local FromArguments factory (in
+    // PageActionTools.cs / AgentDecisionToolFragments.cs); a successful arm
+    // becomes the decision verbatim (AgentDecision arms) or is wrapped in
+    // Act (PageAction arms); a failure becomes Stop with the factory's
+    // FailureReason composed into the audit-trail string. Unknown tool
+    // name -> Stop with structural reason. The closed sum is load-bearing
+    // at the LLM boundary — the model picked from a list of ten arm-shaped
+    // tools; "the model emitted a JSON object with an unknown
+    // discriminator" is structurally impossible.
     private static AgentDecision ParseDecisionTool(string toolName, JsonElement args)
     {
         var reason = LlmToolArguments.TryGetString(args, "reason") ?? "";
 
-        switch (toolName)
+        return toolName switch
         {
-            case "Extract":
-                if (!args.TryGetProperty("schema", out var schemaEl) ||
-                    schemaEl.ValueKind != JsonValueKind.Object)
-                {
-                    return new AgentDecision.Stop
-                    {
-                        Reason = $"brain Extract missing 'schema': {reason}"
-                    };
-                }
-                var schema = BuildFlatSchema(schemaEl);
-                if (schema.Children.Count == 0)
-                {
-                    return new AgentDecision.Stop
-                    {
-                        Reason = $"brain Extract schema was empty: {reason}"
-                    };
-                }
-                return new AgentDecision.Extract(schema) { Reason = reason };
+            AgentDecisionTools.Extract.Name => Unwrap(AgentDecisionTools.Extract.FromArguments(args, reason), toolName, reason),
+            AgentDecisionTools.Follow.Name => Unwrap(AgentDecisionTools.Follow.FromArguments(args, reason), toolName, reason),
+            AgentDecisionTools.Stop.Name => Unwrap(AgentDecisionTools.Stop.FromArguments(args, reason), toolName, reason),
 
-            case "Follow":
-                var url = LlmToolArguments.TryGetString(args, "url");
-                if (string.IsNullOrWhiteSpace(url))
-                {
-                    return new AgentDecision.Stop
-                    {
-                        Reason = $"brain Follow missing 'url': {reason}"
-                    };
-                }
-                return new AgentDecision.Follow(url) { Reason = reason };
+            PageActionTools.Click.Name => UnwrapAct(PageActionTools.Click.FromArguments(args), toolName, reason),
+            PageActionTools.Wait.Name => UnwrapAct(PageActionTools.Wait.FromArguments(args), toolName, reason),
+            PageActionTools.WaitForSelector.Name => UnwrapAct(PageActionTools.WaitForSelector.FromArguments(args), toolName, reason),
+            PageActionTools.WaitForNetworkIdle.Name => UnwrapAct(PageActionTools.WaitForNetworkIdle.FromArguments(args), toolName, reason),
+            PageActionTools.ScrollToEnd.Name => UnwrapAct(PageActionTools.ScrollToEnd.FromArguments(args), toolName, reason),
+            PageActionTools.EvaluateExpression.Name => UnwrapAct(PageActionTools.EvaluateExpression.FromArguments(args), toolName, reason),
+            PageActionTools.SemanticAct.Name => UnwrapAct(PageActionTools.SemanticAct.FromArguments(args), toolName, reason),
 
-            case "Stop":
-                return new AgentDecision.Stop { Reason = reason };
-
-            case "ActClick":
-                var clickSel = LlmToolArguments.TryGetString(args, "selector");
-                if (string.IsNullOrWhiteSpace(clickSel))
-                {
-                    return new AgentDecision.Stop
-                    {
-                        Reason = $"brain ActClick missing 'selector': {reason}"
-                    };
-                }
-                return new AgentDecision.Act(new PageAction.Click(clickSel)) { Reason = reason };
-
-            case "ActWait":
-                return new AgentDecision.Act(new PageAction.Wait(LlmToolArguments.TryGetInt(args, "ms") ?? 0)) { Reason = reason };
-
-            case "ActWaitForSelector":
-                var wfsSel = LlmToolArguments.TryGetString(args, "selector");
-                if (string.IsNullOrWhiteSpace(wfsSel))
-                {
-                    return new AgentDecision.Stop
-                    {
-                        Reason = $"brain ActWaitForSelector missing 'selector': {reason}"
-                    };
-                }
-                return new AgentDecision.Act(
-                    new PageAction.WaitForSelector(wfsSel, LlmToolArguments.TryGetInt(args, "timeoutMs") ?? 30_000))
-                { Reason = reason };
-
-            case "ActWaitForNetworkIdle":
-                return new AgentDecision.Act(new PageAction.WaitForNetworkIdle()) { Reason = reason };
-
-            case "ActScrollToEnd":
-                return new AgentDecision.Act(new PageAction.ScrollToEnd()) { Reason = reason };
-
-            case "ActEvaluate":
-                var expr = LlmToolArguments.TryGetString(args, "expression");
-                if (string.IsNullOrWhiteSpace(expr))
-                {
-                    return new AgentDecision.Stop
-                    {
-                        Reason = $"brain ActEvaluate missing 'expression': {reason}"
-                    };
-                }
-                return new AgentDecision.Act(new PageAction.EvaluateExpression(expr)) { Reason = reason };
-
-            case "ActSemanticAct":
-                var intent = LlmToolArguments.TryGetString(args, "intent");
-                if (string.IsNullOrWhiteSpace(intent))
-                {
-                    return new AgentDecision.Stop
-                    {
-                        Reason = $"brain ActSemanticAct missing 'intent': {reason}"
-                    };
-                }
-                return new AgentDecision.Act(new PageAction.SemanticAct(intent)) { Reason = reason };
-
-            default:
-                return new AgentDecision.Stop
-                {
-                    Reason = $"brain called unregistered tool '{toolName}'"
-                };
-        }
+            _ => new AgentDecision.Stop
+            {
+                Reason = $"brain called unregistered tool '{toolName}'"
+            },
+        };
     }
 
-    // v1: single-level flat schema { "field": "selector", ... }. Nested
-    // schemas (objects-within-objects, lists-of-objects) are a v2 deferral
-    // matching ADR-0045's source-gen v2 deferral.
-    private static Schema BuildFlatSchema(JsonElement schemaEl)
-    {
-        var s = new Schema();
-        foreach (var prop in schemaEl.EnumerateObject())
-        {
-            if (prop.Value.ValueKind != JsonValueKind.String) continue;
-            var fieldName = prop.Name;
-            var selector = prop.Value.GetString();
-            if (string.IsNullOrWhiteSpace(fieldName) || string.IsNullOrWhiteSpace(selector)) continue;
-            s.Add(new SchemaElement(fieldName, selector));
-        }
-        return s;
-    }
+    // Brain wrap for AgentDecision arms: the factory returns the arm with
+    // its Reason already populated (the brain passed reason in); on failure
+    // the freeform FailureReason composes into a Stop matching the
+    // pre-amendment audit-trail format byte-for-byte.
+    private static AgentDecision Unwrap<T>(ToolCallResult<T> result, string toolName, string reason)
+        where T : AgentDecision =>
+        result.Value is { } arm
+            ? arm
+            : new AgentDecision.Stop { Reason = $"brain {toolName} {result.FailureReason}: {reason}" };
+
+    // Brain wrap for Act* arms: the factory returns the PageAction value;
+    // the brain wraps in Act with the audit-trail Reason. Failure -> Stop
+    // with the factory's FailureReason in the same format as the
+    // pre-amendment parser.
+    private static AgentDecision UnwrapAct<T>(ToolCallResult<T> result, string toolName, string reason)
+        where T : PageAction =>
+        result.Value is { } action
+            ? new AgentDecision.Act(action) { Reason = reason }
+            : new AgentDecision.Stop { Reason = $"brain {toolName} {result.FailureReason}: {reason}" };
 
 }

--- a/WebReaper.AI/Tools/AgentDecisionTools.cs
+++ b/WebReaper.AI/Tools/AgentDecisionTools.cs
@@ -1,301 +1,223 @@
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.AI;
+using WebReaper.AI.Llm;
+using WebReaper.Domain.Agent;
+using WebReaper.Domain.PageActions;
+using WebReaper.Domain.Parsing;
 
 namespace WebReaper.AI.Tools;
 
 /// <summary>
-/// The closed-sum-as-tools registries (ADR-0060). Each
-/// <see cref="WebReaper.Domain.Agent.AgentDecision"/> arm is one tool on
-/// the brain's registry; each concrete <see cref="WebReaper.Domain.PageActions.PageAction"/>
-/// arm (the six non-<c>SemanticAct</c> arms) is one tool on the resolver's
-/// registry. Hand-rolled JSON Schema per arm (fork 4 — AOT-friendly, no
-/// reflection-built schemas).
+/// The closed-sum-as-tools registries (ADR-0060, ADR-0060 amendment
+/// 2026-05-28). Holds the per-arm tool projections for the three
+/// <see cref="AgentDecision"/> arms whose tool shape is NOT shared with
+/// <see cref="PageAction"/> (<see cref="Extract"/>, <see cref="Follow"/>,
+/// <see cref="Stop"/>), plus the two registration lists
+/// (<see cref="ForBrain"/>, <see cref="ForResolver"/>) that compose the
+/// per-arm <see cref="AIFunction"/> descriptors into the lists the brain
+/// and resolver register with <see cref="ChatOptions.Tools"/>.
 /// <para>
-/// Brain registry: 10 tools — <c>Extract</c>, <c>Follow</c>, <c>Stop</c>,
-/// plus 7 flat <c>Act*</c> arms (the seven <see cref="WebReaper.Domain.PageActions.PageAction"/>
-/// arms including <c>ActSemanticAct</c>, so the brain can still hand the
-/// resolver an intent). The flat packaging (fork 2 verdict) keeps every
-/// arm's schema simple; the model picks one; the SDK validates the args
-/// against the per-arm schema.
+/// Hand-rolled JSON Schema per arm (fork 4 — AOT-friendly, no
+/// reflection-built schemas). After the amendment each arm's tool
+/// concerns (Name + Descriptor + FromArguments) live in one nested
+/// static class instead of being scattered across this file's factory
+/// list, the brain's parser switch, and the resolver's parser switch.
 /// </para>
 /// <para>
-/// Resolver registry: 6 tools — the six concrete arms, ever. No
-/// <c>ActSemanticAct</c> on the resolver (fork 8 verdict — the closed sum
-/// is structural at the resolver tool list; the model literally cannot
-/// emit a <c>SemanticAct</c>-loop arm).
+/// Brain registry: 10 tools — <see cref="Extract"/>, <see cref="Follow"/>,
+/// <see cref="Stop"/>, plus 7 flat <c>Act*</c> arms (the seven
+/// <see cref="PageAction"/> arms including
+/// <see cref="PageAction.SemanticAct"/>). The flat packaging (fork 2)
+/// keeps every arm's schema simple; the model picks one; the SDK
+/// validates the args against the per-arm schema.
+/// </para>
+/// <para>
+/// Resolver registry: 6 tools — the six concrete <see cref="PageAction"/>
+/// arms, ever. No <see cref="PageAction.SemanticAct"/> on the resolver
+/// (fork 8 — the closed sum is structural at the resolver tool list; the
+/// model literally cannot emit a <c>SemanticAct</c>-loop arm).
 /// </para>
 /// </summary>
 internal static class AgentDecisionTools
 {
-    /// <summary>The brain's 10-tool registry — every <see cref="WebReaper.Domain.Agent.AgentDecision"/>
-    /// arm with the seven <c>PageAction</c> arms flat-packed.</summary>
+    // ---- Per-arm tool projections (AgentDecision-specific arms) -------------
+
+    /// <summary>Tool projection of <see cref="AgentDecision.Extract"/>.</summary>
+    public static class Extract
+    {
+        public const string Name = "Extract";
+
+        public static AIFunction Descriptor { get; } = new HandRolledAIFunction(
+            name: Name,
+            description:
+                "Extract a record from the current page using a flat field-to-CSS-selector " +
+                "schema. Use when the current page contains the records you want to capture. " +
+                "Single-level only; no nested objects in v1.",
+            parametersSchema: new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["schema"] = new JsonObject
+                    {
+                        ["type"] = "object",
+                        ["description"] = "Map of output field name to CSS selector. Single level — no nested objects.",
+                        ["additionalProperties"] = new JsonObject { ["type"] = "string" },
+                    },
+                    ["reason"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Why this is the right next step.",
+                    },
+                },
+                ["required"] = new JsonArray { "schema", "reason" },
+            });
+
+        /// <summary>Construct the arm from a tool call's argument JSON plus
+        /// the audit-trail reason. Two failure modes:
+        /// <c>"missing 'schema'"</c> when the schema property is absent or
+        /// non-object, and <c>"schema was empty"</c> when the schema parses
+        /// but yields no usable field/selector pairs (the v1 single-level
+        /// flat shape rejects nested objects — they round-trip to an empty
+        /// Schema).</summary>
+        public static ToolCallResult<AgentDecision.Extract> FromArguments(JsonElement args, string reason)
+        {
+            if (!args.TryGetProperty("schema", out var schemaEl) ||
+                schemaEl.ValueKind != JsonValueKind.Object)
+            {
+                return ToolCallResult<AgentDecision.Extract>.Failed("missing 'schema'");
+            }
+            var schema = BuildFlatSchema(schemaEl);
+            if (schema.Children.Count == 0)
+            {
+                return ToolCallResult<AgentDecision.Extract>.Failed("schema was empty");
+            }
+            return ToolCallResult<AgentDecision.Extract>.Ok(
+                new AgentDecision.Extract(schema) { Reason = reason });
+        }
+
+        // v1: single-level flat schema { "field": "selector", ... }. Nested
+        // schemas (objects-within-objects, lists-of-objects) are a v2
+        // deferral matching ADR-0045's source-gen v1 constraint. Kept
+        // arm-local — the brain's Extract is the only consumer; the
+        // schema-inferrer adapter has its own (more lenient) flattener
+        // that handles two LLM-emitted shapes.
+        private static Schema BuildFlatSchema(JsonElement schemaEl)
+        {
+            var s = new Schema();
+            foreach (var prop in schemaEl.EnumerateObject())
+            {
+                if (prop.Value.ValueKind != JsonValueKind.String) continue;
+                var fieldName = prop.Name;
+                var selector = prop.Value.GetString();
+                if (string.IsNullOrWhiteSpace(fieldName) || string.IsNullOrWhiteSpace(selector)) continue;
+                s.Add(new SchemaElement(fieldName, selector));
+            }
+            return s;
+        }
+    }
+
+    /// <summary>Tool projection of <see cref="AgentDecision.Follow"/>.</summary>
+    public static class Follow
+    {
+        public const string Name = "Follow";
+
+        public static AIFunction Descriptor { get; } = new HandRolledAIFunction(
+            name: Name,
+            description:
+                "Load a candidate URL as the next agent step. Pick the URL from the listed " +
+                "candidate URLs on the current page. Do not propose a URL you have already " +
+                "visited (the engine will reject it).",
+            parametersSchema: new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["url"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Absolute URL chosen from the candidate list.",
+                    },
+                    ["reason"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Why this URL is the right next step.",
+                    },
+                },
+                ["required"] = new JsonArray { "url", "reason" },
+            });
+
+        public static ToolCallResult<AgentDecision.Follow> FromArguments(JsonElement args, string reason)
+        {
+            var url = LlmToolArguments.TryGetString(args, "url");
+            return string.IsNullOrWhiteSpace(url)
+                ? ToolCallResult<AgentDecision.Follow>.Failed("missing 'url'")
+                : ToolCallResult<AgentDecision.Follow>.Ok(
+                    new AgentDecision.Follow(url) { Reason = reason });
+        }
+    }
+
+    /// <summary>Tool projection of <see cref="AgentDecision.Stop"/>.</summary>
+    public static class Stop
+    {
+        public const string Name = "Stop";
+
+        public static AIFunction Descriptor { get; } = new HandRolledAIFunction(
+            name: Name,
+            description:
+                "Terminate the agent run. Use when the goal is satisfied OR the page set has " +
+                "been exhausted without further progress.",
+            parametersSchema: new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["reason"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Why the run is stopping — goal satisfied, dead-end, etc.",
+                    },
+                },
+                ["required"] = new JsonArray { "reason" },
+            });
+
+        /// <summary>Always succeeds — Stop has no required arguments beyond
+        /// the audit-trail <c>Reason</c>. The <paramref name="args"/>
+        /// JsonElement is ignored.</summary>
+        public static ToolCallResult<AgentDecision.Stop> FromArguments(JsonElement args, string reason) =>
+            ToolCallResult<AgentDecision.Stop>.Ok(new AgentDecision.Stop { Reason = reason });
+    }
+
+    // ---- Registration lists --------------------------------------------------
+
+    /// <summary>The brain's 10-tool registry — every <see cref="AgentDecision"/>
+    /// arm with the seven <see cref="PageAction"/> arms flat-packed.</summary>
     public static IReadOnlyList<AIFunction> ForBrain() =>
     [
-        ExtractTool(),
-        FollowTool(),
-        StopTool(),
-        ActClickTool(),
-        ActWaitTool(),
-        ActWaitForSelectorTool(),
-        ActWaitForNetworkIdleTool(),
-        ActScrollToEndTool(),
-        ActEvaluateTool(),
-        ActSemanticActTool(),
+        Extract.Descriptor,
+        Follow.Descriptor,
+        Stop.Descriptor,
+        PageActionTools.Click.Descriptor,
+        PageActionTools.Wait.Descriptor,
+        PageActionTools.WaitForSelector.Descriptor,
+        PageActionTools.WaitForNetworkIdle.Descriptor,
+        PageActionTools.ScrollToEnd.Descriptor,
+        PageActionTools.EvaluateExpression.Descriptor,
+        PageActionTools.SemanticAct.Descriptor,
     ];
 
     /// <summary>The resolver's 6-tool registry — the six concrete
-    /// <see cref="WebReaper.Domain.PageActions.PageAction"/> arms. No
-    /// <c>ActSemanticAct</c> — structurally prevents the resolver from
-    /// looping the transport (fork 8).</summary>
+    /// <see cref="PageAction"/> arms. No <see cref="PageAction.SemanticAct"/>
+    /// — structurally prevents the resolver from looping the transport
+    /// (fork 8).</summary>
     public static IReadOnlyList<AIFunction> ForResolver() =>
     [
-        ActClickTool(),
-        ActWaitTool(),
-        ActWaitForSelectorTool(),
-        ActWaitForNetworkIdleTool(),
-        ActScrollToEndTool(),
-        ActEvaluateTool(),
+        PageActionTools.Click.Descriptor,
+        PageActionTools.Wait.Descriptor,
+        PageActionTools.WaitForSelector.Descriptor,
+        PageActionTools.WaitForNetworkIdle.Descriptor,
+        PageActionTools.ScrollToEnd.Descriptor,
+        PageActionTools.EvaluateExpression.Descriptor,
     ];
-
-    // ---- AgentDecision arms (brain-only) --------------------------------
-
-    internal static AIFunction ExtractTool() => new HandRolledAIFunction(
-        name: "Extract",
-        description:
-            "Extract a record from the current page using a flat field-to-CSS-selector " +
-            "schema. Use when the current page contains the records you want to capture. " +
-            "Single-level only; no nested objects in v1.",
-        parametersSchema: new JsonObject
-        {
-            ["type"] = "object",
-            ["properties"] = new JsonObject
-            {
-                ["schema"] = new JsonObject
-                {
-                    ["type"] = "object",
-                    ["description"] = "Map of output field name to CSS selector. Single level — no nested objects.",
-                    ["additionalProperties"] = new JsonObject { ["type"] = "string" },
-                },
-                ["reason"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "Why this is the right next step.",
-                },
-            },
-            ["required"] = new JsonArray { "schema", "reason" },
-        });
-
-    internal static AIFunction FollowTool() => new HandRolledAIFunction(
-        name: "Follow",
-        description:
-            "Load a candidate URL as the next agent step. Pick the URL from the listed " +
-            "candidate URLs on the current page. Do not propose a URL you have already " +
-            "visited (the engine will reject it).",
-        parametersSchema: new JsonObject
-        {
-            ["type"] = "object",
-            ["properties"] = new JsonObject
-            {
-                ["url"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "Absolute URL chosen from the candidate list.",
-                },
-                ["reason"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "Why this URL is the right next step.",
-                },
-            },
-            ["required"] = new JsonArray { "url", "reason" },
-        });
-
-    internal static AIFunction StopTool() => new HandRolledAIFunction(
-        name: "Stop",
-        description:
-            "Terminate the agent run. Use when the goal is satisfied OR the page set has " +
-            "been exhausted without further progress.",
-        parametersSchema: new JsonObject
-        {
-            ["type"] = "object",
-            ["properties"] = new JsonObject
-            {
-                ["reason"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "Why the run is stopping — goal satisfied, dead-end, etc.",
-                },
-            },
-            ["required"] = new JsonArray { "reason" },
-        });
-
-    // ---- PageAction arms (brain + resolver) -----------------------------
-
-    internal static AIFunction ActClickTool() => new HandRolledAIFunction(
-        name: "ActClick",
-        description:
-            "Click the element matching a CSS selector. Use for buttons, links, or any " +
-            "clickable element. Prefer id over class, class over tag; combine if needed.",
-        parametersSchema: new JsonObject
-        {
-            ["type"] = "object",
-            ["properties"] = new JsonObject
-            {
-                ["selector"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "CSS selector for the element to click.",
-                },
-                ["reason"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "Why this click is the right next step. (Brain only — resolver ignores.)",
-                },
-            },
-            ["required"] = new JsonArray { "selector" },
-        });
-
-    internal static AIFunction ActWaitTool() => new HandRolledAIFunction(
-        name: "ActWait",
-        description:
-            "Wait a fixed number of milliseconds — let scripted content settle, throttle " +
-            "post-action work, etc.",
-        parametersSchema: new JsonObject
-        {
-            ["type"] = "object",
-            ["properties"] = new JsonObject
-            {
-                ["ms"] = new JsonObject
-                {
-                    ["type"] = "integer",
-                    ["description"] = "Milliseconds to wait.",
-                },
-                ["reason"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "Why this wait is the right next step. (Brain only — resolver ignores.)",
-                },
-            },
-            ["required"] = new JsonArray { "ms" },
-        });
-
-    internal static AIFunction ActWaitForSelectorTool() => new HandRolledAIFunction(
-        name: "ActWaitForSelector",
-        description:
-            "Wait until an element matching a CSS selector appears on the page, up to a " +
-            "timeout. Use for modals, lazy-loaded content, async-rendered components.",
-        parametersSchema: new JsonObject
-        {
-            ["type"] = "object",
-            ["properties"] = new JsonObject
-            {
-                ["selector"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "CSS selector to wait for.",
-                },
-                ["timeoutMs"] = new JsonObject
-                {
-                    ["type"] = "integer",
-                    ["description"] = "Maximum milliseconds to wait. Defaults to 30000 if omitted.",
-                },
-                ["reason"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "Why this wait is the right next step. (Brain only — resolver ignores.)",
-                },
-            },
-            ["required"] = new JsonArray { "selector" },
-        });
-
-    internal static AIFunction ActWaitForNetworkIdleTool() => new HandRolledAIFunction(
-        name: "ActWaitForNetworkIdle",
-        description:
-            "Wait until the page's network activity goes idle — useful after an action " +
-            "that triggers async fetches before extracting.",
-        parametersSchema: new JsonObject
-        {
-            ["type"] = "object",
-            ["properties"] = new JsonObject
-            {
-                ["reason"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "Why this wait is the right next step. (Brain only — resolver ignores.)",
-                },
-            },
-            ["required"] = new JsonArray(),
-        });
-
-    internal static AIFunction ActScrollToEndTool() => new HandRolledAIFunction(
-        name: "ActScrollToEnd",
-        description:
-            "Scroll to the bottom of the page — trigger infinite-scroll loading, reveal " +
-            "lazy-loaded items below the fold.",
-        parametersSchema: new JsonObject
-        {
-            ["type"] = "object",
-            ["properties"] = new JsonObject
-            {
-                ["reason"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "Why this scroll is the right next step. (Brain only — resolver ignores.)",
-                },
-            },
-            ["required"] = new JsonArray(),
-        });
-
-    internal static AIFunction ActEvaluateTool() => new HandRolledAIFunction(
-        name: "ActEvaluate",
-        description:
-            "Evaluate a JavaScript expression in the page context — last resort for " +
-            "actions no other arm covers.",
-        parametersSchema: new JsonObject
-        {
-            ["type"] = "object",
-            ["properties"] = new JsonObject
-            {
-                ["expression"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "JavaScript expression to evaluate in the page context.",
-                },
-                ["reason"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "Why this evaluation is the right next step. (Brain only — resolver ignores.)",
-                },
-            },
-            ["required"] = new JsonArray { "expression" },
-        });
-
-    /// <summary>Brain-only — the resolver MUST NOT register this tool
-    /// (would let the resolver return a <c>SemanticAct</c> arm and loop
-    /// the transport's resolution path). Fork 8 — the closed sum is closed
-    /// at the resolver's tool list, structurally.</summary>
-    internal static AIFunction ActSemanticActTool() => new HandRolledAIFunction(
-        name: "ActSemanticAct",
-        description:
-            "Hand a natural-language intent to the configured action resolver — the " +
-            "resolver picks the concrete arm. Brain-only; the resolver itself never " +
-            "registers this tool (would loop).",
-        parametersSchema: new JsonObject
-        {
-            ["type"] = "object",
-            ["properties"] = new JsonObject
-            {
-                ["intent"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "Natural-language intent, e.g. 'click sign in' or 'open the modal'.",
-                },
-                ["reason"] = new JsonObject
-                {
-                    ["type"] = "string",
-                    ["description"] = "Why this intent is the right next step.",
-                },
-            },
-            ["required"] = new JsonArray { "intent" },
-        });
 }

--- a/WebReaper.AI/Tools/PageActionTools.cs
+++ b/WebReaper.AI/Tools/PageActionTools.cs
@@ -33,8 +33,17 @@ namespace WebReaper.AI.Tools;
 /// Lives in the satellite, not core, so <see cref="PageAction"/> stays
 /// AI-dependency-free (ADR-0009 quarantine).
 /// </para>
+/// <para>
+/// Visibility: <c>internal</c> in v10.0.2 (symmetric with
+/// <see cref="AgentDecisionTools"/>). Consumer-authored brain or
+/// resolver adapters call into the LLM-tool surface via
+/// <see cref="LlmCall{TResponse}"/> + their own descriptor; if a future
+/// consumer use case for reusing these standard tool descriptors
+/// surfaces, the class can be made public in a minor release without
+/// breaking anyone (visibility widening is non-breaking).
+/// </para>
 /// </summary>
-public static class PageActionTools
+internal static class PageActionTools
 {
     // ---- Click --------------------------------------------------------------
 

--- a/WebReaper.AI/Tools/PageActionTools.cs
+++ b/WebReaper.AI/Tools/PageActionTools.cs
@@ -1,0 +1,317 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.AI;
+using WebReaper.AI.Llm;
+using WebReaper.Domain.PageActions;
+
+namespace WebReaper.AI.Tools;
+
+/// <summary>
+/// The arm-local tool projections for every <see cref="PageAction"/> arm
+/// (ADR-0060 amendment 2026-05-28). One nested static class per arm:
+/// each owns its <see cref="Click.Name"/> (the LLM tool name), its
+/// <see cref="Click.Descriptor"/> (the hand-rolled JSON Schema as an
+/// <see cref="AIFunction"/>), and its <see cref="Click.FromArguments"/>
+/// factory (the per-arm <see cref="JsonElement"/> argument extractor
+/// returning a <see cref="ToolCallResult{T}"/>).
+/// <para>
+/// Before the amendment, the JSON schemas lived in
+/// <see cref="AgentDecisionTools"/>'s ~280-line factory list and the
+/// argument-extraction logic lived in
+/// <see cref="WebReaper.AI.LlmAgentBrain"/>'s 101-line
+/// <c>ParseDecisionTool</c> and <see cref="WebReaper.AI.LlmActionResolver"/>'s
+/// 26-line <c>ParseActionTool</c> — three places to edit when adding an
+/// arm. The amendment co-locates all three concerns per arm so adding an
+/// arm means adding one nested static class here and one line to each
+/// of the brain's and resolver's switch + the
+/// <see cref="AgentDecisionTools.ForBrain"/> / <see cref="AgentDecisionTools.ForResolver"/>
+/// registration lists.
+/// </para>
+/// <para>
+/// AOT-friendly per ADR-0060 fork 4 — the schemas are hand-rolled
+/// <see cref="JsonObject"/> literals, no reflection, no runtime code-gen.
+/// Lives in the satellite, not core, so <see cref="PageAction"/> stays
+/// AI-dependency-free (ADR-0009 quarantine).
+/// </para>
+/// </summary>
+public static class PageActionTools
+{
+    // ---- Click --------------------------------------------------------------
+
+    /// <summary>Tool projection of <see cref="PageAction.Click"/>.</summary>
+    public static class Click
+    {
+        /// <summary>The LLM tool name the model emits for this arm.</summary>
+        public const string Name = "ActClick";
+
+        /// <summary>The hand-rolled JSON Schema for this arm's tool call.</summary>
+        public static AIFunction Descriptor { get; } = new HandRolledAIFunction(
+            name: Name,
+            description:
+                "Click the element matching a CSS selector. Use for buttons, links, or any " +
+                "clickable element. Prefer id over class, class over tag; combine if needed.",
+            parametersSchema: new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["selector"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "CSS selector for the element to click.",
+                    },
+                    ["reason"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Why this click is the right next step. (Brain only — resolver ignores.)",
+                    },
+                },
+                ["required"] = new JsonArray { "selector" },
+            });
+
+        /// <summary>Construct the arm from a tool call's argument JSON, or
+        /// report why construction failed.</summary>
+        public static ToolCallResult<PageAction.Click> FromArguments(JsonElement args)
+        {
+            var selector = LlmToolArguments.TryGetString(args, "selector");
+            return string.IsNullOrWhiteSpace(selector)
+                ? ToolCallResult<PageAction.Click>.Failed("missing 'selector'")
+                : ToolCallResult<PageAction.Click>.Ok(new PageAction.Click(selector));
+        }
+    }
+
+    // ---- Wait ---------------------------------------------------------------
+
+    /// <summary>Tool projection of <see cref="PageAction.Wait"/>.</summary>
+    public static class Wait
+    {
+        public const string Name = "ActWait";
+
+        public static AIFunction Descriptor { get; } = new HandRolledAIFunction(
+            name: Name,
+            description:
+                "Wait a fixed number of milliseconds — let scripted content settle, throttle " +
+                "post-action work, etc.",
+            parametersSchema: new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["ms"] = new JsonObject
+                    {
+                        ["type"] = "integer",
+                        ["description"] = "Milliseconds to wait.",
+                    },
+                    ["reason"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Why this wait is the right next step. (Brain only — resolver ignores.)",
+                    },
+                },
+                ["required"] = new JsonArray { "ms" },
+            });
+
+        /// <summary>Always succeeds — missing or malformed <c>ms</c> defaults
+        /// to <c>0</c>, matching the pre-amendment behaviour where ActWait
+        /// without an integer was treated as a zero-length wait.</summary>
+        public static ToolCallResult<PageAction.Wait> FromArguments(JsonElement args) =>
+            ToolCallResult<PageAction.Wait>.Ok(
+                new PageAction.Wait(LlmToolArguments.TryGetInt(args, "ms") ?? 0));
+    }
+
+    // ---- WaitForSelector ----------------------------------------------------
+
+    /// <summary>Tool projection of <see cref="PageAction.WaitForSelector"/>.</summary>
+    public static class WaitForSelector
+    {
+        public const string Name = "ActWaitForSelector";
+
+        public static AIFunction Descriptor { get; } = new HandRolledAIFunction(
+            name: Name,
+            description:
+                "Wait until an element matching a CSS selector appears on the page, up to a " +
+                "timeout. Use for modals, lazy-loaded content, async-rendered components.",
+            parametersSchema: new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["selector"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "CSS selector to wait for.",
+                    },
+                    ["timeoutMs"] = new JsonObject
+                    {
+                        ["type"] = "integer",
+                        ["description"] = "Maximum milliseconds to wait. Defaults to 30000 if omitted.",
+                    },
+                    ["reason"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Why this wait is the right next step. (Brain only — resolver ignores.)",
+                    },
+                },
+                ["required"] = new JsonArray { "selector" },
+            });
+
+        public static ToolCallResult<PageAction.WaitForSelector> FromArguments(JsonElement args)
+        {
+            var selector = LlmToolArguments.TryGetString(args, "selector");
+            if (string.IsNullOrWhiteSpace(selector))
+                return ToolCallResult<PageAction.WaitForSelector>.Failed("missing 'selector'");
+            var timeout = LlmToolArguments.TryGetInt(args, "timeoutMs") ?? 30_000;
+            return ToolCallResult<PageAction.WaitForSelector>.Ok(
+                new PageAction.WaitForSelector(selector, timeout));
+        }
+    }
+
+    // ---- WaitForNetworkIdle -------------------------------------------------
+
+    /// <summary>Tool projection of <see cref="PageAction.WaitForNetworkIdle"/>.</summary>
+    public static class WaitForNetworkIdle
+    {
+        public const string Name = "ActWaitForNetworkIdle";
+
+        public static AIFunction Descriptor { get; } = new HandRolledAIFunction(
+            name: Name,
+            description:
+                "Wait until the page's network activity goes idle — useful after an action " +
+                "that triggers async fetches before extracting.",
+            parametersSchema: new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["reason"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Why this wait is the right next step. (Brain only — resolver ignores.)",
+                    },
+                },
+                ["required"] = new JsonArray(),
+            });
+
+        /// <summary>Always succeeds — the arm carries no required arguments.</summary>
+        public static ToolCallResult<PageAction.WaitForNetworkIdle> FromArguments(JsonElement args) =>
+            ToolCallResult<PageAction.WaitForNetworkIdle>.Ok(new PageAction.WaitForNetworkIdle());
+    }
+
+    // ---- ScrollToEnd --------------------------------------------------------
+
+    /// <summary>Tool projection of <see cref="PageAction.ScrollToEnd"/>.</summary>
+    public static class ScrollToEnd
+    {
+        public const string Name = "ActScrollToEnd";
+
+        public static AIFunction Descriptor { get; } = new HandRolledAIFunction(
+            name: Name,
+            description:
+                "Scroll to the bottom of the page — trigger infinite-scroll loading, reveal " +
+                "lazy-loaded items below the fold.",
+            parametersSchema: new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["reason"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Why this scroll is the right next step. (Brain only — resolver ignores.)",
+                    },
+                },
+                ["required"] = new JsonArray(),
+            });
+
+        /// <summary>Always succeeds — the arm carries no required arguments.</summary>
+        public static ToolCallResult<PageAction.ScrollToEnd> FromArguments(JsonElement args) =>
+            ToolCallResult<PageAction.ScrollToEnd>.Ok(new PageAction.ScrollToEnd());
+    }
+
+    // ---- EvaluateExpression -------------------------------------------------
+
+    /// <summary>Tool projection of <see cref="PageAction.EvaluateExpression"/>.</summary>
+    public static class EvaluateExpression
+    {
+        public const string Name = "ActEvaluate";
+
+        public static AIFunction Descriptor { get; } = new HandRolledAIFunction(
+            name: Name,
+            description:
+                "Evaluate a JavaScript expression in the page context — last resort for " +
+                "actions no other arm covers.",
+            parametersSchema: new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["expression"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "JavaScript expression to evaluate in the page context.",
+                    },
+                    ["reason"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Why this evaluation is the right next step. (Brain only — resolver ignores.)",
+                    },
+                },
+                ["required"] = new JsonArray { "expression" },
+            });
+
+        public static ToolCallResult<PageAction.EvaluateExpression> FromArguments(JsonElement args)
+        {
+            var expression = LlmToolArguments.TryGetString(args, "expression");
+            return string.IsNullOrWhiteSpace(expression)
+                ? ToolCallResult<PageAction.EvaluateExpression>.Failed("missing 'expression'")
+                : ToolCallResult<PageAction.EvaluateExpression>.Ok(
+                    new PageAction.EvaluateExpression(expression));
+        }
+    }
+
+    // ---- SemanticAct (brain-only — never registered on resolver) ------------
+
+    /// <summary>Tool projection of <see cref="PageAction.SemanticAct"/>.
+    /// Brain-only — never appears in
+    /// <see cref="AgentDecisionTools.ForResolver"/> (would let the resolver
+    /// return a SemanticAct arm and loop the transport's resolution
+    /// path; fork 8 verdict — the closed sum is closed at the resolver's
+    /// tool list, structurally).</summary>
+    public static class SemanticAct
+    {
+        public const string Name = "ActSemanticAct";
+
+        public static AIFunction Descriptor { get; } = new HandRolledAIFunction(
+            name: Name,
+            description:
+                "Hand a natural-language intent to the configured action resolver — the " +
+                "resolver picks the concrete arm. Brain-only; the resolver itself never " +
+                "registers this tool (would loop).",
+            parametersSchema: new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["intent"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Natural-language intent, e.g. 'click sign in' or 'open the modal'.",
+                    },
+                    ["reason"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Why this intent is the right next step.",
+                    },
+                },
+                ["required"] = new JsonArray { "intent" },
+            });
+
+        public static ToolCallResult<PageAction.SemanticAct> FromArguments(JsonElement args)
+        {
+            var intent = LlmToolArguments.TryGetString(args, "intent");
+            return string.IsNullOrWhiteSpace(intent)
+                ? ToolCallResult<PageAction.SemanticAct>.Failed("missing 'intent'")
+                : ToolCallResult<PageAction.SemanticAct>.Ok(new PageAction.SemanticAct(intent));
+        }
+    }
+}

--- a/WebReaper.AI/Tools/ToolCallResult.cs
+++ b/WebReaper.AI/Tools/ToolCallResult.cs
@@ -1,0 +1,43 @@
+namespace WebReaper.AI.Tools;
+
+/// <summary>
+/// The result of parsing a tool-call's <c>FunctionCallContent.Arguments</c>
+/// into a typed closed-sum arm — either the successfully-constructed arm
+/// (<see cref="Value"/> non-null, <see cref="FailureReason"/> null) or a
+/// human-readable description of why construction failed
+/// (<see cref="Value"/> null, <see cref="FailureReason"/> the reason).
+/// <para>
+/// The two-shape return exists because the brain and the resolver wrap the
+/// same failure differently: the brain converts a failure into
+/// <see cref="WebReaper.Domain.Agent.AgentDecision.Stop"/> with the reason
+/// baked into the audit-trail <c>Reason</c> string ("brain ActClick missing
+/// 'selector': &lt;brain reason&gt;"); the resolver returns <c>null</c> so
+/// the transport can surface a typed
+/// <see cref="WebReaper.Core.Actions.Concrete.SemanticActResolutionException"/>.
+/// Carrying both pieces lets each consumer apply its own policy.
+/// </para>
+/// <para>
+/// <see cref="FailureReason"/> is a freeform string — typically "missing
+/// '&lt;field&gt;'" for an absent required argument, or a structural
+/// description ("schema was empty") for a parsed-but-invalid arm. The brain
+/// composes the string into its Stop reason verbatim, so per-arm
+/// <c>FromArguments</c> factories own their wording.
+/// </para>
+/// <para>
+/// Sibling to <see cref="Llm.LlmCallResult{T}"/> on the same "named result
+/// shape, not a tuple" axis. Public so consumer-authored tool-calling
+/// adapters reuse the type instead of inventing their own.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The arm type the FromArguments factory constructs.</typeparam>
+/// <param name="Value">The constructed arm on success; <c>null</c> on failure.</param>
+/// <param name="FailureReason">A human-readable description of why
+/// construction failed; <c>null</c> on success.</param>
+public readonly record struct ToolCallResult<T>(T? Value, string? FailureReason) where T : class
+{
+    /// <summary>Construct a success result carrying the arm.</summary>
+    public static ToolCallResult<T> Ok(T value) => new(value, null);
+
+    /// <summary>Construct a failure result with a human-readable reason.</summary>
+    public static ToolCallResult<T> Failed(string reason) => new(null, reason);
+}

--- a/WebReaper.Tests/WebReaper.AI.Tests/PageActionToolsTests.cs
+++ b/WebReaper.Tests/WebReaper.AI.Tests/PageActionToolsTests.cs
@@ -1,0 +1,197 @@
+using System.Text.Json;
+using WebReaper.AI.Tools;
+using WebReaper.Domain.PageActions;
+
+namespace WebReaper.AI.Tests;
+
+// ADR-0060 amendment (2026-05-28): per-arm tool projection in
+// PageActionTools. These tests pin each arm's FromArguments contract
+// directly — the brain (LlmAgentBrain) and resolver (LlmActionResolver)
+// both go through these factories, but the existing integration tests
+// for those adapters exercise the OUTER tool-call path. These tests
+// pin the INNER contract: what each arm accepts, what it rejects, and
+// what shape it emits on failure (the FailureReason string the brain
+// composes into its audit-trail Stop reason).
+public class PageActionToolsTests
+{
+    private static JsonElement Parse(string json) =>
+        JsonDocument.Parse(json).RootElement;
+
+    // ---- Name constants -----------------------------------------------------
+
+    [Fact]
+    public void Tool_names_match_the_pre_amendment_constants()
+    {
+        // The brain's and resolver's switch labels referenced literal
+        // strings before the amendment ("ActClick", "ActWait", ...).
+        // Now they reference the Name constants. Pin the constant
+        // values so a rename here doesn't silently break tool-call
+        // matching against models that learned the old names.
+        Assert.Equal("ActClick", PageActionTools.Click.Name);
+        Assert.Equal("ActWait", PageActionTools.Wait.Name);
+        Assert.Equal("ActWaitForSelector", PageActionTools.WaitForSelector.Name);
+        Assert.Equal("ActWaitForNetworkIdle", PageActionTools.WaitForNetworkIdle.Name);
+        Assert.Equal("ActScrollToEnd", PageActionTools.ScrollToEnd.Name);
+        Assert.Equal("ActEvaluate", PageActionTools.EvaluateExpression.Name);
+        Assert.Equal("ActSemanticAct", PageActionTools.SemanticAct.Name);
+    }
+
+    [Fact]
+    public void Descriptor_name_matches_the_arm_name_constant()
+    {
+        // The HandRolledAIFunction name should match the Name constant
+        // verbatim — the LLM sees the tool by name, the parser
+        // dispatches by name, the two must agree.
+        Assert.Equal(PageActionTools.Click.Name, PageActionTools.Click.Descriptor.Name);
+        Assert.Equal(PageActionTools.Wait.Name, PageActionTools.Wait.Descriptor.Name);
+        Assert.Equal(PageActionTools.WaitForSelector.Name, PageActionTools.WaitForSelector.Descriptor.Name);
+        Assert.Equal(PageActionTools.WaitForNetworkIdle.Name, PageActionTools.WaitForNetworkIdle.Descriptor.Name);
+        Assert.Equal(PageActionTools.ScrollToEnd.Name, PageActionTools.ScrollToEnd.Descriptor.Name);
+        Assert.Equal(PageActionTools.EvaluateExpression.Name, PageActionTools.EvaluateExpression.Descriptor.Name);
+        Assert.Equal(PageActionTools.SemanticAct.Name, PageActionTools.SemanticAct.Descriptor.Name);
+    }
+
+    // ---- Click --------------------------------------------------------------
+
+    [Fact]
+    public void Click_FromArguments_constructs_the_arm_on_valid_input()
+    {
+        var result = PageActionTools.Click.FromArguments(
+            Parse("""{ "selector": ".btn" }"""));
+        var click = Assert.IsType<PageAction.Click>(result.Value);
+        Assert.Equal(".btn", click.Selector);
+        Assert.Null(result.FailureReason);
+    }
+
+    [Fact]
+    public void Click_FromArguments_fails_on_missing_selector()
+    {
+        var result = PageActionTools.Click.FromArguments(Parse("""{}"""));
+        Assert.Null(result.Value);
+        Assert.Equal("missing 'selector'", result.FailureReason);
+    }
+
+    [Fact]
+    public void Click_FromArguments_fails_on_whitespace_selector()
+    {
+        // The brain's pre-amendment contract treated whitespace as
+        // missing (string.IsNullOrWhiteSpace) — pin that here.
+        var result = PageActionTools.Click.FromArguments(
+            Parse("""{ "selector": "   " }"""));
+        Assert.Null(result.Value);
+        Assert.Equal("missing 'selector'", result.FailureReason);
+    }
+
+    // ---- Wait ---------------------------------------------------------------
+
+    [Fact]
+    public void Wait_FromArguments_uses_the_ms_value()
+    {
+        var result = PageActionTools.Wait.FromArguments(
+            Parse("""{ "ms": 250 }"""));
+        var wait = Assert.IsType<PageAction.Wait>(result.Value);
+        Assert.Equal(250, wait.Milliseconds);
+    }
+
+    [Fact]
+    public void Wait_FromArguments_defaults_to_zero_when_ms_absent()
+    {
+        // Pre-amendment behaviour: ActWait without an integer was
+        // treated as a zero-length wait (TryGetInt(args, "ms") ?? 0).
+        // Preserve the lenient default so a model that omits the
+        // argument doesn't silently fail the dispatch.
+        var result = PageActionTools.Wait.FromArguments(Parse("""{}"""));
+        var wait = Assert.IsType<PageAction.Wait>(result.Value);
+        Assert.Equal(0, wait.Milliseconds);
+    }
+
+    // ---- WaitForSelector ----------------------------------------------------
+
+    [Fact]
+    public void WaitForSelector_FromArguments_with_explicit_timeout()
+    {
+        var result = PageActionTools.WaitForSelector.FromArguments(
+            Parse("""{ "selector": ".modal", "timeoutMs": 5000 }"""));
+        var wfs = Assert.IsType<PageAction.WaitForSelector>(result.Value);
+        Assert.Equal(".modal", wfs.Selector);
+        Assert.Equal(5000, wfs.TimeoutMs);
+    }
+
+    [Fact]
+    public void WaitForSelector_FromArguments_defaults_timeout_when_omitted()
+    {
+        // Pre-amendment default: TryGetInt(args, "timeoutMs") ?? 30_000.
+        var result = PageActionTools.WaitForSelector.FromArguments(
+            Parse("""{ "selector": ".modal" }"""));
+        var wfs = Assert.IsType<PageAction.WaitForSelector>(result.Value);
+        Assert.Equal(30_000, wfs.TimeoutMs);
+    }
+
+    [Fact]
+    public void WaitForSelector_FromArguments_fails_on_missing_selector()
+    {
+        var result = PageActionTools.WaitForSelector.FromArguments(
+            Parse("""{ "timeoutMs": 5000 }"""));
+        Assert.Null(result.Value);
+        Assert.Equal("missing 'selector'", result.FailureReason);
+    }
+
+    // ---- Argument-less arms (WaitForNetworkIdle, ScrollToEnd) ---------------
+
+    [Fact]
+    public void WaitForNetworkIdle_FromArguments_always_succeeds()
+    {
+        // The arm carries no required arguments; FromArguments should
+        // succeed regardless of input shape (even if args is empty or
+        // contains stray keys the LLM emitted).
+        Assert.IsType<PageAction.WaitForNetworkIdle>(
+            PageActionTools.WaitForNetworkIdle.FromArguments(Parse("""{}""")).Value);
+        Assert.IsType<PageAction.WaitForNetworkIdle>(
+            PageActionTools.WaitForNetworkIdle.FromArguments(Parse("""{ "stray": 1 }""")).Value);
+    }
+
+    [Fact]
+    public void ScrollToEnd_FromArguments_always_succeeds()
+    {
+        Assert.IsType<PageAction.ScrollToEnd>(
+            PageActionTools.ScrollToEnd.FromArguments(Parse("""{}""")).Value);
+    }
+
+    // ---- EvaluateExpression -------------------------------------------------
+
+    [Fact]
+    public void EvaluateExpression_FromArguments_on_valid_input()
+    {
+        var result = PageActionTools.EvaluateExpression.FromArguments(
+            Parse("""{ "expression": "document.title" }"""));
+        var eval = Assert.IsType<PageAction.EvaluateExpression>(result.Value);
+        Assert.Equal("document.title", eval.Expression);
+    }
+
+    [Fact]
+    public void EvaluateExpression_FromArguments_fails_on_missing_expression()
+    {
+        var result = PageActionTools.EvaluateExpression.FromArguments(Parse("""{}"""));
+        Assert.Null(result.Value);
+        Assert.Equal("missing 'expression'", result.FailureReason);
+    }
+
+    // ---- SemanticAct --------------------------------------------------------
+
+    [Fact]
+    public void SemanticAct_FromArguments_on_valid_input()
+    {
+        var result = PageActionTools.SemanticAct.FromArguments(
+            Parse("""{ "intent": "click sign in" }"""));
+        var act = Assert.IsType<PageAction.SemanticAct>(result.Value);
+        Assert.Equal("click sign in", act.Intent);
+    }
+
+    [Fact]
+    public void SemanticAct_FromArguments_fails_on_missing_intent()
+    {
+        var result = PageActionTools.SemanticAct.FromArguments(Parse("""{}"""));
+        Assert.Null(result.Value);
+        Assert.Equal("missing 'intent'", result.FailureReason);
+    }
+}

--- a/docs/adr/0060-tool-calling-brain-and-action-resolver.md
+++ b/docs/adr/0060-tool-calling-brain-and-action-resolver.md
@@ -468,6 +468,98 @@ mechanism):**
 - `WebReaper.AotSmokeTest` — unchanged (mechanism + tools live in the
   non-AOT satellite).
 
+## Amendment (2026-05-28): arm-local tool projection
+
+The original v1 shape parked every arm's JSON Schema in
+`AgentDecisionTools.cs` (10 hand-rolled `AIFunction` factories, ~280
+lines of schema literals) and the per-arm argument parsing in two
+separate switches: `LlmAgentBrain.ParseDecisionTool` (101 lines, all
+10 arms) and `LlmActionResolver.ParseActionTool` (26 lines, 6 arms).
+The closed sum (`AgentDecision`, `PageAction`) was the source of
+truth; its tool projection was the three-file shadow.
+
+Adding a new `PageAction` arm in that shape meant editing three
+satellite files in addition to the closed sum, with no compiler help
+linking them. Each arm's JSON Schema, its argument extractor, and
+its arm-construction logic lived in three different places.
+
+### Decision
+
+Each arm's tool concerns collapse into one nested static class in the
+satellite, owning three things:
+
+- A `const string Name` — the LLM tool name the model emits.
+- A `static AIFunction Descriptor` — the hand-rolled JSON Schema
+  (unchanged from v1; fork 4 holds).
+- A `static ToolCallResult<TArm> FromArguments(JsonElement[, string reason])`
+  — the per-arm argument extractor and arm constructor.
+
+`PageActionTools.cs` holds the seven `PageAction` arms;
+`AgentDecisionTools.cs` holds the three `AgentDecision`-specific arms
+(Extract, Follow, Stop) plus the two registration lists
+(`ForBrain`, `ForResolver`) that reference per-arm `Descriptor`
+properties verbatim. The brain's `ParseDecisionTool` and the
+resolver's `ParseActionTool` become uniform switches: one case per
+arm dispatching by `<Arm>.Name` to `<Arm>.FromArguments(args)`,
+wrapping the `ToolCallResult` differently (the brain composes a Stop
+reason from `FailureReason`; the resolver returns `null`).
+
+The new `ToolCallResult<T>` record struct (in `WebReaper.AI/Tools/`)
+carries `(T? Value, string? FailureReason)` — the two-shape return
+that lets brain and resolver apply their distinct failure policies
+without each one knowing what fields the other arm expects.
+
+### Why not cross-assembly partial records
+
+The natural-feeling shape — `partial record` on the closed-sum arm in
+core extended by a partial fragment in the satellite — does not
+compile. C# partial declarations must live in the same assembly;
+declaring `public abstract partial record PageAction` in core and
+again in the satellite raises CS0436 and treats the two declarations
+as distinct conflicting types. Nested static classes in the
+satellite achieve the same locality at the call site
+(`PageActionTools.Click.Name` reads similarly to
+`PageAction.Click.ToolName`) without violating the rule.
+
+### What stays from fork 4
+
+Hand-rolled `JsonObject` schema literals, no reflection, no runtime
+code-gen. The amendment moves them, it does not change how they are
+written.
+
+### Cost
+
+Net line count rose modestly (+150 across the satellite) because the
+per-arm parsing logic moved INTO arm-local classes. Each individual
+adapter shrank:
+
+- `LlmAgentBrain.cs`: 347 → 252 (-95). `ParseDecisionTool` shrank
+  from a 101-line nested switch to a 25-line uniform switch plus
+  two helper methods (`Unwrap`, `UnwrapAct`).
+- `LlmActionResolver.cs`: 180 → 146 (-34). `ParseActionTool` shrank
+  from 26 lines of arm-specific cases to a 9-line uniform switch.
+- `AgentDecisionTools.cs`: 301 → 223 (PageAction schemas moved out;
+  Extract/Follow/Stop projections moved in; the registration lists
+  are now 12-line declarative lists referencing per-arm
+  `Descriptor` properties).
+
+The win is locality, not line count: adding a new `PageAction` arm
+is now one new nested static class in `PageActionTools.cs` plus a
+one-line addition to each of `AgentDecisionTools.ForBrain`,
+`AgentDecisionTools.ForResolver`, the brain's switch, and the
+resolver's switch. Each of those four updates is a single line
+referencing the same `<Arm>.Name` constant.
+
+### Validation
+
+- All 253 AI tests pass (the `AgentDecisionToolsTests`
+  end-to-end pinning of every tool's schema continues to apply
+  unchanged — the projection is byte-identical, just relocated).
+- All 409 unit tests pass.
+- No changes to core (`WebReaper`) — the ADR-0009 satellite
+  quarantine is preserved.
+- AOT discipline preserved — no reflection added, no runtime code-gen.
+
 ## References
 
 - ADR-0001 — closed-sum pattern; the discipline this ADR pushes to

--- a/docs/adr/0060-tool-calling-brain-and-action-resolver.md
+++ b/docs/adr/0060-tool-calling-brain-and-action-resolver.md
@@ -550,11 +550,52 @@ one-line addition to each of `AgentDecisionTools.ForBrain`,
 resolver's switch. Each of those four updates is a single line
 referencing the same `<Arm>.Name` constant.
 
+### Visibility
+
+Both `PageActionTools` and `AgentDecisionTools` are `internal` —
+symmetric. Consumer-authored brain or resolver adapters build their
+own tool descriptors via the public `LlmCall<TResponse>` +
+`HandRolledAIFunction` surface; the standard tool descriptors here
+are an implementation detail of the satellite's `LlmAgentBrain` and
+`LlmActionResolver`. If a future consumer use case for reusing these
+standard tool descriptors surfaces (e.g. a deterministic brain that
+wants the exact schema the LLM brain registers), the classes can be
+widened to `public` in a minor release without breaking anyone
+(visibility widening is non-breaking). Starting internal is the
+conservative posture.
+
+### Per-arm contracts pinned by `PageActionToolsTests`
+
+The amendment adds a focused test file (`PageActionToolsTests`, 16
+tests) that pins each arm's `FromArguments` contract directly. The
+existing `LlmActionResolverTests` and `LlmAgentBrainTests` exercise
+the OUTER tool-call dispatch end-to-end; the new tests pin the INNER
+contract (what each arm accepts, what it rejects, the exact
+`FailureReason` string the brain composes into its Stop reason).
+This closes the test-coverage gap a future contributor refactoring
+a single arm's `FromArguments` would otherwise fall through.
+
+### Intentional `BuildFlatSchema` divergence (carried over)
+
+The `BuildFlatSchema` helper in `AgentDecisionTools.Extract` (13
+lines, strict — string-valued properties only) is intentionally not
+shared with `LlmSchemaInferrer.BuildFlatSchema` (43 lines, lenient —
+handles both the flat `"field": "selector"` shape AND the structured
+`"field": { "selector": "..." }` shape some verbose models emit; and
+throws when no usable pairs remain). The two adapters solve
+different problems: the brain trusts its own tool prompt's schema
+shape (one-shot per Extract decision, the tool prompt fixes the
+flat shape), while the inferrer parses LLM-emitted schemas that may
+arrive in either of two acceptable shapes (single inference pays
+for the whole crawl, so lenient parsing earns its keep). The
+duplication is by design; consolidating would lose information.
+
 ### Validation
 
-- All 253 AI tests pass (the `AgentDecisionToolsTests`
-  end-to-end pinning of every tool's schema continues to apply
-  unchanged — the projection is byte-identical, just relocated).
+- All 269 AI tests pass (was 253 + 16 from the new
+  `PageActionToolsTests`; the `AgentDecisionToolsTests` end-to-end
+  pinning of every tool's schema continues to apply unchanged — the
+  projection is byte-identical, just relocated).
 - All 409 unit tests pass.
 - No changes to core (`WebReaper`) — the ADR-0009 satellite
   quarantine is preserved.


### PR DESCRIPTION
**Stacked on top of [#133](https://github.com/pavlovtech/WebReaper/pull/133).** Base will auto-retarget to `master` once #133 merges. Review after #133.

## Summary

Each `AgentDecision` and `PageAction` arm's LLM tool projection (Name + JSON Schema + argument extractor) now lives in one nested static class instead of being hand-rolled across three satellite files. The brain's and resolver's parsers become structurally arm-agnostic uniform switches.

## ADR-0060 amendment

Records the arm-local pattern, the cross-assembly `partial record` fork that was considered and rejected (CS0436), and the locality-vs-line-count framing.

## Shape change

**Before:**
- `AgentDecisionTools.cs` — 10 hand-written JSON Schema factories (~280 lines)
- `LlmAgentBrain.ParseDecisionTool` — 101-line nested switch with per-arm argument extraction inline
- `LlmActionResolver.ParseActionTool` — 26-line switch, separate per-arm logic for the 6-arm subset
- Adding an arm = 3 satellite files touched with no compiler link

**After:**
```csharp
public static class PageActionTools
{
    public static class Click
    {
        public const string Name = "ActClick";
        public static AIFunction Descriptor { get; } = ...;
        public static ToolCallResult<PageAction.Click> FromArguments(JsonElement args);
    }
    // ... 6 more arms
}
```

Parsers shrink to uniform switches:
```csharp
PageActionTools.Click.Name => UnwrapAct(PageActionTools.Click.FromArguments(args), toolName, reason),
```

New public `ToolCallResult<T>` helper: `(T? Value, string? FailureReason)` — two-shape return so brain composes a Stop reason from `FailureReason` and resolver returns `null`, without coupling.

## Why nested static classes, not `partial record`

The natural shape (`partial record` arm fragments in the satellite extending arms declared in core) does not compile: C# partial declarations must live in the same assembly. CS0436 treats cross-assembly fragments as conflicting type declarations. Nested static classes achieve the same call-site locality (`PageActionTools.Click.Name`) without violating the rule. Core stays AI-dependency-free (ADR-0009 quarantine preserved).

## Numbers

| File | Before | After | Δ |
|---|---|---|---|
| LlmAgentBrain.cs | 347 | 252 | **-95** |
| LlmActionResolver.cs | 180 | 146 | **-34** |
| AgentDecisionTools.cs | 301 | 223 | **-78** |
| PageActionTools.cs | 0 | 317 | **+317** (NEW) |
| ToolCallResult.cs | 0 | 43 | **+43** (NEW) |

Net line count rose modestly because per-arm parsing logic moved INTO arm-local classes. The win is **locality**: adding a new `PageAction` arm is now one new nested static class plus four one-line additions referencing the same `<Arm>.Name` constant.

## AOT discipline

Fork 4 holds. Hand-rolled `JsonObject` schema literals, no reflection, no runtime code-gen. The amendment moves them, it does not change how they are written.

## Tests

```
AI:    253 passed (unchanged)
Unit:  409 passed (unchanged)
```

`AgentDecisionToolsTests` end-to-end schema pinning continues unchanged — the projection is byte-identical, just relocated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)