### PR TITLE
refactor(core): extract ContentExtractorPipeline shared module (ADR-0072)

### DIFF
--- a/WebReaper.Tests/WebReaper.UnitTests/ContentExtractorPipelineTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/ContentExtractorPipelineTests.cs
@@ -1,0 +1,252 @@
+using System.Text.Json.Nodes;
+using AngleSharp.Dom;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using WebReaper.Builders;
+using WebReaper.Core.Parser.Abstract;
+using WebReaper.Core.Parser.Concrete;
+using WebReaper.Domain.Parsing;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0072: ContentExtractorPipeline is the shared extractor + validator
+// + wrapping-logic module both ScraperEngineBuilder and AgentEngineBuilder
+// embed. These tests pin the inner contract:
+//
+//   - GetExtractorOrDefault returns a SchemaFold when no extractor is
+//     registered; memoises after first call (??=); WithContentExtractor
+//     replaces the cached value.
+//   - WithFallbackExtractor wraps the current extractor with
+//     ExtractionRouter; WithSelfHealing wraps with
+//     SelfHealingContentExtractor; both read the current validator at
+//     the call site.
+//   - The Func<ILogger> getter is invoked at wrapper-construction time,
+//     NOT at pipeline-construction time. This is the regression the
+//     design specifically guards against — capturing logger by value
+//     would silently break WithLogger-after-WithFallbackExtractor.
+public class ContentExtractorPipelineTests
+{
+    // ---- GetExtractorOrDefault ---------------------------------------------
+
+    [Fact]
+    public void GetExtractorOrDefault_returns_a_SchemaFold_when_unset()
+    {
+        var pipeline = new ContentExtractorPipeline(() => NullLogger.Instance);
+
+        var result = pipeline.GetExtractorOrDefault();
+
+        Assert.IsType<SchemaFold<IParentNode>>(result);
+    }
+
+    [Fact]
+    public void GetExtractorOrDefault_memoises_after_first_call()
+    {
+        // Pre-ADR-0072, SpiderBuilder.Build used `??=` to commit the
+        // default on first use. The pipeline preserves that behaviour
+        // so BuildAsync reading the pipeline multiple times (e.g. once
+        // for LearnedSchemaContentExtractor's inner extractor and again
+        // for the spider sync) gets the SAME default instance, not a
+        // fresh allocation each time.
+        var pipeline = new ContentExtractorPipeline(() => NullLogger.Instance);
+
+        var first = pipeline.GetExtractorOrDefault();
+        var second = pipeline.GetExtractorOrDefault();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetExtractorOrDefault_commits_the_default_to_the_pipeline_state()
+    {
+        // Calling GetExtractorOrDefault on a fresh pipeline is observable
+        // as a state mutation: Extractor was null before, non-null after.
+        // Document this so a future "make it idempotent" refactor revisits
+        // the BuildAsync memoisation invariant first.
+        var pipeline = new ContentExtractorPipeline(() => NullLogger.Instance);
+        Assert.Null(pipeline.Extractor);
+
+        var resolved = pipeline.GetExtractorOrDefault();
+
+        Assert.Same(resolved, pipeline.Extractor);
+    }
+
+    [Fact]
+    public void GetExtractorOrDefault_returns_the_registered_extractor_when_set()
+    {
+        var custom = new StubContentExtractor();
+        var pipeline = new ContentExtractorPipeline(() => NullLogger.Instance);
+        pipeline.WithContentExtractor(custom);
+
+        Assert.Same(custom, pipeline.GetExtractorOrDefault());
+    }
+
+    [Fact]
+    public void WithContentExtractor_replaces_an_already_registered_extractor()
+    {
+        var first = new StubContentExtractor();
+        var second = new StubContentExtractor();
+        var pipeline = new ContentExtractorPipeline(() => NullLogger.Instance);
+
+        pipeline.WithContentExtractor(first);
+        pipeline.WithContentExtractor(second);
+
+        Assert.Same(second, pipeline.Extractor);
+    }
+
+    // ---- WithFallbackExtractor + validator threading -----------------------
+
+    [Fact]
+    public void WithFallbackExtractor_wraps_the_current_extractor_in_ExtractionRouter()
+    {
+        var primary = new StubContentExtractor();
+        var fallback = new StubContentExtractor();
+        var pipeline = new ContentExtractorPipeline(() => NullLogger.Instance);
+        pipeline.WithContentExtractor(primary);
+
+        pipeline.WithFallbackExtractor(fallback);
+
+        Assert.IsType<ExtractionRouter>(pipeline.Extractor);
+    }
+
+    [Fact]
+    public void WithFallbackExtractor_with_no_prior_extractor_wraps_the_default_SchemaFold()
+    {
+        // "Currently registered or default": when no extractor is set,
+        // WithFallbackExtractor still works by composing against a
+        // default SchemaFold. Asserting the result is an ExtractionRouter
+        // is enough — its internals are unit-tested in ExtractionRouter's
+        // own test file (this test just pins the composition shape).
+        var fallback = new StubContentExtractor();
+        var pipeline = new ContentExtractorPipeline(() => NullLogger.Instance);
+
+        pipeline.WithFallbackExtractor(fallback);
+
+        Assert.IsType<ExtractionRouter>(pipeline.Extractor);
+    }
+
+    [Fact]
+    public void WithSelfHealing_wraps_the_current_extractor_in_SelfHealingContentExtractor()
+    {
+        var primary = new StubContentExtractor();
+        var repairer = new StubSelectorRepairer();
+        var pipeline = new ContentExtractorPipeline(() => NullLogger.Instance);
+        pipeline.WithContentExtractor(primary);
+
+        pipeline.WithSelfHealing(repairer);
+
+        Assert.IsType<SelfHealingContentExtractor>(pipeline.Extractor);
+    }
+
+    [Fact]
+    public void WithSchemaValidator_state_is_visible_via_the_Validator_property()
+    {
+        var validator = new StubSchemaValidator();
+        var pipeline = new ContentExtractorPipeline(() => NullLogger.Instance);
+
+        pipeline.WithSchemaValidator(validator);
+
+        Assert.Same(validator, pipeline.Validator);
+    }
+
+    // ---- Func<ILogger> capture semantics (the regression guard) -------------
+
+    [Fact]
+    public void Logger_getter_is_invoked_at_each_wrapper_construction_not_at_pipeline_construction()
+    {
+        // The reason ContentExtractorPipeline takes Func<ILogger> instead
+        // of a captured ILogger value: the outer builder's Logger field
+        // is mutable via WithLogger. Capturing by value at construction
+        // would silently break the case where WithLogger is called AFTER
+        // pipeline construction but BEFORE WithFallbackExtractor.
+        //
+        // Pin the contract by:
+        //   1. Verifying the getter is NOT called at construction time.
+        //   2. Mutating the logger after construction, then calling
+        //      WithFallbackExtractor, and verifying the getter saw the
+        //      NEW logger (not the construction-time one).
+        int getterCallCount = 0;
+        ILogger latestLogger = NullLogger.Instance;
+        ILogger? lastReturned = null;
+
+        var pipeline = new ContentExtractorPipeline(() =>
+        {
+            getterCallCount++;
+            lastReturned = latestLogger;
+            return latestLogger;
+        });
+
+        // Construction must NOT call the getter eagerly.
+        Assert.Equal(0, getterCallCount);
+        Assert.Null(lastReturned);
+
+        // Mutate the underlying logger to a sentinel value.
+        var sentinel = NullLogger.Instance; // we'll compare by reference
+        var fakeLogger = (ILogger)new FakeLogger();
+        latestLogger = fakeLogger;
+
+        // WithFallbackExtractor must call the getter at composition time
+        // — at least once, picking up the post-mutation logger.
+        pipeline.WithFallbackExtractor(new StubContentExtractor());
+
+        Assert.True(getterCallCount > 0,
+            "WithFallbackExtractor must call the logger getter, not capture at construction.");
+        Assert.Same(fakeLogger, lastReturned);
+        Assert.NotSame(sentinel, lastReturned);
+    }
+
+    // ---- Constructor argument validation ------------------------------------
+
+    [Fact]
+    public void Constructor_rejects_null_logger_provider()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new ContentExtractorPipeline(null!));
+    }
+
+    [Fact]
+    public void With_methods_reject_null_arguments()
+    {
+        var pipeline = new ContentExtractorPipeline(() => NullLogger.Instance);
+        Assert.Throws<ArgumentNullException>(() => pipeline.WithContentExtractor(null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.WithFallbackExtractor(null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.WithSelfHealing(null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.WithSchemaValidator(null!));
+    }
+
+    // ---- Stubs --------------------------------------------------------------
+
+    private sealed class StubContentExtractor : IContentExtractor
+    {
+        public Task<JsonObject> ExtractAsync(string document, Schema? schema) =>
+            Task.FromResult(new JsonObject());
+    }
+
+    private sealed class StubSelectorRepairer : ISelectorRepairer
+    {
+        public Task<Schema?> RepairAsync(
+            Schema original,
+            string document,
+            JsonObject failedResult,
+            string? failureReason = null,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<Schema?>(null);
+    }
+
+    private sealed class StubSchemaValidator : ISchemaValidator
+    {
+        public ValidationResult Validate(JsonObject? extracted, Schema? schema) =>
+            ValidationResult.Valid;
+    }
+
+    // A non-NullLogger ILogger used as a distinguishable sentinel for
+    // the regression-guard test — Assert.Same compares by reference.
+    private sealed class FakeLogger : ILogger
+    {
+        IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+        public bool IsEnabled(LogLevel logLevel) => false;
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+        { }
+    }
+}

--- a/WebReaper/Builders/AgentEngineBuilder.cs
+++ b/WebReaper/Builders/AgentEngineBuilder.cs
@@ -50,8 +50,11 @@ public sealed class AgentEngineBuilder
     private IAgentBrain _brain = NullAgentBrain.Instance;
     private IAgentRunStore _runStore = new InMemoryAgentRunStore();
     private IPageLoader? _pageLoader;
-    private IContentExtractor? _contentExtractor;
-    private ISchemaValidator? _schemaValidator;
+    // ADR-0072: the shared extractor + validator + wrapping-logic
+    // module both this builder and ScraperEngineBuilder embed. Lazily
+    // assigned in the constructor so the logger lambda captures the
+    // current _logger value at each pipeline call.
+    private readonly ContentExtractorPipeline _pipeline;
     private IActionResolver _actionResolver = NullActionResolver.Instance;
     private IVisitedLinkTracker _visitedTracker = new InMemoryVisitedLinkTracker();
     private readonly List<IScraperSink> _sinks = new();
@@ -92,6 +95,7 @@ public sealed class AgentEngineBuilder
         ArgumentException.ThrowIfNullOrEmpty(goal);
         _startUrl = startUrl;
         _goal = goal;
+        _pipeline = new ContentExtractorPipeline(() => _logger);
     }
 
     /// <summary>
@@ -172,8 +176,7 @@ public sealed class AgentEngineBuilder
     /// <see cref="SchemaFold{TNode}"/>.</summary>
     public AgentEngineBuilder WithContentExtractor(IContentExtractor extractor)
     {
-        ArgumentNullException.ThrowIfNull(extractor);
-        _contentExtractor = extractor;
+        _pipeline.WithContentExtractor(extractor);
         return this;
     }
 
@@ -191,9 +194,7 @@ public sealed class AgentEngineBuilder
     /// <paramref name="fallback"/> is null.</exception>
     public AgentEngineBuilder WithFallbackExtractor(IContentExtractor fallback)
     {
-        ArgumentNullException.ThrowIfNull(fallback);
-        var primary = _contentExtractor ?? new SchemaFold<IParentNode>(new AngleSharpSchemaBackend(), _logger);
-        _contentExtractor = new ExtractionRouter(primary, fallback, _schemaValidator, _logger);
+        _pipeline.WithFallbackExtractor(fallback);
         return this;
     }
 
@@ -208,9 +209,7 @@ public sealed class AgentEngineBuilder
     /// <paramref name="repairer"/> is null.</exception>
     public AgentEngineBuilder WithSelfHealing(ISelectorRepairer repairer)
     {
-        ArgumentNullException.ThrowIfNull(repairer);
-        var primary = _contentExtractor ?? new SchemaFold<IParentNode>(new AngleSharpSchemaBackend(), _logger);
-        _contentExtractor = new SelfHealingContentExtractor(primary, repairer, _schemaValidator, _logger);
+        _pipeline.WithSelfHealing(repairer);
         return this;
     }
 
@@ -233,8 +232,7 @@ public sealed class AgentEngineBuilder
     /// <paramref name="validator"/> is null.</exception>
     public AgentEngineBuilder WithSchemaValidator(ISchemaValidator validator)
     {
-        ArgumentNullException.ThrowIfNull(validator);
-        _schemaValidator = validator;
+        _pipeline.WithSchemaValidator(validator);
         return this;
     }
 
@@ -374,8 +372,11 @@ public sealed class AgentEngineBuilder
                 ".WithLlmBrain(chatClient) extension — before BuildAsync().");
 
         var loader = _pageLoader ?? BuildDefaultPageLoader();
-        var contentExtractor = _contentExtractor ?? new SchemaFold<IParentNode>(new AngleSharpSchemaBackend(), _logger);
-        var validator = _schemaValidator ?? SchemaSatisfiedValidator.Instance;
+        // ADR-0072: resolve both the extractor and validator from the
+        // shared pipeline. _contentExtractor / _schemaValidator fields
+        // are gone; the pipeline holds the post-With*-method state.
+        var contentExtractor = _pipeline.GetExtractorOrDefault();
+        var validator = _pipeline.Validator ?? SchemaSatisfiedValidator.Instance;
 
         var engine = new AgentEngine(
             startUrl: _startUrl,

--- a/WebReaper/Builders/ContentExtractorPipeline.cs
+++ b/WebReaper/Builders/ContentExtractorPipeline.cs
@@ -117,7 +117,19 @@ internal sealed class ContentExtractorPipeline
     /// <see cref="SchemaFold{TNode}"/> over the AngleSharp/CSS backend.
     /// Used by the wrapper methods AND by the outer builders at
     /// <c>BuildAsync</c> time to resolve the final extractor passed into
-    /// the engine. Idempotent: does NOT mutate the current extractor.</summary>
+    /// the engine.
+    /// <para>
+    /// Memoising: when <see cref="Extractor"/> is null, the first call
+    /// constructs a default <see cref="SchemaFold{TNode}"/> AND commits
+    /// it to the pipeline (<c>_extractor ??= ...</c>). Every subsequent
+    /// call returns the same instance. This matches the pre-ADR-0072
+    /// <c>SpiderBuilder.Build</c> behaviour, which assigned via
+    /// <c>??=</c> on first use; it also prevents <c>BuildAsync</c> from
+    /// allocating multiple SchemaFold instances when the pipeline is
+    /// read more than once (e.g. once for the
+    /// <see cref="WebReaper.Core.Parser.Concrete.LearnedSchemaContentExtractor"/>
+    /// inner extractor and again for the spider sync).
+    /// </para></summary>
     public IContentExtractor GetExtractorOrDefault() =>
-        _extractor ?? new SchemaFold<IParentNode>(new AngleSharpSchemaBackend(), _logger());
+        _extractor ??= new SchemaFold<IParentNode>(new AngleSharpSchemaBackend(), _logger());
 }

--- a/WebReaper/Builders/ContentExtractorPipeline.cs
+++ b/WebReaper/Builders/ContentExtractorPipeline.cs
@@ -1,0 +1,123 @@
+using AngleSharp.Dom;
+using Microsoft.Extensions.Logging;
+using WebReaper.Core.Parser.Abstract;
+using WebReaper.Core.Parser.Concrete;
+
+namespace WebReaper.Builders;
+
+/// <summary>
+/// The shared "current extractor + current validator + the wrappers that
+/// compose them" module both <see cref="ScraperEngineBuilder"/> and
+/// <see cref="AgentEngineBuilder"/> embed (ADR-0072, 2026-05-28).
+/// <para>
+/// Before ADR-0072 each builder carried near-identical bodies for
+/// <c>WithContentExtractor</c>, <c>WithFallbackExtractor</c>,
+/// <c>WithSelfHealing</c>, and <c>WithSchemaValidator</c> — the same
+/// "read current extractor or default, wrap with
+/// <see cref="ExtractionRouter"/> / <see cref="SelfHealingContentExtractor"/>,
+/// read current validator" logic written twice. This module owns the
+/// state and the composition once; both builders forward.
+/// </para>
+/// <para>
+/// Scope is deliberate: only the four extractor-cluster methods, where
+/// the wrapping logic is non-trivial and the validator state is read
+/// across calls. Sinks (<c>AddSink</c> / <c>WriteToConsole</c>),
+/// processors (<c>AddProcessor</c>), and the action resolver
+/// (<c>WithActionResolver</c>) stay on each builder — those are 1-line
+/// list adds or property sets with no shared composition logic; the
+/// deletion test for sharing them fails (moving them here would
+/// relocate complexity, not concentrate it).
+/// </para>
+/// <para>
+/// Internal — the two outer builders compose with this module by HAS-A,
+/// not IS-A; the ADR-0025 "two seams, not one bug" outer separation
+/// holds. The shared inner module is named, not the outer.
+/// </para>
+/// </summary>
+internal sealed class ContentExtractorPipeline
+{
+    // ADR-0072: a getter, not a captured logger. The outer builder's
+    // Logger / _logger is mutated by WithLogger after construction; the
+    // wrappers (ExtractionRouter / SelfHealingContentExtractor) must
+    // receive whichever logger is current at the time the With* method
+    // runs — same semantics as the pre-refactor code (which read the
+    // outer Logger property at call time).
+    private readonly Func<ILogger> _logger;
+    private IContentExtractor? _extractor;
+    private ISchemaValidator? _validator;
+
+    public ContentExtractorPipeline(Func<ILogger> loggerProvider)
+    {
+        ArgumentNullException.ThrowIfNull(loggerProvider);
+        _logger = loggerProvider;
+    }
+
+    /// <summary>The current content extractor, or <c>null</c> if none has
+    /// been registered. The two outer builders' <c>BuildAsync</c> resolve
+    /// the default via <see cref="GetExtractorOrDefault"/> at build time.</summary>
+    public IContentExtractor? Extractor => _extractor;
+
+    /// <summary>The current schema validator, or <c>null</c> if none has
+    /// been registered — wrappers receive <c>null</c> and fall back to
+    /// their own constructor default (<see cref="SchemaSatisfiedValidator"/>),
+    /// preserving the "one obvious default" invariant.</summary>
+    public ISchemaValidator? Validator => _validator;
+
+    /// <summary>Replace the current extractor with <paramref name="extractor"/>.</summary>
+    /// <exception cref="ArgumentNullException"><paramref name="extractor"/> is null.</exception>
+    public void WithContentExtractor(IContentExtractor extractor)
+    {
+        ArgumentNullException.ThrowIfNull(extractor);
+        _extractor = extractor;
+    }
+
+    /// <summary>
+    /// Wrap the currently-registered (or default <see cref="SchemaFold{TNode}"/>)
+    /// extractor with an <see cref="ExtractionRouter"/> (ADR-0046): on a
+    /// validation failure (per the registered validator, or the default
+    /// <see cref="SchemaSatisfiedValidator"/>), escalate to
+    /// <paramref name="fallback"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="fallback"/> is null.</exception>
+    public void WithFallbackExtractor(IContentExtractor fallback)
+    {
+        ArgumentNullException.ThrowIfNull(fallback);
+        var primary = GetExtractorOrDefault();
+        _extractor = new ExtractionRouter(primary, fallback, _validator, _logger());
+    }
+
+    /// <summary>
+    /// Wrap the currently-registered (or default <see cref="SchemaFold{TNode}"/>)
+    /// extractor with a <see cref="SelfHealingContentExtractor"/>
+    /// (ADR-0047): on a failed deterministic pass, ask
+    /// <paramref name="repairer"/> for a patched Schema, re-validate, and
+    /// cache the patch for every subsequent page of the run.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="repairer"/> is null.</exception>
+    public void WithSelfHealing(ISelectorRepairer repairer)
+    {
+        ArgumentNullException.ThrowIfNull(repairer);
+        var primary = GetExtractorOrDefault();
+        _extractor = new SelfHealingContentExtractor(primary, repairer, _validator, _logger());
+    }
+
+    /// <summary>Register a custom <see cref="ISchemaValidator"/> — consulted
+    /// by <see cref="WithFallbackExtractor"/> / <see cref="WithSelfHealing"/>
+    /// at the time they compose their wrapper. Call <em>before</em> those
+    /// methods; the wrapper composes against whatever validator is
+    /// registered at that moment.</summary>
+    /// <exception cref="ArgumentNullException"><paramref name="validator"/> is null.</exception>
+    public void WithSchemaValidator(ISchemaValidator validator)
+    {
+        ArgumentNullException.ThrowIfNull(validator);
+        _validator = validator;
+    }
+
+    /// <summary>Return the current extractor or build the default
+    /// <see cref="SchemaFold{TNode}"/> over the AngleSharp/CSS backend.
+    /// Used by the wrapper methods AND by the outer builders at
+    /// <c>BuildAsync</c> time to resolve the final extractor passed into
+    /// the engine. Idempotent: does NOT mutate the current extractor.</summary>
+    public IContentExtractor GetExtractorOrDefault() =>
+        _extractor ?? new SchemaFold<IParentNode>(new AngleSharpSchemaBackend(), _logger());
+}

--- a/WebReaper/Builders/ScraperEngineBuilder.cs
+++ b/WebReaper/Builders/ScraperEngineBuilder.cs
@@ -56,6 +56,13 @@ public class ScraperEngineBuilder
     private ConfigBuilder ConfigBuilder { get; } = new();
     private SpiderBuilder SpiderBuilder { get; } = new();
 
+    // ADR-0072: the shared extractor + validator + wrapping-logic module
+    // both this builder and AgentEngineBuilder embed. Logger is read via
+    // a getter lambda so WithLogger updates after the field-initializer
+    // run still flow through to wrappers constructed by
+    // WithFallbackExtractor / WithSelfHealing.
+    private readonly ContentExtractorPipeline _pipeline;
+
     /// <summary>
     /// Per-run telemetry hooks (ADR-0066). Set by satellites at
     /// <c>WithLlm*</c> / <c>.UseAi(...)</c> time to register a
@@ -78,7 +85,16 @@ public class ScraperEngineBuilder
     /// then <see cref="ICrawlSeed.Extract"/> — never <c>new</c>ed. This is the
     /// structural guarantee (ADR-0025): the build terminals cannot be reached
     /// without a Crawl seed and a schema.</summary>
-    internal ScraperEngineBuilder() { }
+    internal ScraperEngineBuilder()
+    {
+        _pipeline = new ContentExtractorPipeline(() => Logger);
+    }
+
+    /// <summary>Internal accessor for the shared extractor pipeline — used
+    /// by <see cref="ICrawlSeed"/> implementations (the <c>AsMarkdown()</c>
+    /// and other terminals) to register their seed extractor via the
+    /// pipeline instead of bypassing it.</summary>
+    internal ContentExtractorPipeline Pipeline => _pipeline;
 
     /// <summary>
     /// Discover the URLs of a site without running a Crawl (ADR-0042 —
@@ -171,8 +187,11 @@ public class ScraperEngineBuilder
             // ConfigBuilder._schema null (Spider/CrawlStep/Config are
             // already null-tolerant — ADR-0008 / ADR-0025 read-side
             // wiring) and registers the Markdown extractor on the
-            // ADR-0039 IContentExtractor seam.
-            _builder.SpiderBuilder.WithContentExtractor(new MarkdownContentExtractor());
+            // ADR-0039 IContentExtractor seam. ADR-0072: registration
+            // goes through the shared pipeline, not directly to
+            // SpiderBuilder — keeps a single source of truth for the
+            // current extractor.
+            _builder.Pipeline.WithContentExtractor(new MarkdownContentExtractor());
             return _builder;
         }
 
@@ -237,7 +256,7 @@ public class ScraperEngineBuilder
     /// (ADR-0002 / ADR-0039) — instead of the default AngleSharp/CSS fold.</summary>
     public ScraperEngineBuilder WithContentExtractor(IContentExtractor extractor)
     {
-        SpiderBuilder.WithContentExtractor(extractor);
+        _pipeline.WithContentExtractor(extractor);
         return this;
     }
 
@@ -261,15 +280,7 @@ public class ScraperEngineBuilder
     /// <paramref name="fallback"/> is null.</exception>
     public ScraperEngineBuilder WithFallbackExtractor(IContentExtractor fallback)
     {
-        ArgumentNullException.ThrowIfNull(fallback);
-        // The "currently registered or default" rule: read the spider
-        // builder's current extractor; if null, use a SchemaFold over
-        // the default AngleSharp/CSS backend (the same default
-        // SpiderBuilder.Build wires).
-        var primary = SpiderBuilder.GetContentExtractorOrDefault(Logger);
-        SpiderBuilder.WithContentExtractor(
-            new WebReaper.Core.Parser.Concrete.ExtractionRouter(
-                primary, fallback, _schemaValidator, Logger));
+        _pipeline.WithFallbackExtractor(fallback);
         return this;
     }
 
@@ -291,20 +302,9 @@ public class ScraperEngineBuilder
     /// <paramref name="repairer"/> is null.</exception>
     public ScraperEngineBuilder WithSelfHealing(WebReaper.Core.Parser.Abstract.ISelectorRepairer repairer)
     {
-        ArgumentNullException.ThrowIfNull(repairer);
-        var primary = SpiderBuilder.GetContentExtractorOrDefault(Logger);
-        SpiderBuilder.WithContentExtractor(
-            new WebReaper.Core.Parser.Concrete.SelfHealingContentExtractor(
-                primary, repairer, _schemaValidator, Logger));
+        _pipeline.WithSelfHealing(repairer);
         return this;
     }
-
-    // ADR-0062: the builder-registered schema validator, read by
-    // WithFallbackExtractor / WithSelfHealing at the time they compose
-    // their wrapper. Null defaults to SchemaSatisfiedValidator.Instance
-    // at construction time (each wrapper picks the default itself when
-    // we pass null in — keeps the "one obvious default" invariant).
-    private WebReaper.Core.Parser.Abstract.ISchemaValidator? _schemaValidator;
 
     /// <summary>
     /// Register a custom <see cref="WebReaper.Core.Parser.Abstract.ISchemaValidator"/>
@@ -332,8 +332,7 @@ public class ScraperEngineBuilder
     public ScraperEngineBuilder WithSchemaValidator(
         WebReaper.Core.Parser.Abstract.ISchemaValidator validator)
     {
-        ArgumentNullException.ThrowIfNull(validator);
-        _schemaValidator = validator;
+        _pipeline.WithSchemaValidator(validator);
         return this;
     }
 
@@ -979,19 +978,27 @@ public class ScraperEngineBuilder
                     "BuildAsync(), or supply a custom ISchemaInferrer via " +
                     ".WithSchemaInferrer(inferrer).");
             }
-            var inner = SpiderBuilder.GetContentExtractorOrDefault(Logger);
-            var validator = _schemaValidator ?? SchemaSatisfiedValidator.Instance;
+            // ADR-0072: read inner extractor and validator from the
+            // shared pipeline instead of the previously-duplicated
+            // ScraperEngineBuilder._schemaValidator field.
+            var inner = _pipeline.GetExtractorOrDefault();
+            var validator = _pipeline.Validator ?? SchemaSatisfiedValidator.Instance;
             var wrapped = new LearnedSchemaContentExtractor(
                 _schemaInferrer, inner, marker.Goal, Logger,
                 validator,
                 _reInferAfterFailures,
                 _maxReInferencesPerInstance);
-            SpiderBuilder.WithContentExtractor(wrapped);
+            _pipeline.WithContentExtractor(wrapped);
             // ADR-0058: register the wrapper as a teardown hook so the
             // SemaphoreSlim disposes on engine teardown.
             OnTeardown(wrapped);
         }
 
+        // ADR-0072: sync the pipeline's resolved extractor into the
+        // SpiderBuilder once, immediately before SpiderBuilder.Build —
+        // the spider doesn't read from the pipeline directly; it gets
+        // the finalized extractor via WithContentExtractor.
+        SpiderBuilder.WithContentExtractor(_pipeline.GetExtractorOrDefault());
         var spider = SpiderBuilder.Build();
         await ConfigStorage.CreateConfigAsync(config);
 

--- a/docs/adr/0072-content-extractor-pipeline-module.md
+++ b/docs/adr/0072-content-extractor-pipeline-module.md
@@ -292,10 +292,30 @@ into `SpiderBuilder` once at `BuildAsync` time.
 
 ### Tests
 
-- All 409 unit tests pass.
-- All 240 AI tests pass (this branch is off `master`; the +13 tests
-  from PR #133's `LlmToolArguments` ship with that branch).
-- Behavior-preserving refactor; no test changes required.
+The amendment adds `ContentExtractorPipelineTests` (12 tests in
+`WebReaper.Tests/WebReaper.UnitTests/`) that pin the inner contract
+directly, alongside the existing end-to-end builder tests:
+
+- `GetExtractorOrDefault` returns a `SchemaFold` when unset.
+- `GetExtractorOrDefault` memoises (`??=`) — repeated calls return
+  the same instance. Pre-ADR-0072 the `??=` memoisation lived in
+  `SpiderBuilder.Build`; the post-refactor lifted it INTO the
+  pipeline so any future `BuildAsync` that reads the pipeline more
+  than once (e.g. once for the `LearnedSchemaContentExtractor` inner
+  extractor and again for the spider sync) sees the SAME default
+  instance, not a fresh allocation each time.
+- The `Func<ILogger>` getter is invoked at wrapper-construction
+  time, NOT at pipeline-construction time. This is the regression
+  the design specifically guards against: capturing the logger by
+  value would silently break `WithLogger`-after-`WithFallbackExtractor`.
+  The test mutates the underlying logger between pipeline construction
+  and the `WithFallbackExtractor` call, then verifies the getter saw
+  the post-mutation logger (by `Assert.Same` against a sentinel).
+
+Plus the standard null-argument and state-replacement checks.
+
+Totals: 421 unit tests (was 409, +12), 240 AI tests, all pass.
+Behavior-preserving refactor; no other test changes required.
 
 ## References
 

--- a/docs/adr/0072-content-extractor-pipeline-module.md
+++ b/docs/adr/0072-content-extractor-pipeline-module.md
@@ -1,0 +1,317 @@
+# `ContentExtractorPipeline` — the shared extractor + validator module both engine builders embed
+
+## Status
+
+**Accepted — implemented** (2026-05-28). Post-v10.0.1 architecture
+deepening targeting the duplication between `ScraperEngineBuilder` and
+`AgentEngineBuilder`. Both builders carried near-identical bodies for
+the four extractor-cluster methods (`WithContentExtractor`,
+`WithFallbackExtractor`, `WithSelfHealing`, `WithSchemaValidator`) —
+the same "read current extractor or default, wrap with
+`ExtractionRouter` / `SelfHealingContentExtractor`, read current
+validator" logic written twice across the two outer-shell builders.
+This ADR introduces an internal `ContentExtractorPipeline` module
+both builders embed; the four methods become 1-line forwards.
+
+## Context
+
+ADR-0025 split the build path into two outer seams — the in-process
+`ScraperEngineBuilder` (Crawl driver) and the `AgentEngineBuilder`
+(Agent driver). "Two seams, not one bug" — the outer surfaces stay
+distinct because the two drivers genuinely differ (Crawl is parallel
+with a Spider per job; Agent is sequential with a decide → persist →
+execute loop). The ADR-0025 verdict applies to the OUTER builders.
+
+The INNER composition of the post-extraction surface is the same for
+both drivers, though:
+
+- A current `IContentExtractor` (the extractor the engine runs per
+  page). ADR-0039 seam.
+- A current `ISchemaValidator` (the verdict source for routing and
+  self-heal). ADR-0062 seam.
+- The wrappers that compose them: `ExtractionRouter` (ADR-0046
+  primary-fallback) and `SelfHealingContentExtractor` (ADR-0047
+  proposer-validator-cache).
+
+Pre-refactor, the four `With*` methods that own this composition
+lived twice — one copy per builder. Bodies were near-byte-identical:
+
+- `WithContentExtractor(x)` — set the current extractor.
+- `WithFallbackExtractor(fallback)` — `current = ExtractionRouter(current ?? default, fallback, validator, logger)`.
+- `WithSelfHealing(repairer)` — `current = SelfHealingContentExtractor(current ?? default, repairer, validator, logger)`.
+- `WithSchemaValidator(v)` — set the validator.
+
+The wrapping methods read both the current extractor (with a
+"current or default" fallback to the AngleSharp/CSS `SchemaFold`) and
+the current validator (passed through to the wrapper or defaulted by
+the wrapper). Validator state was a duplicated `_schemaValidator`
+field on each builder. The default-extractor construction
+(`new SchemaFold<IParentNode>(new AngleSharpSchemaBackend(), logger)`)
+appeared in both builders' wrapper methods AND in their `BuildAsync`
+methods AND in `SpiderBuilder.GetContentExtractorOrDefault`.
+
+The deletion test:
+
+- Delete `ScraperEngineBuilder.WithFallbackExtractor` — the complexity
+  reappears in N callers (each consumer that wants LLM-fallback would
+  hand-wire `ExtractionRouter`).
+- Delete `AgentEngineBuilder.WithFallbackExtractor` — same answer.
+- Delete the duplication of those two methods — the complexity
+  concentrates in one place (the shared module). **The duplication
+  was not earning its keep.**
+
+## Decision
+
+A new internal `ContentExtractorPipeline` (in `WebReaper/Builders/`)
+owns the extractor + validator state and the four `With*` methods'
+composition logic. Both builders embed one and forward.
+
+### Module shape
+
+```csharp
+internal sealed class ContentExtractorPipeline
+{
+    private readonly Func<ILogger> _logger;       // a getter, not captured
+    private IContentExtractor? _extractor;
+    private ISchemaValidator? _validator;
+
+    public ContentExtractorPipeline(Func<ILogger> loggerProvider);
+
+    public IContentExtractor? Extractor { get; }   // null if none registered
+    public ISchemaValidator? Validator { get; }    // null if none registered
+
+    public void WithContentExtractor(IContentExtractor extractor);
+    public void WithFallbackExtractor(IContentExtractor fallback);
+    public void WithSelfHealing(ISelectorRepairer repairer);
+    public void WithSchemaValidator(ISchemaValidator validator);
+
+    public IContentExtractor GetExtractorOrDefault();  // current or new SchemaFold
+}
+```
+
+Logger is captured via a `Func<ILogger>` getter, not a value, because
+the outer builders mutate their `Logger` / `_logger` field via
+`WithLogger` after the pipeline is constructed. The pipeline calls
+the getter at each wrapper-construction site so the latest logger
+flows through — same semantics as the pre-refactor code which read
+the outer `Logger` property at call time.
+
+### Builder integration
+
+Each outer builder gains a `private readonly ContentExtractorPipeline _pipeline`
+field, constructed in the builder's constructor with the logger
+getter. Each builder's four `With*` methods become 1-line forwards:
+
+```csharp
+public ScraperEngineBuilder WithFallbackExtractor(IContentExtractor fallback)
+{
+    _pipeline.WithFallbackExtractor(fallback);
+    return this;
+}
+```
+
+The `_schemaValidator` field is removed from each builder; the
+pipeline owns it.
+
+`BuildAsync` reads the resolved extractor from the pipeline:
+- `AgentEngineBuilder` passes `_pipeline.GetExtractorOrDefault()` to
+  the `AgentEngine` constructor, and `_pipeline.Validator ?? SchemaSatisfiedValidator.Instance`
+  as the validator.
+- `ScraperEngineBuilder` syncs the pipeline's resolved extractor into
+  `SpiderBuilder.WithContentExtractor(...)` immediately before
+  `SpiderBuilder.Build()` (the Spider doesn't need to know about the
+  pipeline; it gets the finalized extractor through the existing
+  `SpiderBuilder` surface). The ADR-0067 `LearnedSchemaContentExtractor`
+  wrapping code reads `_pipeline.Validator` and registers the wrapped
+  extractor back through `_pipeline.WithContentExtractor(wrapped)`
+  before the sync.
+
+The seed terminals (`AsMarkdown()`, etc.) also register via the
+pipeline (`Pipeline.WithContentExtractor(new MarkdownContentExtractor())`)
+instead of bypassing it through `SpiderBuilder.WithContentExtractor`
+directly — keeps a single source of truth for the current extractor.
+
+### Scope decision: 4 methods only
+
+The shared module covers the four methods where the composition
+logic is non-trivial AND validator state is read across calls. It
+does NOT cover:
+
+- `AddSink` / `WriteToConsole` / `WriteToJsonFile` — 1-line list
+  adders with no shared state or composition.
+- `AddProcessor` — same shape.
+- `WithActionResolver` — a 1-line field setter; the resolver isn't
+  part of the extractor pipeline.
+- `WithPageLoader` / `WithCookieStorage` / proxy / cookie methods —
+  Crawl-specific or builder-specific; not duplicated symmetrically
+  between the two builders.
+
+For those methods the deletion test fails: pulling them into a
+shared module would relocate complexity (each builder still needs a
+1-line forward) without concentrating any composition logic. The
+locality win is zero. Leave them.
+
+### Naming
+
+`ContentExtractorPipeline` over `ContentPipeline` / `PostExtractionPipeline` /
+`ExtractionStack`:
+
+- Names the **state and composition** of the content extractor, which
+  is what the module owns. The validator is on it because the
+  wrapping methods need it, not because it's the "validator stack."
+- "Pipeline" matches CONTEXT.md's "page-processor pipeline" naming for
+  the post-extraction surface, even though this module is just the
+  extractor half.
+- "ContentPipeline" was too broad (suggested it owned processors and
+  sinks too, which it does not).
+- "ExtractionStack" sounded like a deployment thing.
+
+### SpiderBuilder stays unchanged
+
+`SpiderBuilder.WithContentExtractor` and `Build()` are still needed
+by `DistributedSpiderBuilder` (ADR-0009's reduced shell, which has
+only `WithContentExtractor` and no wrapping methods — nothing to
+share with `ScraperEngineBuilder`). The pipeline state lives on
+`ScraperEngineBuilder._pipeline`; the resolved extractor is synced
+into `SpiderBuilder` once at `BuildAsync` time.
+
+## Considered options
+
+### Fork 1 — Shape of the shared module
+
+- **Embedded `ContentExtractorPipeline` component (chosen).** Each
+  builder holds one; the four `With*` methods forward. Explicit
+  composition, clear ownership, IDE-discoverable methods on each
+  builder.
+- **Default-interface-implementation mixin.** An interface with
+  default-method implementations both builders satisfy. Rejected:
+  C# default-interface-implementations are only accessible through
+  the interface; the builders would still need explicit 1-line
+  re-declarations to expose the methods on the type. Same boilerplate
+  as the embedded shape, plus indirection.
+- **Generic extension methods on an `IPipelineHost` marker
+  interface.** `builder.WithFallbackExtractor(x)` resolves to an
+  extension method that reads `builder.Pipeline.Extractor`. Loses
+  IDE discoverability (the method is in a separate extensions
+  namespace) and creates surprise when users navigate to definition.
+- **Shared base class.** `class AgentEngineBuilder : BuilderBase`,
+  `class ScraperEngineBuilder : BuilderBase`. Rejected: makes the two
+  outer builders structurally related, which ADR-0025's "two seams,
+  not one bug" framing argues against. The shared inner module is
+  HAS-A, not IS-A.
+
+### Fork 2 — Scope
+
+- **Four extractor-cluster methods (chosen).** Where the composition
+  logic is non-trivial.
+- **All ~8 duplicated methods.** Includes sinks, processors,
+  `WithActionResolver`, writer sugars. Rejected: those are 1-line
+  list adds or property sets with no shared composition; the
+  deletion test fails for them. Sharing would relocate complexity,
+  not concentrate it.
+- **Only the byte-identical methods.** Just `WithSchemaValidator`
+  + the wrapper trio's near-identical bodies. Rejected: the wrappers
+  read the validator from the validator-method's state, so
+  `WithSchemaValidator` HAS to live with them.
+
+### Fork 3 — Logger handling
+
+- **`Func<ILogger>` getter (chosen).** Pipeline calls the getter at
+  each wrapper-construction site. Captures `WithLogger` updates that
+  happen between pipeline construction and the wrapper call —
+  matches the pre-refactor "read Logger at the call site" semantics.
+- **Captured `ILogger` value at construction time.** Rejected:
+  silently breaks the case where `WithLogger` is called after the
+  outer builder is constructed but before `WithFallbackExtractor`.
+  Behaviour change.
+- **`ILogger` setter the outer builder pushes on each `WithLogger`.**
+  Functionally equivalent to the getter; the getter is cleaner
+  (single source of truth: the outer builder's logger field).
+
+### Fork 4 — Does SpiderBuilder absorb the pipeline?
+
+- **Stays unchanged (chosen).** `DistributedSpiderBuilder` still
+  needs `SpiderBuilder.WithContentExtractor`; nothing to share with
+  `ScraperEngineBuilder` for that builder. Sync the pipeline's
+  resolved extractor into SpiderBuilder once at `BuildAsync` time.
+- **SpiderBuilder absorbs the pipeline.** Rejected: `SpiderBuilder`
+  is the Spider's per-Job I/O shell (ADR-0022); owning extractor
+  composition logic on top of its load-transport / proxy / cookie
+  responsibilities would broaden it past the ADR-0022 shape.
+- **`SpiderBuilder.WithContentExtractor` is removed; `Build()` takes
+  the extractor as a parameter.** Rejected: would require
+  `DistributedSpiderBuilder` to also hold its own pipeline (or
+  duplicate the resolution logic), which doesn't earn its keep for
+  a builder with one extractor-related method.
+
+## Consequences
+
+### Wins
+
+- **Locality.** The composition logic for the extractor + validator
+  cluster lives in one place. A future change (e.g. adding a new
+  wrapper class) is one edit, not two.
+- **Symmetry.** Both builders' `With*` method bodies are 1-line
+  forwards. Adding a new extractor-cluster method (e.g.
+  `WithCaching`) is one method on the pipeline plus a 3-line forward
+  on each builder, with no risk of the bodies drifting.
+- **The default-extractor invariant is in one place.** Pre-refactor
+  the AngleSharp/CSS `SchemaFold` default appeared in three places
+  (each builder's wrappers + `SpiderBuilder.GetContentExtractorOrDefault`
+  + each builder's `BuildAsync`). Post-refactor it's in one
+  (`ContentExtractorPipeline.GetExtractorOrDefault`).
+
+### Costs
+
+- **One more module.** The internal surface area grows by one class.
+  Trade-off accepted for the locality + symmetry win.
+- **Pipeline's logger is a `Func<>`.** A small indirection cost at
+  each wrapper construction (one delegate invocation). Negligible at
+  build time; the wrappers are constructed once per call, not per
+  page.
+- **`SpiderBuilder` keeps `WithContentExtractor` as an internal
+  contract surface.** ScraperEngineBuilder.BuildAsync calls it once
+  to sync the resolved extractor in. Modest coupling between the
+  outer builder and SpiderBuilder, but no worse than the
+  pre-refactor flow (which also called WithContentExtractor on
+  SpiderBuilder).
+
+### Non-changes
+
+- ADR-0009 satellite quarantine intact. The pipeline lives in core
+  (not the AI satellite); the AI satellite continues to register
+  extractors via the existing builder surface, which transparently
+  goes through the pipeline.
+- ADR-0025 two-seam outer separation intact. The two outer builders
+  stay distinct; only the inner shared module is named.
+- AOT discipline preserved. The pipeline is a regular class with no
+  reflection or runtime code-gen.
+- Public API of both builders unchanged. The four `With*` methods
+  retain their signatures and semantics; only the bodies forward
+  instead of inlining the composition.
+
+### Tests
+
+- All 409 unit tests pass.
+- All 240 AI tests pass (this branch is off `master`; the +13 tests
+  from PR #133's `LlmToolArguments` ship with that branch).
+- Behavior-preserving refactor; no test changes required.
+
+## References
+
+- ADR-0009 — registration seam + satellite pattern; the AI satellite
+  still wires through the existing builder methods (now pipeline-backed).
+- ADR-0022 — Crawl driver + Spider split; `SpiderBuilder` stays the
+  Spider's per-Job shell, not absorbed.
+- ADR-0025 — staged builder entry + two-seam pattern; this ADR
+  complements rather than contradicts (the two outer seams hold; the
+  shared inner module is named).
+- ADR-0039 — `IContentExtractor` seam; what the pipeline composes.
+- ADR-0046 — `ExtractionRouter`; the primary-fallback wrapper the
+  pipeline's `WithFallbackExtractor` constructs.
+- ADR-0047 — `SelfHealingContentExtractor`; the cached-patch wrapper
+  the pipeline's `WithSelfHealing` constructs.
+- ADR-0062 — `ISchemaValidator` seam; the validator state the
+  pipeline owns and the wrappers consume.
+- ADR-0067 — `LearnedSchemaContentExtractor`; reads
+  `_pipeline.Validator` at BuildAsync time.


### PR DESCRIPTION
**Independent of [#133](https://github.com/pavlovtech/WebReaper/pull/133) and [#134](https://github.com/pavlovtech/WebReaper/pull/134)** — different files (core, not AI satellite). Can merge in any order.

## Summary

`ScraperEngineBuilder` and `AgentEngineBuilder` carried near-byte-identical bodies for the four extractor-cluster methods (`WithContentExtractor`, `WithFallbackExtractor`, `WithSelfHealing`, `WithSchemaValidator`). Introduces an internal `ContentExtractorPipeline` module both builders embed; the four methods become 1-line forwards. The validator field is owned by one module instead of two.

## ADR-0072

Records the shape, the embedded-component vs. interface-mixin vs. extension-method vs. base-class fork (chose embedded), the 4-method scope verdict (deletion test fails for the 1-line list-adders), the `Func<ILogger>` getter rationale (preserves "read Logger at call site" semantics across `WithLogger` updates), and the SpiderBuilder-stays-unchanged decision (DistributedSpiderBuilder still uses it).

## Shape change

**Before:**
```csharp
public ScraperEngineBuilder WithFallbackExtractor(IContentExtractor fallback)
{
    ArgumentNullException.ThrowIfNull(fallback);
    var primary = SpiderBuilder.GetContentExtractorOrDefault(Logger);
    SpiderBuilder.WithContentExtractor(
        new ExtractionRouter(primary, fallback, _schemaValidator, Logger));
    return this;
}
// ... and the same 4-line body in AgentEngineBuilder.WithFallbackExtractor
```

**After:**
```csharp
public ScraperEngineBuilder WithFallbackExtractor(IContentExtractor fallback)
{
    _pipeline.WithFallbackExtractor(fallback);
    return this;
}
// ... and the same 1-line forward in AgentEngineBuilder.WithFallbackExtractor
```

The composition logic lives in `ContentExtractorPipeline.WithFallbackExtractor` once.

## Locality wins

| Concern | Before | After |
|---|---|---|
| Default SchemaFold construction | 3 places per builder (wrappers ×2, BuildAsync, SpiderBuilder.GetContentExtractorOrDefault) | 1 method (`GetExtractorOrDefault`) |
| `_schemaValidator` state | 1 field per builder (2 total) | 1 module |
| `ExtractionRouter` composition | 2 inlined copies | 1 method |
| `SelfHealingContentExtractor` composition | 2 inlined copies | 1 method |

## Scope (deletion test applied)

**Included** (4 methods with non-trivial shared composition):
- `WithContentExtractor` — sets current extractor
- `WithFallbackExtractor` — wraps with ExtractionRouter, reads validator
- `WithSelfHealing` — wraps with SelfHealingContentExtractor, reads validator
- `WithSchemaValidator` — sets validator that wrappers read

**Excluded** (1-line forwarders, no shared composition):
- `AddSink` / `WriteToConsole` / `WriteToJsonFile`
- `AddProcessor`
- `WithActionResolver`

Pulling those into the shared module would relocate complexity, not concentrate it. The deletion test fails for them.

## Logger handling: `Func<ILogger>` getter

The pre-refactor code read `Logger` at the wrapper-call site (so `WithLogger` updates flowed through to wrappers constructed later). Capturing `ILogger` by value at pipeline construction would silently break that. The pipeline takes `Func<ILogger> loggerProvider` and calls it at each wrapper-construction site.

## SpiderBuilder stays unchanged

`SpiderBuilder.WithContentExtractor` is still needed by `DistributedSpiderBuilder` (the ADR-0009 reduced shell, with only this one extractor method — nothing to share with `ScraperEngineBuilder`). `ScraperEngineBuilder.BuildAsync` syncs the pipeline's resolved extractor into `SpiderBuilder` once before `SpiderBuilder.Build()`.

## Numbers

| File | Before | After | Δ |
|---|---|---|---|
| `ScraperEngineBuilder.cs` | 1043 | 1050 | **+7** |
| `AgentEngineBuilder.cs` | 420 | 421 | **+1** |
| `ContentExtractorPipeline.cs` | 0 | 123 | **+123** (NEW) |

Net rose because the new module's docstrings exceed the inline-body savings. The win is locality, not line count — same pattern as PR #134.

## Non-changes

- **ADR-0009 satellite quarantine intact** — pipeline lives in core; the AI satellite continues to wire through the existing builder surface.
- **ADR-0025 two-seam outer separation intact** — the two outer builders stay distinct; only the inner shared module is named.
- **AOT preserved** — no reflection, no runtime code-gen.
- **Public API unchanged** — the four `With*` methods retain signatures and semantics; only bodies forward.

## Tests

```
Unit:  409 passed
AI:    240 passed (this branch is off master; #133's +13 LlmToolArguments tests ship with that branch)
```

Behavior-preserving refactor — no test changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)