### PR TITLE
fix: install.sh URL 404 + stale JSON-shape enumeration in resolver prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The `LlmActionResolver` whitelist extends from four shapes to seven; the brain r
 | `WebReaper.Playwright/PlaywrightPageLoadTransport.cs` | Three new dispatch arms, one line each (`page.FillAsync`, `page.Keyboard.PressAsync`, `page.Locator(sel).ScrollIntoViewIfNeededAsync`). |
 | `WebReaper.AI/Tools/PageActionTools.cs` | Three new nested static classes following PR #134's arm-local pattern: `PageActionTools.Fill`, `.Press`, `.ScrollIntoView` each with `Name` const + `Descriptor` JSON Schema + `FromArguments`. |
 | `WebReaper.AI/Tools/AgentDecisionTools.cs` | `ForBrain()` grows 10 → 13 tools (adds `Press`, `ScrollIntoView`, `Fill`); `ForResolver()` grows 6 → 9 tools (same). |
-| `WebReaper.AI/LlmActionResolver.cs` | Prompt whitelist extends to mention all seven concrete shapes (`fill`, `press`, `scrollIntoView` added). `ParseActionTool` switch gains one case per new arm. |
+| `WebReaper.AI/LlmActionResolver.cs` | `ParseActionTool` switch gains one case per new arm. The system prompt does NOT enumerate JSON shapes — the tool list is the schema (ADR-0060), so the new arms surface via their tools, not prompt text (pinned by `System_prompt_no_longer_enumerates_JSON_shapes`). |
 | `WebReaper.AI/LlmAgentBrain.cs` | `ParseDecisionTool` gains one case per new arm. |
 | `WebReaper.Tests/WebReaper.UnitTests/StjSerializationTests.cs` | Three new arm round-trip tests pinning typed-field equality through the codec. |
 | `WebReaper.Tests/WebReaper.UnitTests/PayloadShellTests.cs` | Three new `ScraperConfig` payload-shell round-trip tests; the ScrollIntoView test additionally covers chain-nested `LinkPathSelector.PageActions`. |
@@ -59,6 +59,14 @@ The byte-identical `TryGetString` / `TryGetInt` JSON-argument extractors that li
 | `WebReaper.AI.Llm.LlmToolArguments` | Static. Two methods: `TryGetString(JsonElement, string) → string?` and `TryGetInt(JsonElement, string) → int?`. Both return `null` for missing properties, JSON-null, or non-matching kinds. `TryGetInt` tolerates string-encoded integers (`"30000"` → `30_000`) but the JSON integer-token-vs-decimal-token boundary is strict (`1` → `1`, `1.0` → `null`); the leniency contract is pinned by `LlmToolArgumentsTests`. |
 
 No behaviour changes — the helpers are byte-identical to the now-deleted private copies; the existing brain and resolver tests continue to pass unchanged.
+
+### `WebReaper.AI` off the preview `Microsoft.Extensions.AI` abstractions
+
+`WebReaper.AI` moves its `Microsoft.Extensions.AI.Abstractions` floor from the preview `9.4.0-preview.1.25207.5` to stable `10.3.0`. No code changes; the satellite compiles and its tests pass against the GA abstractions. `10.3.0` is the highest version where the latest stable `Anthropic.SDK` (5.10.0) stays binary-compatible (`HostedMcpServerTool.AuthorizationToken` changed at `10.4.0`), and `Microsoft.Extensions.AI.OpenAI 10.3.0` targets the same abstractions, so both stock providers coexist on one version. Consumers' minimum `Microsoft.Extensions.AI.Abstractions` rises off preview accordingly.
+
+| File | Change |
+|---|---|
+| `WebReaper.AI/WebReaper.AI.csproj` | `Microsoft.Extensions.AI.Abstractions` `9.4.0-preview.1.25207.5` → `10.3.0` (stable; this is a dependency floor, not a pin). |
 
 ## 10.0.1: NuGet metadata polish (no code changes)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ brew install pavlovtech/webreaper/webreaper
 **Any POSIX shell (install.sh):**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh
 ```
 
 **.NET library:**

--- a/WebReaper.AI/LlmActionResolver.cs
+++ b/WebReaper.AI/LlmActionResolver.cs
@@ -43,25 +43,20 @@ namespace WebReaper.AI;
 /// </summary>
 public sealed class LlmActionResolver : IActionResolver
 {
+    // ADR-0060: post tool-calling pivot the tool list IS the schema, so the
+    // prompt no longer enumerates JSON shapes ({ "kind": ... }) — the provided
+    // action tools and their parameter schemas define the concrete shapes. The
+    // model just picks one tool. Behavioural pin: AgentDecisionToolsTests /
+    // LlmActionResolverTests.System_prompt_no_longer_enumerates_JSON_shapes.
     private const string DefaultSystemPrompt =
         "You are resolving a user's natural-language intent to a concrete " +
         "browser action on the supplied HTML page. Call EXACTLY ONE of the " +
-        "provided action tools to indicate the concrete action. Pick the " +
-        "simplest action that satisfies the intent. Prefer a CSS selector " +
-        "specific enough not to collide with other elements (prefer id over " +
-        "class, class over tag; combine if needed). " +
-        "Available concrete shapes: " +
-        "{ \"kind\": \"click\", \"selector\": \"<css>\" }, " +
-        "{ \"kind\": \"wait\", \"ms\": <int> }, " +
-        "{ \"kind\": \"waitForSelector\", \"selector\": \"<css>\" }, " +
-        "{ \"kind\": \"waitForNetworkIdle\" }, " +
-        "{ \"kind\": \"scrollToEnd\" }, " +
-        "{ \"kind\": \"scrollIntoView\", \"selector\": \"<css>\" }, " +
-        "{ \"kind\": \"evaluate\", \"expression\": \"<js>\" }, " +
-        "{ \"kind\": \"press\", \"key\": \"<Playwright-style key, e.g. Enter | Control+A | a>\" }, " +
-        "{ \"kind\": \"fill\", \"selector\": \"<css>\", \"value\": \"<text>\" }. " +
-        "Use 'fill' when the intent is to type text into an input, textarea, or " +
-        "content-editable element. The fill action clears any existing value " +
+        "provided action tools to indicate the concrete action; the tool list " +
+        "is the schema. Pick the simplest action that satisfies the intent. " +
+        "Prefer a CSS selector specific enough not to collide with other " +
+        "elements (prefer id over class, class over tag; combine if needed). " +
+        "Use the fill tool when the intent is to type text into an input, " +
+        "textarea, or content-editable element; it clears any existing value " +
         "before inserting the new text.";
 
     private readonly LlmCall<PageAction?> _call;

--- a/WebReaper.Cli/skill/SKILL.md
+++ b/WebReaper.Cli/skill/SKILL.md
@@ -129,7 +129,7 @@ line to stderr. Common cases:
 
 - **`webreaper: command not found`** → not installed. Instruct the user:
   - **macOS / Linux**: `brew install pavlovtech/webreaper/webreaper`, or
-    `curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh`
+    `curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh`
   - **Windows**: download the latest archive for `win-x64` (or `win-arm64`)
     from <https://github.com/pavlovtech/WebReaper/releases/latest>, extract
     `webreaper.exe`, place on `%PATH%`.

--- a/docs/adr/0070-cli-distribution-channels.md
+++ b/docs/adr/0070-cli-distribution-channels.md
@@ -82,7 +82,7 @@ history is auditable here, not split across two repositories.
 A `scripts/install.sh` checked into this repo. Install command:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh
 ```
 
 The script is the maximum-care version — ~120 lines, every failure-mode

--- a/docs/testing/manual-test-plan.md
+++ b/docs/testing/manual-test-plan.md
@@ -62,13 +62,6 @@ scripts/test-install.sh
 
 ## 1. Installation matrix (manual)
 
-> **Known doc bug:** `install.sh --help` and the README advertise
-> `curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh`,
-> but the script lives at `scripts/install.sh` — that root URL 404s. Verify and
-> fix the published URL (or add a root-level `install.sh`) before relying on the
-> documented one-liner. `scripts/test-install.sh` sidesteps this by running the
-> repo's actual script.
-
 - [ ] **Homebrew (macOS arm64):** `brew install pavlovtech/webreaper/webreaper` → `webreaper version`
 - [ ] **Homebrew (macOS x64):** same, on Intel
 - [ ] **install.sh (Linux x64):** clean box, `curl … | sh` → installs, `webreaper version`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,9 +2,9 @@
 # install.sh: WebReaper CLI installer (ADR-0070).
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh
 #   # or with flags:
-#   curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh -s -- --force
+#   curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh -s -- --force
 #
 # Environment variables:
 #   WEBREAPER_VERSION        : pin to a specific tag (e.g. v10.0.0). Default: latest release.
@@ -62,7 +62,7 @@ usage() {
 # install.sh: WebReaper CLI installer
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh
 #
 # Flags: --force, --upgrade, --help.
 # See script header for env vars and exit codes.


### PR DESCRIPTION
Closes the two actionable follow-ups flagged after the test-suite work (key rotation skipped per request; OpenAI quota is environmental).

## 1. `install.sh` URL 404
The advertised one-liner `curl .../master/install.sh` 404s — the script lives at `scripts/install.sh` (ADR-0070's documented location). Corrected the URL to `.../master/scripts/install.sh` in the README, the CLI skill, the `install.sh` header, and ADR-0070's command example. The corrected URL returns **HTTP 200**.

## 2. Stale JSON-shape enumeration in the resolver prompt
`LlmActionResolver`'s system prompt still listed the old `{ "kind": "click", ... }` JSON shapes (extended by ADR-0074), contradicting the tool-calling pivot (ADR-0060: the tool list is the schema). Removed it; the arms surface via their tools. Fixes the long-red `System_prompt_no_longer_enumerates_JSON_shapes` test — **`WebReaper.AI.Tests` now 270/270** (was 269/270). No functional change: the resolver still resolves every arm via its tool; CHANGELOG line for ADR-0074 corrected to match.

## 3. CHANGELOG
Documented `WebReaper.AI`'s move off the preview `Microsoft.Extensions.AI.Abstractions` onto stable `10.3.0`.

## Verified
- `WebReaper.AI.Tests`: 270/270.
- Solution builds 0 warnings / 0 errors.
- Corrected install URL returns HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
