### PR TITLE
chore: drop stale PR #134 dependency notes from ADR-0074 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,6 @@ The `LlmActionResolver` whitelist extends from four shapes to seven; the brain r
 | `WebReaper.AI/LlmActionResolver.cs` | Prompt whitelist extends to mention the three new shapes. `ParseActionTool` switch gains one line per arm (PR #134 uniform pattern). |
 | `WebReaper.AI/LlmAgentBrain.cs` | `ParseDecisionTool` gains one line per arm. |
 
-### Implementation note: depends on PR #134 landing first
-
-[ADR-0074 §References](docs/adr/0074-pageaction-form-interaction-primitives.md) records that the arm-local tool projection pattern (PR #134) is stranded on master at the time of this entry (the [[stacked-pr-merge-gotcha]] auto-merged it into a deleted base branch). The re-apply is in flight on `chore/re-apply-pr-134-arm-local-tool-projection`; the file-edit count above assumes it has landed. Against master's current flat-factory shape (without PR #134), the satellite-side cost is ~70 more lines per arm in the brain + resolver switch statements; same arms, more editing.
-
 ## 10.0.2 (in progress): post-launch refactors
 
 ### `WebReaper.Mcp` browser mode wired (ADR-0073)

--- a/docs/adr/0074-pageaction-form-interaction-primitives.md
+++ b/docs/adr/0074-pageaction-form-interaction-primitives.md
@@ -647,12 +647,10 @@ are both additive-public-types).
   [Considered options (m)](#m-mcp-scrape--extract-tool-surface-for-the-new-arms)).
 - PR #134 (`refactor(ai): arm-local tool projection`): the arm-local
   `PageActionTools.<Arm>` pattern this ADR's tool-registry additions
-  follow. Stranded by the [[stacked-pr-merge-gotcha]] on master at
-  the time of this draft; re-apply in flight on
-  `chore/re-apply-pr-134-arm-local-tool-projection`. ADR-0074
-  implementation depends on the re-apply landing first; the cost
-  numbers in [§ Implementation outline](#implementation-outline)
-  assume the post-#134 file layout.
+  follow. Re-applied via PR #139 (the original was stranded by the
+  [[stacked-pr-merge-gotcha]]); the post-#134 file layout is on
+  master, and the cost numbers in [§ Implementation outline](#implementation-outline)
+  assume that layout.
 - Firecrawl `/scrape` API reference
   (`https://docs.firecrawl.dev/api-reference/endpoint/scrape`): the
   9-action-types vocabulary this ADR achieves parity against (closing


### PR DESCRIPTION
PR #139 re-applied PR #134's arm-local tool projection onto master. Two stale references remained from the ADR-0074 design pass:

* [docs/adr/0074-pageaction-form-interaction-primitives.md](docs/adr/0074-pageaction-form-interaction-primitives.md) §References described PR #134 as "stranded" with a "re-apply in flight" — replaced with one sentence noting the re-apply via PR #139.
* [CHANGELOG.md](CHANGELOG.md) `## 10.1.0 (in progress)` carried an "Implementation note: depends on PR #134 landing first" subsection — deleted entirely, since the file-edit ledger above it now matches reality.

Found while editing the implementation-issue bodies (#142, #143, #144) and PRD #141 after the user flagged the repeated stale-blocker mentions. Issues are already updated; this PR cleans the docs on master.

No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)