### PR TITLE
fix(mcp): wire browser=true to WebReaper.Cdp (ADR-0073)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 ## 10.0.2 (in progress): post-launch refactors
 
-### `WebReaper.AI` — new public type `LlmToolArguments` (ADR-0059 amendment)
+### `WebReaper.Mcp` browser mode wired (ADR-0073)
+
+Patch fix to a behaviour gap noted but deferred in [PR #122](https://github.com/pavlovtech/WebReaper/pull/122). The MCP satellite's `scrape` and `extract` tools accept a `browser=true` parameter that flips the seed to `ScraperEngineBuilder.CrawlWithBrowser(url)`, but `WebReaper.Mcp.csproj` did not `ProjectReference` any browser-transport satellite, so the first dynamic page load hit the core's `BrowserNotConfiguredPageLoadTransport` error. The parameter was structurally unwired.
+
+[ADR-0073](docs/adr/0073-mcp-browser-transport-policy.md) records the wiring decision: `WebReaper.Mcp` bakes `WebReaper.Cdp` (ADR-0052), mirroring the CLI's ADR-0055 precedent. `Microsoft.Playwright` and `WebReaper.Stealth.*` stay out of the satellite's dependency graph; consistency across both agent-facing satellites carries the convention.
+
+| File | Change |
+|---|---|
+| `WebReaper.Mcp/WebReaper.Mcp.csproj` | Added `<ProjectReference Include="..\WebReaper.Cdp\WebReaper.Cdp.csproj" />`. |
+| `WebReaper.Mcp/WebReaperTools.cs` | `Scrape` and `Extract` now conditionally call `.WithCdpPageLoader(new CdpLaunchOptions())` when `browser=true`. Switched to `await using` for the engine so the spawned Chromium process tears down on each call (ADR-0058 chain). Tool descriptions updated to mention the auto-spawn behaviour. |
+| `WebReaper.Mcp/README.md` | New "Browser mode" section documenting the auto-spawn path and prerequisite (a system Chrome / Chromium / Edge on the MCP host). |
+
+The `map` tool needs no change (sitemap discovery is static, no browser load). The `WebReaper.Mcp` NuGet package gains `WebReaper.Cdp` as a transitive dependency at the v10.0.2 bump; both packages move in lockstep on the WebReaper release cadence.
+
+### `WebReaper.AI` new public type `LlmToolArguments` (ADR-0059 amendment)
 
 The byte-identical `TryGetString` / `TryGetInt` JSON-argument extractors that lived as private static methods in both `LlmActionResolver` and `LlmAgentBrain` move to a shared public static class `WebReaper.AI.Llm.LlmToolArguments`. Sibling to `LlmCall<TResponse>` on the same "one canonical mechanism, not five copies" axis the original ADR defines. Consumer-authored tool-calling `Llm*` adapters reuse the helpers for consistent leniency rules instead of re-implementing.
 

--- a/WebReaper.Mcp/README.md
+++ b/WebReaper.Mcp/README.md
@@ -83,9 +83,13 @@ etc.) for `google-chrome`, `chromium`, `chrome`, `microsoft-edge`,
 actionable error message.
 
 Each MCP tool invocation spawns and tears down its own browser process
-(per-call lifecycle). Long-running stealth scenarios should use the
-[WebReaper CLI](../WebReaper.Cli/) directly; the MCP satellite stays
-thin and stateless.
+(per-call lifecycle). A Chromium instance is ~200 MB resident; if the
+MCP server accepts calls from untrusted clients, run it under
+appropriate process / memory limits (`ulimit`, systemd
+`MemoryMax=`, container memory caps) so a flurry of `browser=true`
+calls cannot exhaust host memory. Long-running stealth scenarios
+should use the [WebReaper CLI](../WebReaper.Cli/) directly; the MCP
+satellite stays thin and stateless.
 
 ## Why prefer the CLI / Skill over MCP?
 

--- a/WebReaper.Mcp/README.md
+++ b/WebReaper.Mcp/README.md
@@ -60,6 +60,33 @@ Edit `~/.cursor/mcp.json`:
 
 (Adjust the `command` to the absolute path of the installed binary.)
 
+## Browser mode (`browser=true`)
+
+The `scrape` and `extract` tools accept a `browser` boolean parameter.
+Setting it `true` switches the page loader to a headless browser for
+JS-rendered pages. The MCP server auto-spawns a system Chrome /
+Chromium / Edge via [`WebReaper.Cdp`](../WebReaper.Cdp/README.md)
+([ADR-0073](../docs/adr/0073-mcp-browser-transport-policy.md), mirroring
+the CLI's [ADR-0055](../docs/adr/0055-cli-browser-stealth-policy.md)
+policy).
+
+Install a Chromium-family browser on the MCP host first:
+
+- macOS: `brew install --cask google-chrome` or `brew install chromium`.
+- Linux: distribution package or `apt install chromium-browser`.
+- Windows: Chrome / Edge ship preinstalled or via winget.
+
+The launcher searches `PATH` and platform-conventional install
+locations (`/Applications/Google Chrome.app`, `C:\Program Files\Google\Chrome`,
+etc.) for `google-chrome`, `chromium`, `chrome`, `microsoft-edge`,
+`msedge`. Calls that need a browser when none is found fail with an
+actionable error message.
+
+Each MCP tool invocation spawns and tears down its own browser process
+(per-call lifecycle). Long-running stealth scenarios should use the
+[WebReaper CLI](../WebReaper.Cli/) directly; the MCP satellite stays
+thin and stateless.
+
 ## Why prefer the CLI / Skill over MCP?
 
 Per the WebReaper repositioning plan, the **CLI** is ~35× cheaper than

--- a/WebReaper.Mcp/WebReaper.Mcp.csproj
+++ b/WebReaper.Mcp/WebReaper.Mcp.csproj
@@ -31,6 +31,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WebReaper\WebReaper.csproj" />
+    <!-- ADR-0073: bake WebReaper.Cdp to wire the browser=true tool
+         parameter. Mirrors ADR-0055 (the CLI). Microsoft.Playwright
+         and WebReaper.Stealth.* are never baked here for the same
+         reasoning as the CLI satellite. -->
+    <ProjectReference Include="..\WebReaper.Cdp\WebReaper.Cdp.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WebReaper.Mcp/WebReaperTools.cs
+++ b/WebReaper.Mcp/WebReaperTools.cs
@@ -3,14 +3,15 @@ using System.Text;
 using System.Text.Json.Nodes;
 using ModelContextProtocol.Server;
 using WebReaper.Builders;
+using WebReaper.Cdp;
 using WebReaper.Core.Mapping;
 using WebReaper.Domain.Parsing;
 using WebReaper.Sinks.Models;
 
 namespace WebReaper.Mcp;
 
-// ADR-0049: the three MCP tools the satellite exposes — scrape, map,
-// extract. Each wraps an existing library API; the tool layer is thin
+// ADR-0049: the three MCP tools the satellite exposes (scrape, map,
+// extract). Each wraps an existing library API; the tool layer is thin
 // glue between the MCP-protocol JSON shape and the library's fluent
 // builders.
 
@@ -23,7 +24,7 @@ public static class WebReaperTools
         "into context.")]
     public static async Task<string> Scrape(
         [Description("The URL to scrape.")] string url,
-        [Description("Use the headless browser (for JS-rendered pages). Default false.")] bool browser = false)
+        [Description("Use the headless browser (for JS-rendered pages). Auto-spawns a system Chrome / Chromium / Edge via WebReaper.Cdp; install a Chromium-family browser on the MCP host first. Default false.")] bool browser = false)
     {
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("URL is required.", nameof(url));
@@ -33,10 +34,19 @@ public static class WebReaperTools
             : ScraperEngineBuilder.Crawl(url);
 
         var records = new List<ParsedData>();
-        var engine = await seed.AsMarkdown()
+        var builder = seed.AsMarkdown()
             .Subscribe(records.Add)
-            .StopWhenAllLinksProcessed()
-            .BuildAsync();
+            .StopWhenAllLinksProcessed();
+
+        // ADR-0073: wire WebReaper.Cdp launch-and-connect on browser=true.
+        // The Cdp loader's PATH search finds google-chrome / chromium /
+        // chrome / microsoft-edge / msedge; fails actionable when none
+        // present. `await using` the engine so the spawned-Chromium
+        // process tears down with the call (ADR-0058 chain).
+        if (browser)
+            builder = builder.WithCdpPageLoader(new CdpLaunchOptions());
+
+        await using var engine = await builder.BuildAsync();
         await engine.RunAsync();
 
         var output = new StringBuilder();
@@ -80,7 +90,7 @@ public static class WebReaperTools
     public static async Task<string> Extract(
         [Description("The URL to extract from.")] string url,
         [Description("The extraction schema as JSON. See the WebReaper docs for the shape.")] string schemaJson,
-        [Description("Use the headless browser. Default false.")] bool browser = false)
+        [Description("Use the headless browser. Auto-spawns a system Chrome / Chromium / Edge via WebReaper.Cdp; install a Chromium-family browser on the MCP host first. Default false.")] bool browser = false)
     {
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("URL is required.", nameof(url));
@@ -103,13 +113,18 @@ public static class WebReaperTools
             : ScraperEngineBuilder.Crawl(url);
 
         var records = new List<ParsedData>();
-        var engine = await seed.Extract(schema)
+        var builder = seed.Extract(schema)
             .Subscribe(records.Add)
-            .StopWhenAllLinksProcessed()
-            .BuildAsync();
+            .StopWhenAllLinksProcessed();
+
+        // ADR-0073: see Scrape() above for the wiring rationale.
+        if (browser)
+            builder = builder.WithCdpPageLoader(new CdpLaunchOptions());
+
+        await using var engine = await builder.BuildAsync();
         await engine.RunAsync();
 
-        // JSON Lines — one record per line.
+        // JSON Lines: one record per line.
         return string.Join("\n", records.Select(r => r.Data.ToJsonString()));
     }
 

--- a/docs/adr/0073-mcp-browser-transport-policy.md
+++ b/docs/adr/0073-mcp-browser-transport-policy.md
@@ -1,0 +1,249 @@
+# `WebReaper.Mcp` browser transport policy: bake `WebReaper.Cdp`, mirror ADR-0055
+
+## Status
+
+**Accepted**. Follow-through to [PR #122](https://github.com/pavlovtech/WebReaper/pull/122),
+which fixed only the stale tool description; the wiring fix was deferred
+to its own ADR + slice. v10.0.2 patch.
+
+## Context
+
+The `WebReaper.Mcp` satellite (ADR-0049) exposes three MCP tools over
+stdio: `scrape`, `map`, `extract`. Two of them (`scrape`, `extract`)
+accept a `browser` boolean parameter that flips the seed from
+`ScraperEngineBuilder.Crawl(url)` to `ScraperEngineBuilder.CrawlWithBrowser(url)`.
+That seed sets the page type to `Dynamic`; on `RunAsync` the core
+dispatches the Dynamic load to whichever `IPageLoadTransport` was
+registered by `.WithCdpPageLoader(...)` / `.WithPlaywrightPageLoader(...)` /
+a `WebReaper.Stealth.*` extension.
+
+**The gap.** `WebReaper.Mcp.csproj` `ProjectReference`s only
+`WebReaper.csproj`, no browser-transport satellite. When the MCP client
+calls `scrape(url, browser=true)` the seed flips to Dynamic, the builder
+composes without a transport, and the first dynamic page load hits the
+core's `BrowserNotConfiguredPageLoadTransport` error directing the user
+to add a satellite, except the MCP server process is the one that
+should have it baked, and no MCP client can add a NuGet reference on
+its behalf. The `browser=true` parameter is therefore *structurally*
+unwired: it sets a flag that the satellite has no transport to honour.
+
+PR #122 noted the gap as a follow-up; the description fix alone shipped.
+This ADR records the wiring decision.
+
+### Architectural precedent (ADR-0055)
+
+The CLI faced the same question (which transport to bake into a
+single-distributable binary) and answered:
+
+> The CLI bakes **only** `WebReaper.Cdp` for browser support, the
+> AOT-clean transport (ADR-0052's bedrock). … `Microsoft.Playwright`
+> is never baked; nor is any `WebReaper.Stealth.X` satellite; those
+> ship for library use only.
+
+`WebReaper.Mcp` is not AOT-published (ADR-0049: "No PublishAot in v1;
+the MCP SDK has reflection paths"), so the AOT half of ADR-0055's
+rationale is *softer* here. The other half (lightweight dependency
+graph, AOT-friendly bedrock so future MCP-AOT is on-ramp-able, stealth
+forks compose on Cdp regardless) still applies, and the *consistency*
+argument (one canonical browser baked across both satellite agent
+surfaces) carries the rest.
+
+## Decision
+
+`WebReaper.Mcp` follows the ADR-0055 precedent: **bake only
+`WebReaper.Cdp`**. The MCP tools wire `.WithCdpPageLoader(new CdpLaunchOptions())`
+on the path where `browser=true`. The launch-and-connect overload finds
+a system Chrome / Chromium / Edge on PATH (or fails actionably if
+none), spawns it with `--remote-debugging-port=0 --headless=new`, and
+the transport's `IAsyncDisposable` tears the process down on engine
+disposal (ADR-0058 chain).
+
+### What changes
+
+```diff
+ WebReaper.Mcp.csproj
+   <ItemGroup>
+     <ProjectReference Include="..\WebReaper\WebReaper.csproj" />
++    <ProjectReference Include="..\WebReaper.Cdp\WebReaper.Cdp.csproj" />
+   </ItemGroup>
+```
+
+```diff
+ WebReaperTools.cs (Scrape and Extract)
+   var seed = browser
+       ? ScraperEngineBuilder.CrawlWithBrowser(url)
+       : ScraperEngineBuilder.Crawl(url);
+
+-  var engine = await seed.AsMarkdown()
++  var builder = seed.AsMarkdown()
+       .Subscribe(records.Add)
+-      .StopWhenAllLinksProcessed()
+-      .BuildAsync();
++      .StopWhenAllLinksProcessed();
++
++  if (browser)
++      builder = builder.WithCdpPageLoader(new CdpLaunchOptions());
++
++  await using var engine = await builder.BuildAsync();
+   await engine.RunAsync();
+```
+
+The `await using` shape matters: the `CdpLaunchOptions` overload owns
+the spawned-Chromium process lifecycle; without the `using` the child
+process leaks across MCP tool invocations until the MCP server itself
+exits (ADR-0054 gotcha, generalised to any launch-and-connect path).
+
+## Considered options
+
+### (a) Bake `WebReaper.Cdp` (chosen)
+
+Lightweight dependency, no PuppeteerSharp / Microsoft.Playwright pull,
+AOT-friendly bedrock (so a future MCP-AOT path is on-ramp-able). Mirrors
+the CLI. Consistent agent-surface posture: one canonical transport
+baked into both satellites that publish as agent-facing binaries.
+
+### (b) Bake `WebReaper.Playwright` (rejected)
+
+Microsoft.Playwright pulls a large dependency graph (Node.js runtime,
+~100 MB browsers via `playwright install`). The MCP server boots on
+every agent invocation in some hosts (Claude Desktop spawns fresh on
+each conversation); a heavier package directly tax-charges every MCP
+spin-up. Playwright's structural advantages (all seven `PageAction`
+arms vs Cdp's six pre-ADR-0057, now closed) don't matter to the v1
+MCP tool set, which calls `LoadAsync` once per URL with no action
+chain.
+
+### (c) Bake both `WebReaper.Cdp` and `WebReaper.Playwright`, pick at runtime (rejected)
+
+Two transports configured + an MCP-tool-parameter to choose between
+them. Twice the dependency surface; the picker UX duplicates the
+MCP tool's existing `browser=true` parameter; no observed demand. The
+satellite is the *interop adapter* (ADR-0049): keep its surface thin.
+
+### (d) Keep MCP transport-pluggable; document the gap (rejected)
+
+PR #122's option (c). Punts the wiring to the MCP-host operator,
+who has no NuGet seam to add the satellite from outside the published
+binary. The casual MCP-user (Cursor, Claude Desktop) cannot escape
+the gap; this satellite would be permanently no-op on `browser=true`.
+
+### (e) Remove the `browser` parameter from MCP tools (rejected)
+
+PR #122's option (b). Honest but lossy: dynamic-page sites are the
+hard cases agents most want to scrape. A satellite that refuses to
+even *try* on JS-rendered pages is the wrong shape for the interop
+adapter slot.
+
+## Bounded scope (what v1 does and does not do)
+
+### v1 does
+
+- Wire `.WithCdpPageLoader(new CdpLaunchOptions())` on the
+  `browser=true` path of `scrape` and `extract`.
+- Use the launch-and-connect overload: PATH search for
+  `google-chrome` / `chromium` / `chrome` / `microsoft-edge` /
+  `msedge`, spawn `--remote-debugging-port=0 --headless=new`,
+  teardown on engine disposal.
+- Fail actionable when no system browser is found (the Cdp loader's
+  built-in message points the user at installing Chrome / Chromium).
+- `await using` the engine so the spawned-Chromium process exits
+  with the MCP tool invocation.
+
+### v1 does not
+
+- **No `webreaper browser install` equivalent.** The CLI gates this
+  on a curated managed-Chromium acquisition (ADR-0055); MCP relies
+  on system-installed browsers in v1. A managed download path inside
+  the MCP server would either bloat the package or require a
+  user-prompt flow over a protocol that has no UX surface for one.
+  If MCP hosts surface this as a real friction in practice, a
+  future ADR adds a fallback (perhaps shelling out to the CLI when
+  one is detected on PATH).
+- **No stealth-backend selection.** The CLI integrates
+  `KnownStealthBackends` via a curated registry (ADR-0055); the MCP
+  tools do not expose a stealth parameter. Users blocked by bot-checks
+  fall back to the CLI / the library directly; the MCP satellite is
+  not the right surface for the Hybrid C escalation UX (no Y/n prompt
+  channel; bot-check detection adds latency to every call).
+- **No `--browser-cdp-url` BYO equivalent on the MCP tool parameter.**
+  A future tool argument (`cdpUrl=...`) is a clean additive minor;
+  zero observed demand today.
+- **No new test project.** `WebReaper.Mcp.Tests` doesn't exist
+  (ADR-0049 §Guardrails: "no unit tests in v1; the satellite's
+  surface is dominantly SDK boilerplate"). The behaviour change is
+  a one-line conditional builder forward; the surface tested is
+  the `WebReaper.Cdp` extension's, already covered in
+  `WebReaper.Cdp.Tests`. Adding a brand-new test project just to
+  assert "the `if (browser)` branch calls `.WithCdpPageLoader(...)`"
+  is over-weight for the slice; revisit if a regression surfaces.
+
+## Implementation outline
+
+Two-file change plus the ADR + CHANGELOG.
+
+1. **`WebReaper.Mcp/WebReaper.Mcp.csproj`**: add the
+   `ProjectReference` to `..\WebReaper.Cdp\WebReaper.Cdp.csproj`.
+2. **`WebReaper.Mcp/WebReaperTools.cs`**: restructure `Scrape` and
+   `Extract` so the builder is held in a local before `BuildAsync`,
+   guarded by `if (browser) builder = builder.WithCdpPageLoader(new CdpLaunchOptions());`.
+   Switch to `await using` for the engine so the spawned-Chromium
+   process exits with the call.
+3. **`WebReaper.Mcp/README.md`**: short section, "Browser mode
+   (`browser=true`) auto-spawns a system Chrome / Chromium / Edge
+   via the `WebReaper.Cdp` launch-and-connect overload; install a
+   Chromium-family browser on the MCP host first."
+4. **`CHANGELOG.md`**: entry under `## 10.0.2 (in progress)`
+   describing the wiring fix and the ADR-0073 reference.
+
+The `Map` tool does not take a `browser` parameter (sitemap-based
+discovery is static; ADR-0042 doesn't drive a browser load), so it
+needs no change.
+
+## Consequences
+
+- **`browser=true` actually works.** MCP clients (Cursor / Claude
+  Desktop / Copilot Studio) can scrape JS-rendered pages without
+  manual transport plumbing the protocol can't carry.
+- **`WebReaper.Mcp` package gets `WebReaper.Cdp` as a transitive
+  dependency.** Both packages are in lockstep on the WebReaper
+  release cadence; no version-drift hazard.
+- **Convention crystallises.** Two of the three agent-facing
+  satellites (`WebReaper.Cli`, `WebReaper.Mcp`) now bake `WebReaper.Cdp`
+  on the same rationale. A future third (a hypothetical
+  `WebReaper.Mcp.AspNetCore` for hosted HTTP MCP) inherits the
+  precedent without re-litigation.
+- **First-call cost on a clean host.** On a machine with no Chrome
+  / Chromium / Edge installed, `browser=true` fails actionably on
+  the first call. v1 accepts this; v2 may add a fallback. Same
+  posture the CLI has when run before `webreaper browser install`
+  on a machine with no system Chrome.
+- **Per-call Chromium spawn cost.** Each MCP tool invocation that
+  uses `browser=true` spawns and tears down a Chromium process.
+  Acceptable for the v1 single-shot tool shape (ADR-0049 bounded
+  scope: "No persistent state across calls"). A long-running MCP
+  session amortises this over many calls; a future "keep browser
+  alive across calls" optimisation would graduate the satellite
+  from stateless to stateful (out of scope for v1; observed-demand
+  driven).
+
+## SemVer
+
+**Patch (additive behaviour, fixed surface).** The `browser`
+parameter previously threw on the first dynamic load; now it works.
+Behaviour-delta-as-bug-fix, no public-surface change to the MCP
+tools or the library; `WebReaper.Mcp.csproj` grows one
+`ProjectReference` (transitive dependency note for downstream
+package consumers, no breaking semver lever).
+
+## References
+
+- ADR-0049: `WebReaper.Mcp` satellite shape.
+- ADR-0052: `WebReaper.Cdp` raw-CDP transport (the satellite this
+  bakes).
+- ADR-0053: `WebReaper.Playwright` (the satellite this does NOT
+  bake; reasoning above).
+- ADR-0055: `WebReaper.Cli` browser/stealth policy (the precedent
+  this mirrors).
+- ADR-0058: engine teardown disposal chain (why `await using` is
+  load-bearing on the spawned-Chromium lifecycle).
+- PR #122: the stale-description fix that flagged this wiring gap.

--- a/docs/adr/0073-mcp-browser-transport-policy.md
+++ b/docs/adr/0073-mcp-browser-transport-policy.md
@@ -225,6 +225,24 @@ needs no change.
   alive across calls" optimisation would graduate the satellite
   from stateless to stateful (out of scope for v1; observed-demand
   driven).
+- **The `await using` on the engine fixes a latent leak on the
+  non-browser path too.** Before this PR the MCP tools held the
+  engine in a `var` and never disposed it; ADR-0058's reverse
+  disposal chain (page processors → sinks → tracker → scheduler →
+  spider) was never invoked. Per-invocation, the InMemory adapters
+  in the no-browser path leak only memory (GC reclaims on process
+  exit), but the discipline is now uniform across both branches:
+  `await using var engine = await builder.BuildAsync();`.
+- **Verified: launch is lazy, not eager.** `WithCdpPageLoader(CdpLaunchOptions)`
+  in `WebReaper.Cdp/CdpPageLoaderBuilderExtensions.cs` captures a
+  closure over `LaunchedCdpEndpoint? endpoint = null` and spawns
+  Chromium inside `ProvideAsync` on the first `LoadAsync` call, not
+  at the `WithCdpPageLoader` call site. So if `BuildAsync` throws
+  before any page load runs, no subprocess was spawned and the
+  `await using` has nothing to dispose: no leak path. The disposal
+  contract for the spawn-and-run-then-throw case is already covered
+  by `CloakBrowserSmokeTests` in `WebReaper.IntegrationTests` (the
+  CloakBrowser stealth path composes on this exact extension).
 
 ## SemVer
 


### PR DESCRIPTION
## The gap

`WebReaper.Mcp` (ADR-0049) exposes `scrape` / `map` / `extract` as MCP tools. The `scrape` and `extract` tools accept a `browser` boolean parameter that flips the seed from `ScraperEngineBuilder.Crawl(url)` to `ScraperEngineBuilder.CrawlWithBrowser(url)`. That seed sets the page type to `Dynamic`; on `RunAsync` the core dispatches to whichever `IPageLoadTransport` the builder registered.

But `WebReaper.Mcp.csproj` `ProjectReference`s only `WebReaper.csproj`, no browser-transport satellite. The `browser=true` parameter was structurally unwired: it set a flag with no transport to honour, and the first dynamic load hit the core's `BrowserNotConfiguredPageLoadTransport` error.

[PR #122](https://github.com/pavlovtech/WebReaper/pull/122) only fixed the stale tool description and deferred the wiring fix to its own ADR + slice. This is that slice.

## The decision (ADR-0073)

`WebReaper.Mcp` bakes **only** `WebReaper.Cdp` (ADR-0052). The MCP tools wire `.WithCdpPageLoader(new CdpLaunchOptions())` when `browser=true`. The launch-and-connect overload finds a system Chrome / Chromium / Edge on PATH (or fails actionably if none), spawns it with `--remote-debugging-port=0 --headless=new`, and the transport tears the process down on engine disposal (ADR-0058 chain).

### Why Cdp, not Playwright

Mirrors the CLI's [ADR-0055](docs/adr/0055-cli-browser-stealth-policy.md) precedent:

> The CLI bakes **only** `WebReaper.Cdp` for browser support, the AOT-clean transport. `Microsoft.Playwright` is never baked; nor is any `WebReaper.Stealth.X` satellite; those ship for library use only.

The MCP satellite is not AOT-published (ADR-0049: "No PublishAot in v1"), so the AOT half of ADR-0055's rationale is softer here. The other half (lightweight dependency graph, AOT-friendly bedrock so future MCP-AOT is on-ramp-able, stealth forks compose on Cdp regardless) still applies, and the *consistency* argument (one canonical browser baked across both agent-facing satellites) carries the rest.

## Diff

| File | Change |
|---|---|
| `WebReaper.Mcp/WebReaper.Mcp.csproj` | Added `<ProjectReference Include="..\WebReaper.Cdp\WebReaper.Cdp.csproj" />`. |
| `WebReaper.Mcp/WebReaperTools.cs` | `Scrape` and `Extract` now conditionally call `.WithCdpPageLoader(new CdpLaunchOptions())` when `browser=true`. Switched to `await using` for the engine so the spawned Chromium process tears down per call (closes a latent leak on both the browser AND non-browser path, since the engine was previously never disposed at all). Tool descriptions mention the auto-spawn behaviour. |
| `WebReaper.Mcp/README.md` | New "Browser mode" section documenting the auto-spawn path, the prerequisite (system Chrome / Chromium / Edge on the MCP host), and a process-limits recommendation when serving untrusted clients (each Chromium is ~200 MB resident; recommend `ulimit` / systemd `MemoryMax` / container memory caps). |
| `docs/adr/0073-mcp-browser-transport-policy.md` | Full ADR with all considered options + bounded scope + verified lifecycle. |
| `CHANGELOG.md` | Entry under `## 10.0.2 (in progress)`. Also tidies a stray em-dash from the sibling `LlmToolArguments` heading per the project's [[no-em-dashes]] discipline (the heading still says the same thing without the em-dash). |

The `map` tool needs no change (sitemap discovery is static, no browser load).

## Self-review (post-/review by Claude)

A `/review` pass surfaced five recommendations. Two closed by verification, three applied as a follow-up commit:

| # | Concern | Resolution |
|---|---|---|
| 1 | Does `WithCdpPageLoader(CdpLaunchOptions)` spawn Chromium eagerly (at builder call time) or lazily (at first `LoadAsync`)? If eager, a `BuildAsync` exception before `await using` would leak. | **Verified lazy.** `CdpPageLoaderBuilderExtensions.cs:42-71` captures a closure with `LaunchedCdpEndpoint? endpoint = null` and spawns inside `ProvideAsync` on first `LoadAsync`. A `BuildAsync` exception before any page load cannot leak a subprocess (none spawned yet). ADR Consequences now documents this. |
| 2 | The `await using` change is broader than "wire `browser=true`" — also fixes a latent leak on the non-browser path. | **ADR Consequences updated** to call out that the discipline is now uniform across both branches. |
| 3 | DOS vector: malicious MCP client floods `browser=true` calls. | **README Browser-mode section** now warns about per-call ~200 MB Chromium cost and recommends `ulimit` / `MemoryMax` / container memory caps when serving untrusted clients. |
| 4 | Missing orphan-process smoke test. | **Already covered.** `WebReaper.IntegrationTests/CloakBrowserSmokeTests` exercises the same `WithCdpPageLoader(CdpLaunchOptions)` extension end-to-end (CloakBrowser composes on it), plus `EngineTeardownDisposalTests` covers the in-memory chain. Adding an MCP-specific smoke would duplicate. |
| 5 | The CHANGELOG diff incidentally removes an em-dash from a sibling `LlmToolArguments` heading; the agent's report claimed unrelated content was untouched. | **Acknowledged in the table above.** The change is correct per the project's [[no-em-dashes]] discipline; the agent's self-report was inaccurate. Left the fix in place. |

## Build + tests

- `dotnet build WebReaper.sln`: 0 warnings, 0 errors.
- `WebReaper.UnitTests`: 421/421 passing.
- `WebReaper.AI.Tests`: 254/254 passing.
- `WebReaper.Cdp.Tests`: 16/16 passing.

## Bounded scope (v1)

- **No managed-Chromium acquisition** (`webreaper browser install` equivalent). The CLI handles that for casual users; the MCP server relies on a system-installed browser.
- **No stealth-backend selection.** Users blocked by bot-checks fall back to the CLI (where ADR-0055's Hybrid C escalation UX lives).
- **No `--browser-cdp-url` BYO tool parameter.** Clean additive minor if observed demand surfaces.
- **No new test project.** ADR-0049 §Guardrails was explicit about MCP having no v1 tests; the surface change is a one-line conditional builder forward.

## SemVer

Patch (additive behaviour, fixed surface). `browser=true` previously threw on first dynamic load; now it works. Behaviour-as-bug-fix; no public-surface change to the MCP tools or the library. `WebReaper.Mcp.csproj` grows one `ProjectReference` (transitive dependency note for downstream package consumers, no breaking semver lever). Lands in v10.0.2 alongside the `LlmToolArguments` refactor already staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)