### PR TITLE
feat(perf): parameterized real-site mode for the throughput harness

### DIFF
--- a/WebReaper.Tests/WebReaper.Perf/Program.cs
+++ b/WebReaper.Tests/WebReaper.Perf/Program.cs
@@ -1,18 +1,33 @@
 // WebReaper throughput harness. Not a gated test — a `dotnet run` tool that
-// crawls the deterministic local site and reports pages/sec + peak memory at
-// a range of parallelism degrees, plus a small HTTP-vs-CDP per-page cost row.
+// measures end-to-end crawl speed (load -> extract -> emit), the number that
+// matters for "how fast does it scrape", not a micro-benchmark of one method.
 //
+// Local synthetic mode (default) — the engine ceiling, no network:
 //   dotnet run -c Release --project WebReaper.Tests/WebReaper.Perf [pageCount]
 //
-// There is no BenchmarkDotNet dependency: this measures the end-to-end crawl
-// (load → extract → emit), which is the number that matters for "how fast does
-// it scrape", not a micro-benchmark of one method.
+// Real-site mode — network-bound, any target (first arg is an http(s) URL):
+//   dotnet run -c Release --project WebReaper.Tests/WebReaper.Perf \
+//       <url> <follow-css> [field=css ...]
+//   e.g. ... "https://books.toscrape.com/catalogue/page-1.html" \
+//            "article.product_pod h3 a" "title=.product_main h1" "price=.price_color"
+//   With no field=css pairs it extracts markdown. Compare the real pages/sec
+//   against the local ceiling to see how much is the network vs the engine.
+//
+// There is no BenchmarkDotNet dependency.
 
 using System.Diagnostics;
 using WebReaper.Builders;
 using WebReaper.Cdp;
 using WebReaper.Domain.Parsing;
 using WebReaper.TestServer;
+
+// Real-site mode dispatch: first arg is an http(s) URL.
+if (args is [var maybeUrl, ..] &&
+    (maybeUrl.StartsWith("http://") || maybeUrl.StartsWith("https://")))
+{
+    await BenchmarkRealSite(args);
+    return;
+}
 
 var pageCount = args.Length > 0 && int.TryParse(args[0], out var n) ? n : 300;
 
@@ -83,4 +98,71 @@ static async Task<TimeSpan> CrawlCdp(LocalTestSite site, int count, int degree)
     }
     sw.Stop();
     return sw.Elapsed;
+}
+
+// ---- Real-site mode -------------------------------------------------------
+
+static async Task BenchmarkRealSite(string[] args)
+{
+    var url = args[0];
+    if (args.Length < 2)
+    {
+        Console.Error.WriteLine(
+            "Usage: <url> <follow-css> [field=css ...]\n" +
+            "  e.g. \"https://books.toscrape.com/catalogue/page-1.html\" " +
+            "\"article.product_pod h3 a\" \"title=.product_main h1\"");
+        return;
+    }
+    var followSelector = args[1];
+
+    // Build the extraction schema from field=css pairs (split on the first '=').
+    // No pairs => markdown extraction.
+    var schema = new Schema();
+    foreach (var pair in args.Skip(2))
+    {
+        var eq = pair.IndexOf('=');
+        var field = eq > 0 ? pair[..eq] : "";
+        var selector = eq > 0 ? pair[(eq + 1)..] : "";
+        if (string.IsNullOrWhiteSpace(field) || string.IsNullOrWhiteSpace(selector))
+        {
+            Console.Error.WriteLine($"  (ignoring malformed field spec: '{pair}'; want field=css)");
+            continue;
+        }
+        schema.Add(new SchemaElement(field, selector));
+    }
+
+    var extract = schema.Count > 0 ? string.Join(", ", schema.Select(e => e.Field)) : "markdown";
+    Console.WriteLine($"Real-site (network-bound) -- {url}");
+    Console.WriteLine($"Follow: {followSelector}   Extract: {extract}\n");
+    Console.WriteLine($"{"parallelism",-13}{"pages",-8}{"elapsed (s)",-14}{"pages/sec",-12}{"wall ms/page",-13}");
+    Console.WriteLine(new string('-', 60));
+
+    foreach (var degree in new[] { 1, 5, 10, 20 })
+    {
+        var (pages, elapsed) = await CrawlReal(url, followSelector, schema, degree);
+        var perSec = pages == 0 ? 0 : pages / elapsed.TotalSeconds;
+        var msPerPage = pages == 0 ? 0 : elapsed.TotalMilliseconds / pages;
+        Console.WriteLine($"{degree,-13}{pages,-8}{elapsed.TotalSeconds,-14:F2}{perSec,-12:F1}{msPerPage,-13:F0}");
+    }
+    Console.WriteLine("\n(p=1 wall ms/page is the real per-page latency; higher parallelism amortizes it.)");
+}
+
+static async Task<(int pages, TimeSpan elapsed)> CrawlReal(
+    string url, string followSelector, Schema schema, int degree)
+{
+    var pages = 0;
+    var sw = Stopwatch.StartNew();
+    var seed = ScraperEngineBuilder.Crawl(url);
+    var builder = schema.Count > 0 ? seed.Extract(schema) : seed.AsMarkdown();
+    await using (var engine = await builder
+        .Follow(followSelector)
+        .WithParallelismDegree(degree)
+        .Subscribe(_ => Interlocked.Increment(ref pages))
+        .StopWhenAllLinksProcessed()
+        .BuildAsync())
+    {
+        await engine.RunAsync();
+    }
+    sw.Stop();
+    return (pages, sw.Elapsed);
 }

--- a/docs/testing/manual-test-plan.md
+++ b/docs/testing/manual-test-plan.md
@@ -43,8 +43,12 @@ dotnet test WebReaper.Tests/WebReaper.IntegrationTests --filter "Category=Llm"
 dotnet test WebReaper.Tests/WebReaper.IntegrationTests --filter "Category=Mcp"
 dotnet test WebReaper.Tests/WebReaper.IntegrationTests --filter "Category=Perf"
 
-# Throughput numbers (not asserted)
+# Throughput numbers (not asserted) — local synthetic ceiling
 dotnet run -c Release --project WebReaper.Tests/WebReaper.Perf 500
+# Network-bound, any real site: <url> <follow-css> [field=css ...]
+dotnet run -c Release --project WebReaper.Tests/WebReaper.Perf \
+  "https://books.toscrape.com/catalogue/page-1.html" \
+  "article.product_pod h3 a" "title=.product_main h1" "price=.price_color"
 
 # Dockerized install.sh smoke (network + Docker)
 scripts/test-install.sh


### PR DESCRIPTION
## What

A parameterized real-site mode for the perf harness, so it can benchmark any target, not just the local synthetic server. First arg as an http(s) URL switches modes:

    dotnet run -c Release --project WebReaper.Tests/WebReaper.Perf \
      <url> <follow-css> [field=css ...]

No `field=css` pairs falls back to markdown extraction. The default local synthetic mode (the engine ceiling) is unchanged.

## Why

The local harness measures the engine's own overhead (sub-millisecond per page). Real scraping is network-bound, and now you can put the two side by side. Example against books.toscrape.com (20 book detail pages):

| Parallelism | pages/sec | wall ms/page |
|---|---|---|
| 1 | 1.4 | 734 |
| 5 | 5.5 | 183 |
| 10 | 8.5 | 117 |
| 20 | 12.5 | 80 |

Against the ~7,500 pages/sec local ceiling, this makes it obvious that ~99.9% of real scrape time is the network and the target site, not WebReaper.

## Verified locally
- Solution builds 0 warnings / 0 errors.
- Real-site mode runs against books.toscrape.com (numbers above).
- Local synthetic mode unchanged (backward-compat confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
