### PR TITLE
chore: clear pre-existing build warnings (33 → 0) + Node.js 24 action bump

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
     - name: Restore dependencies

--- a/.github/workflows/WebReaperAzureFuncs.yml
+++ b/.github/workflows/WebReaperAzureFuncs.yml
@@ -13,9 +13,9 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
     - name: Restore

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,13 +81,13 @@ jobs:
       packages: ${{ steps.select.outputs.packages }}
       core_selected: ${{ steps.select.outputs.core_selected }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
@@ -207,11 +207,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: nuget-release   # required-reviewer approval gate (runbook Phase 2)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
@@ -256,7 +256,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run == false }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           fetch-depth: 0
@@ -349,11 +349,11 @@ jobs:
           - { os: windows-latest,   rid: win-arm64,   archive: zip,    ext: '.exe' }
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
@@ -519,7 +519,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
@@ -563,7 +563,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run == false }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 

--- a/Examples/BrownsfashionScraper/Worker.cs
+++ b/Examples/BrownsfashionScraper/Worker.cs
@@ -9,7 +9,9 @@ namespace BrownsfashionScraper
     public class ScrapingWorker : BackgroundService
     {
         private readonly ILogger<ScrapingWorker> _logger;
-        private ScraperEngine _scraper;
+        // Assigned in StartAsync before any caller can observe it; null
+        // until then.
+        private ScraperEngine? _scraper;
 
         public ScrapingWorker(ILogger<ScrapingWorker> logger)
         {
@@ -77,7 +79,9 @@ namespace BrownsfashionScraper
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            await _scraper.RunAsync(stoppingToken);
+            // _scraper is assigned in StartAsync before ExecuteAsync runs
+            // (BackgroundService lifecycle); the runtime invariant holds.
+            await _scraper!.RunAsync(stoppingToken);
         }
     }
 }

--- a/Misc/WebReaper.ProxyProviders/WebShareProxy/Proxy.cs
+++ b/Misc/WebReaper.ProxyProviders/WebShareProxy/Proxy.cs
@@ -1,10 +1,12 @@
-﻿namespace WebReaper.ProxyProviders.WebShareProxy
+namespace WebReaper.ProxyProviders.WebShareProxy
 {
+    // WebShare API response shape; all properties are populated by the
+    // System.Text.Json deserializer.
     public class Proxy
     {
-        public string Username { get; set; }
-        public string Password { get; set; }
-        public string Proxy_Address { get; set; }
-        public Dictionary<string, int> Ports { get; set; }
+        public string Username { get; set; } = "";
+        public string Password { get; set; } = "";
+        public string Proxy_Address { get; set; } = "";
+        public Dictionary<string, int> Ports { get; set; } = new();
     }
 }

--- a/WebReaper.Extraction.Attributes/ScrapeFieldAttribute.cs
+++ b/WebReaper.Extraction.Attributes/ScrapeFieldAttribute.cs
@@ -5,11 +5,12 @@ namespace WebReaper.Extraction.Attributes;
 /// <c>WebReaper.Extraction.Generators</c> Roslyn source generator
 /// (ADR-0045).
 /// </summary>
-/// <param name="selector">The CSS / XPath / JSONPath selector — passes
-/// to the fold's backend unchanged. Required.</param>
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 public sealed class ScrapeFieldAttribute : Attribute
 {
+    /// <summary>Construct the attribute with a required selector.</summary>
+    /// <param name="selector">The CSS / XPath / JSONPath selector — passes
+    /// to the fold's backend unchanged.</param>
     public ScrapeFieldAttribute(string selector)
     {
         Selector = selector;

--- a/WebReaper.Mcp/WebReaper.Mcp.csproj
+++ b/WebReaper.Mcp/WebReaper.Mcp.csproj
@@ -22,7 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.5" />
+    <!-- Preview SDK; pin explicitly per release. The 0.5.0-preview.5
+         tag was pulled from NuGet; bump to the latest available preview
+         to silence NU1603. -->
+    <PackageReference Include="ModelContextProtocol" Version="0.6.0-preview.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
   </ItemGroup>
 

--- a/WebReaper.Tests/WebReaper.IntegrationTests/TestOutputLogger.cs
+++ b/WebReaper.Tests/WebReaper.IntegrationTests/TestOutputLogger.cs
@@ -13,7 +13,7 @@ namespace WebReaper.IntegrationTests
             this.output = output;
         }
 
-        public IDisposable BeginScope<TState>(TState state) => default!;
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
         public bool IsEnabled(LogLevel logLevel) => true;
 

--- a/WebReaper.Tests/WebReaper.UnitTests/CapturingLogger.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/CapturingLogger.cs
@@ -11,7 +11,7 @@ internal sealed class CapturingLogger : ILogger
     public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; }
         = new();
 
-    public IDisposable BeginScope<TState>(TState state) => default!;
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
     public bool IsEnabled(LogLevel logLevel) => true;
 
     public void Log<TState>(

--- a/WebReaper.Tests/WebReaper.UnitTests/ProxyValidationTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/ProxyValidationTests.cs
@@ -120,11 +120,11 @@ namespace WebReaper.UnitTests
         }
 
         [Fact]
-        public void StaticProxySourceParsesAddresses()
+        public async Task StaticProxySourceParsesAddresses()
         {
             var source = StaticProxySource.FromAddresses(new[] { "1.2.3.4:8080", "http://5.6.7.8:3128" });
 
-            var proxies = source.GetCandidatesAsync().GetAwaiter().GetResult();
+            var proxies = await source.GetCandidatesAsync();
 
             Assert.Equal(2, proxies.Count);
             Assert.Equal("http://1.2.3.4:8080/", proxies[0].Address!.ToString());

--- a/WebReaper.Tests/WebReaper.UnitTests/TestOutputLogger.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/TestOutputLogger.cs
@@ -13,7 +13,7 @@ namespace WebReaper.UnitTests
             this.output = output;
         }
 
-        public IDisposable BeginScope<TState>(TState state) => default!;
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
         public bool IsEnabled(LogLevel logLevel) => true;
 

--- a/WebReaper.Tests/WebReaper.UnitTests/WebReaper.UnitTests.csproj
+++ b/WebReaper.Tests/WebReaper.UnitTests/WebReaper.UnitTests.csproj
@@ -11,7 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.0" />
+    <!-- Used by ParserTests for windows-1251 page decoding. NU1510
+         (.NET 10 pruning heuristic) misclassifies this as unneeded;
+         the legacy encoding provider isn't in the framework default. -->
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.0" NoWarn="NU1510" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/WebReaper/Builders/AgentEngineBuilder.cs
+++ b/WebReaper/Builders/AgentEngineBuilder.cs
@@ -97,7 +97,7 @@ public sealed class AgentEngineBuilder
     /// <summary>
     /// Begin building an agent run targeting <paramref name="startUrl"/> with
     /// the natural-language <paramref name="goal"/>. Static, sibling to
-    /// <see cref="ScraperEngineBuilder.Crawl(System.Collections.Generic.IEnumerable{string})"/>.
+    /// <see cref="ScraperEngineBuilder.Crawl(string[])"/>.
     /// </summary>
     public static AgentEngineBuilder Start(string startUrl, string goal)
         => new(startUrl, goal);

--- a/WebReaper/Builders/ConfigBuilder.cs
+++ b/WebReaper/Builders/ConfigBuilder.cs
@@ -35,7 +35,12 @@ internal class ConfigBuilder
 
     private PageType _startPageType;
 
-    private IEnumerable<string> _startUrls;
+    // Initialized to an empty seed so the type-system contract holds
+    // from construction. The ADR-0025 staged builder guarantees one of
+    // Get / GetWithBrowser is called before Build (the seed terminals
+    // route through them); the empty default is a structural belt-and-
+    // suspenders, never observed at runtime.
+    private IEnumerable<string> _startUrls = Array.Empty<string>();
 
     /// <summary>
     /// The crawl's start URLs, loaded as static HTTP pages. Defines the seed

--- a/WebReaper/Builders/ScraperEngineBuilder.cs
+++ b/WebReaper/Builders/ScraperEngineBuilder.cs
@@ -226,7 +226,10 @@ public class ScraperEngineBuilder
     private ILogger Logger { get; set; } = NullLogger.Instance;
 
     private IScheduler Scheduler { get; set; } = new InMemoryScheduler();
-    private IScraperConfigStorage? ConfigStorage { get; set; } = new InMemoryScraperConfigStorage();
+    // Non-nullable — default is the in-memory adapter; WithConfigStorage
+    // takes a non-nullable IScraperConfigStorage so the property can
+    // never be null in normal use.
+    private IScraperConfigStorage ConfigStorage { get; set; } = new InMemoryScraperConfigStorage();
     /// <summary>The proxy provider, once configured via
     /// <see cref="WithProxies"/> / <see cref="WithValidatedProxies(IProxySource, IEnumerable{IProxyValidator}, ValidatedProxyProviderOptions)"/>.</summary>
     protected IProxyProvider? ProxyProvider { get; set; }

--- a/WebReaper/Builders/SpiderBuilder.cs
+++ b/WebReaper/Builders/SpiderBuilder.cs
@@ -44,7 +44,11 @@ internal class SpiderBuilder
 
     private ILogger Logger { get; set; } = NullLogger.Instance;
 
-    private ScraperConfig Config { get; set; }
+    // Nullable until ScraperEngineBuilder.BuildAsync calls WithConfig
+    // (ADR-0034: required parameter on the Build call). The two read
+    // sites in Build() are post-WithConfig and use the null-forgiving
+    // operator to surface the structural invariant.
+    private ScraperConfig? Config { get; set; }
 
     private IVisitedLinkTracker SiteLinkTracker { get; set; } = new InMemoryVisitedLinkTracker();
 
@@ -195,8 +199,8 @@ internal class SpiderBuilder
     }
 
     /// <summary>Register the <see cref="IActionResolver"/> the Puppeteer
-    /// transport invokes for <see cref="PageAction.SemanticAct"/> arms
-    /// (ADR-0050). The default is <see cref="NullActionResolver"/>; the
+    /// transport invokes for <see cref="WebReaper.Domain.PageActions.PageAction.SemanticAct"/>
+    /// arms (ADR-0050). The default is <see cref="NullActionResolver"/>; the
     /// LLM-backed implementation ships in the <c>WebReaper.AI</c> satellite.</summary>
     public SpiderBuilder WithActionResolver(IActionResolver actionResolver)
     {
@@ -309,10 +313,14 @@ internal class SpiderBuilder
 
         var crawlStep = new CrawlStep(ContentExtractor);
 
+        // Config is null until WithConfig is called; ADR-0034 makes it
+        // required by the time Build runs (the outer ScraperEngineBuilder
+        // .BuildAsync calls WithConfig before Build). Null-forgive on
+        // the read sites — the runtime invariant holds.
         var spider = new Spider(
             crawlStep,
             PageLoader,
-            Config.Headless,
+            Config!.Headless,
             Config.ParsingScheme);
 
         return spider;

--- a/WebReaper/Core/Actions/Abstract/IActionResolver.cs
+++ b/WebReaper/Core/Actions/Abstract/IActionResolver.cs
@@ -4,7 +4,7 @@ namespace WebReaper.Core.Actions.Abstract;
 
 /// <summary>
 /// The resolution seam for <see cref="PageAction.SemanticAct"/> (ADR-0050):
-/// given a natural-language <paramref name="intent"/> string and the current
+/// given a natural-language <c>intent</c> string and the current
 /// page's rendered HTML, return a concrete <see cref="PageAction"/> arm
 /// (typically <see cref="PageAction.Click"/>,
 /// <see cref="PageAction.WaitForSelector"/>, <see cref="PageAction.Wait"/>, or

--- a/WebReaper/Core/Agent/Concrete/AgentEngine.cs
+++ b/WebReaper/Core/Agent/Concrete/AgentEngine.cs
@@ -401,7 +401,12 @@ public sealed class AgentEngine
                         }
                         else
                         {
-                            var processed = await RunProcessorsAsync(currentUrl, pageHtml, extracted, extract.Schema, cancellationToken);
+                            // The null branch above (extracted is null →
+                            // Invalid verdict → !IsValid → outer if) ensures
+                            // extracted is non-null here; the compiler's
+                            // narrowing doesn't span the verdict variable so
+                            // a forgiving operator surfaces the invariant.
+                            var processed = await RunProcessorsAsync(currentUrl, pageHtml, extracted!, extract.Schema, cancellationToken);
                             if (processed is not null)
                             {
                                 records.Add(processed.Data);

--- a/WebReaper/Core/LinkTracker/Concrete/FileVisitedLinkedTracker.cs
+++ b/WebReaper/Core/LinkTracker/Concrete/FileVisitedLinkedTracker.cs
@@ -13,7 +13,13 @@ internal class FileVisitedLinkedTracker : IVisitedLinkTracker, IAsyncInitializab
     private readonly string _fileName;
 
     private readonly SemaphoreSlim _semaphore = new(1, 1);
-    private ConcurrentBag<string> _visitedLinks;
+    // Initialized to empty so the type-system contract holds from
+    // construction. InitializeCoreAsync (driven once by InitializeAsync
+    // before the crawl, ADR-0033) reassigns this from the file content;
+    // the empty default is observable only if AddVisitedLinkAsync /
+    // GetVisitedLinksAsync are called before InitializeAsync — a
+    // sequencing error rather than a null deref.
+    private ConcurrentBag<string> _visitedLinks = new();
     
     public FileVisitedLinkedTracker(string fileName, bool dataCleanupOnStart = false)
     {

--- a/WebReaper/Core/Parser/Concrete/AngleSharpRawExtractor.cs
+++ b/WebReaper/Core/Parser/Concrete/AngleSharpRawExtractor.cs
@@ -10,7 +10,7 @@ namespace WebReaper.Core.Parser.Concrete;
 /// is set), inner-HTML (when <see cref="SchemaElement.GetHtml"/> is
 /// true), or text content (otherwise). The default is the AngleSharp
 /// <c>IElement</c>'s own <see cref="IElement.GetAttribute(string)"/> /
-/// <see cref="IElement.InnerHtml"/> / <see cref="IElement.Text"/>; a
+/// <see cref="IElement.InnerHtml"/> / <c>IElement.Text()</c>; a
 /// missing attribute returns <see cref="string.Empty"/>, never null.
 /// </summary>
 /// <remarks>

--- a/WebReaper/Domain/Agent/AgentResult.cs
+++ b/WebReaper/Domain/Agent/AgentResult.cs
@@ -33,8 +33,8 @@ namespace WebReaper.Domain.Agent;
 /// have already received each record (per-Extract fan-out, fork 9); this list
 /// is the in-process convenience copy.</param>
 /// <param name="TerminationReason">Human-readable explanation of why the run
-/// ended — the brain's <see cref="AgentDecision.Stop.Reason"/> when the brain
-/// stopped, otherwise the engine's cap label
+/// ended — the brain's <see cref="AgentDecision.Reason"/> on the <c>Stop</c>
+/// arm when the brain stopped, otherwise the engine's cap label
 /// (<c>"MaxSteps reached"</c>, <c>"MaxBudgetTokens (X) reached (spent=Y)"</c>,
 /// <c>"Scheduler drained"</c>).</param>
 /// <param name="History">Every <see cref="AgentDecision"/> the brain returned

--- a/WebReaper/Domain/Agent/AgentState.cs
+++ b/WebReaper/Domain/Agent/AgentState.cs
@@ -10,10 +10,10 @@ namespace WebReaper.Domain.Agent;
 /// <para>
 /// All collection-shaped fields are <em>capped</em> (fork 3 verdict — bounded
 /// history, bounded visited list, bounded candidate URLs, bounded current-page
-/// markdown). The caps live on the
-/// <see cref="WebReaper.AI.LlmAgentBrainOptions"/> so callers can widen them
-/// for richer brains. Token cost is the constraint; unbounded prompts are the
-/// first cause of cost runaway on long runs.
+/// markdown). The caps live on the satellite's <c>LlmAgentBrainOptions</c>
+/// (in <c>WebReaper.AI</c>) so callers can widen them for richer brains.
+/// Token cost is the constraint; unbounded prompts are the first cause of
+/// cost runaway on long runs.
 /// </para>
 /// </summary>
 /// <param name="Goal">The natural-language goal supplied at run start —

--- a/WebReaper/Domain/Parsing/SchemaElement.cs
+++ b/WebReaper/Domain/Parsing/SchemaElement.cs
@@ -9,8 +9,11 @@ namespace WebReaper.Domain.Parsing;
 public record SchemaElement()
 {
     /// <summary>An element that extracts text content for
-    /// <paramref name="field"/> via <c>Selector</c> set later.</summary>
-    public SchemaElement(string field) : this()
+    /// <paramref name="field"/> via <c>Selector</c> set later.
+    /// <paramref name="field"/> is nullable to support the root
+    /// <see cref="Schema"/> case (Field=null); the property
+    /// <see cref="Field"/> matches that nullability.</summary>
+    public SchemaElement(string? field) : this()
     {
         Field = field;
     }

--- a/WebReaper/Logging/ColorConsoleLogger.cs
+++ b/WebReaper/Logging/ColorConsoleLogger.cs
@@ -15,9 +15,13 @@ internal sealed class ColorConsoleLogger : ILogger
         [LogLevel.None] = ConsoleColor.Gray
     };
 
-    public IDisposable BeginScope<TState>(TState state)
+    // ILogger.BeginScope's interface signature is
+    // `IDisposable? BeginScope<TState>(TState state) where TState : notnull`
+    // — match it exactly to clear CS8633 (nullability + constraint
+    // mismatch). The body keeps returning null (no real scoping).
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
     {
-        return default!;
+        return null;
     }
 
     public bool IsEnabled(LogLevel logLevel)


### PR DESCRIPTION
**Independent of #133/#134/#135** — touches a different set of files (cleanup hygiene + CI). Can merge in any order.

## Two commits

### 1. `ci: bump actions/checkout to v6 and actions/setup-dotnet to v5`

GitHub deprecated Node.js 20 actions on 2025-09-19. The runner default flips to Node.js 24 on **June 2, 2026** (5 days from this PR). All five workflows used the Node-20-pinned `@v4` of these actions.

- `actions/checkout@v4` → `@v6` (latest v6.0.2, 2026-01-09)
- `actions/setup-dotnet@v4` → `@v5` (latest v5.2.0, 2026-03-05)

Files: `CI.yml`, `release.yml` (×8 occurrences), `WebReaperAzureFuncs.yml`, `claude-code-review.yml`, `claude.yml`.

### 2. `chore: clear all pre-existing build warnings (33 → 0)`

Solution went from **33 warnings on origin/master** to **0 warnings**. All pre-existing hygiene debt from before v10.0.0 — they were drowning out genuine new warnings in CI.

| Category | Count | Examples |
|---|---|---|
| Nullable (CS8602 / 8604 / 8618 / 8633) | 11 | `ConfigBuilder._startUrls`, `SpiderBuilder.Config`, `FileVisitedLinkedTracker._visitedLinks`, `ColorConsoleLogger.BeginScope`, `Schema → SchemaElement(string)` |
| XML doc (CS1572 / 1574 / 1734) | 7 | `IActionResolver paramref 'intent'`, `Crawl(IEnumerable<string>)` stale cref, `IElement.Text` (method, not property), `LlmAgentBrainOptions` (in satellite, not visible to core), `ScrapeFieldAttribute` param on class instead of ctor |
| Test infrastructure | 4 | Three ILogger.BeginScope variants in `CapturingLogger` / `TestOutputLogger`, one `xUnit1031` blocking-task test |
| Packaging | 2 | `WebReaper.Mcp.csproj` ModelContextProtocol bump (`0.5.0-preview.5` was yanked from NuGet → `0.6.0-preview.1`); `NoWarn="NU1510"` on the genuinely-used `System.Text.Encoding.CodePages` |
| Sample / utility | 5 | `BrownsfashionScraper.Worker._scraper`, `Misc/WebReaper.ProxyProviders.Proxy` (4 deserializer-populated props) |

See the commit message for the per-fix rationale (each was chosen with the local invariant in mind: nullable+forgive vs. default-initialize vs. fix the cref).

## What this PR does NOT do

- No public API surface changes (the four `With*` methods, the ILogger contract, etc. all preserve their semantics)
- No behaviour changes — all 409 unit + 240 AI tests pass unchanged
- No new ADRs (this is hygiene, not architecture)

## Tests

```
Build: 0 warnings, 0 errors (was 33 warnings on master)
Unit:  409 passed
AI:    240 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)