### PR TITLE
Architecture deepening: ADR-0076..0079 design pass

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,6 +124,10 @@ _Avoid_: result, decision, outcome (that is the **Crawl outcome**).
 A destination a ParsedData is emitted to (file, Redis, Cosmos, …). The terminal half of the post-extraction surface — Emit, a concurrent fan-out, sibling to the in-pipeline **Page processor** (ADR-0038). `Subscribe` is sugar that registers a delegate **Sink**, not a separate notification seam.
 _Avoid_: output, writer, exporter, subscription.
 
+**Post-extraction pipeline**:
+The one runtime module that owns the whole post-extraction surface for a single **ParsedData**: run it through the **Page processor** pipeline (Process), and if the **Page verdict** is `Kept`, fan it out to every **Sink** (Emit), returning the surviving record (or `null` when a processor dropped it). One fused `ProcessAndEmitAsync` so the drop-means-no-emit invariant lives in one place; the **Crawl driver** ignores the return, the **Agent driver** uses it for its run-scoped record bookkeeping (`AgentDecisionOutcome.Extracted`). Holds the processors and sinks and owns their lifecycle: it is itself an **Adapter warm-up** (`IAsyncInitializable`) and **Engine-teardown disposal chain** (`IAsyncDisposable`) participant, so each driver warms and disposes it as one adapter slotted between the **Visited-link tracker** and (on dispose) ahead of the tracker, never iterating the processor/sink collections itself. Public, so the consumer-authored distributed **Crawl driver** is a first-class third caller, not a re-implementer. Process and Emit stay distinct seams *inside* it (the **Page processor** and **Sink** interfaces are unchanged); the module composes them, it does not merge them. Distinct from the builder-side `ContentExtractorPipeline` (ADR-0072), which assembles the *extractor* stack at wiring time; this is the *runtime* path a record takes after extraction.
+_Avoid_: emission pipeline (undersells the Process half), record handler, sink dispatcher, output pipeline, page-processor pipeline (that is only the Process half).
+
 **File sink drain**:
 The one home for the buffered file-write mechanism (`BufferedFileSink`): a
 producer enqueues rows, one background consumer appends them to the file;
@@ -148,6 +152,10 @@ _Avoid_: repository, cache, document DB, config storage.
 **Payload shell**:
 The thin module above a **keyed blob store** that owns one payload's serialization grammar and quirks (the config shell owns its `System.Text.Json` source-gen grammar — ADR-0008, replacing `TypeNameHandling.Auto`; the cookie shell owns `CookieContainer ↔ CookieCollection`) and decides what *absent* means for that payload.
 _Avoid_: storage, provider, serializer.
+
+**Closed-sum codec**:
+The one hand-written-but-shared JSON mechanism the flat **closed sum**s (`PageAction`, `AgentDecision`, `AgentDecisionOutcome`) describe their arms to, getting streaming `Read(ref Utf8JsonReader)` + `Write(Utf8JsonWriter, T)` for free (`ClosedSumCodec<T>` + a per-arm descriptor). The serialization-layer sibling of the **LLM call** mechanism: the mechanism owns the object envelope, the `type` discriminator write/dispatch, the one-time `JsonNode.Parse(ref reader)` materialization (the `ref struct`-reader can't be handed to a delegate, so the read side materializes once then dispatches per arm on a plain `JsonObject`), the single missing-field `Require` contract, the unknown-tag throw, and the common-field pass; each arm's descriptor owns only its tag, its field writes, and its build-from-`JsonObject`. Adding an arm is one descriptor row, not three edits across a write switch + read loop + read switch. AOT-clean (System.Text.Json.Nodes, no reflection — ADR-0008 holds); the materialize-then-dispatch allocation is irrelevant at these call frequencies (config load, agent resume, per-**Agent step**). Nesting is composition: a parent arm builds a child via the child codec's `From(JsonNode)` entry. Three codecs stay bespoke because they are not flat tag-sums — **Schema** (a recursive container/leaf tree on `$kind`, which the mechanism *composes with* via `From` but is not built by), `AgentRunSnapshot` (a product type with arrays), and the selector-chain / backlink `ImmutableQueue` converters; each keeps calling the migrated codecs' streaming `Read(ref r)` unchanged through a shim.
+_Avoid_: closed-sum converter (the `JsonConverter<T>` wrapper is a thin shell over this), discriminated-union serializer, polymorphic codec, the codec (unqualified).
 
 **File persistence prep**:
 The one home for the three things every file-backed adapter must get right
@@ -503,11 +511,25 @@ dispatches to the descriptor's `ParseToolCall`. The closed sum
 becomes load-bearing **at the LLM boundary** the same way it is
 in C#: an unknown arm is structurally impossible at the seam,
 not a `default:` branch. Flat packaging on both registries
-(brain ships nine flat tools — three decision arms plus seven
-flat `Act*` arms; resolver ships six — only the concrete `Act*`
-arms; the `ActSemanticAct` absence is the structural loop
-prevention). Resolver's "must not return SemanticAct" rule is
-enforced by NOT registering the tool, not by runtime check.
+(post ADR-0074 the brain ships 13 flat tools — three decision
+arms plus the ten flat `Act*` arms; the resolver ships 9 — the
+nine concrete `Act*` arms; the `ActSemanticAct` absence is the
+structural loop prevention). Both registries are **derived
+views of one `PageActionArms` arm list**, each entry a
+`(Descriptor, Parse)` pair, so the tool offered to the model
+and the parse that decodes its call are the same list seen two
+ways — the registration list and the parse dispatch cannot
+drift (the pre-derivation hazard: register an arm in
+`ForBrain()` but forget `ParseDecisionTool`, and the model's
+call silently became `Stop`). Resolver's "must not return
+SemanticAct" rule is enforced structurally by SemanticAct
+exposing **no resolver adapter** — an arm with no resolver
+`Parse` cannot appear in a registry derived from the arm list,
+so the omission is a compile-time absence, not a runtime
+`.Where(x != SemanticAct)` filter or a hand-maintained second
+list. The `_ => null` (resolver) / `_ => Stop` (brain) fallback
+remains, but now catches only a genuinely hallucinated tool
+name, never a wiring omission.
 _Avoid_: tool list (unqualified — there are two distinct
 registries), function registry, brain commands.
 

--- a/WebReaper.Tests/WebReaper.UnitTests/AgentEngineDriverTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/AgentEngineDriverTests.cs
@@ -12,6 +12,7 @@ using WebReaper.Domain.Agent;
 using WebReaper.Domain.PageActions;
 using WebReaper.Domain.Parsing;
 using WebReaper.Domain.Selectors;
+using WebReaper.Infra.Abstract;
 using WebReaper.Sinks.Abstract;
 using WebReaper.Sinks.Models;
 
@@ -606,7 +607,60 @@ public class AgentEngineDriverTests
         Assert.Equal(200, followed.StatusCode);
     }
 
+    [Fact]
+    public async Task Durable_sink_on_an_agent_run_is_warmed_and_flushed_on_dispose()
+    {
+        // ADR-0076 bug fix: pre-0076 the Agent driver was neither
+        // IAsyncInitializable nor IAsyncDisposable, so a durable sink (Redis /
+        // Mongo / Cosmos, or a buffered file drain) never ran its
+        // InitializeAsync and never got its flush-on-dispose — silent record
+        // loss on agent runs. The engine now warms its sinks at RunAsync and
+        // flushes them on DisposeAsync (via the Post-extraction pipeline).
+        var schema = new Schema { new SchemaElement("title", "h1") };
+        var brain = new ScriptedBrain(
+            new AgentDecision.Extract(schema) { Reason = "extract" },
+            new AgentDecision.Stop { Reason = "done" });
+        var loader = new FakeLoader("<html><body><h1>Hello</h1></body></html>");
+        var sink = new DurableSink();
+
+        await using (var engine = await AgentEngineBuilder
+            .Start("https://example.com/", "get the title")
+            .WithBrain(brain)
+            .WithPageLoader(loader)
+            .AddSink(sink)
+            .BuildAsync())
+        {
+            await engine.RunAsync();
+
+            // Warmed exactly once at RunAsync; the record reached the sink.
+            Assert.Equal(1, sink.Inits);
+            Assert.Single(sink.Emitted);
+            // Not yet disposed — still inside the using scope.
+            Assert.Equal(0, sink.Disposes);
+        }
+
+        // Flushed on scope exit (engine.DisposeAsync → pipeline → sink).
+        Assert.Equal(1, sink.Disposes);
+    }
+
     // --------------- fakes ---------------
+
+    // ADR-0076: a durable sink declares the warm-up + dispose capabilities the
+    // pre-0076 agent path silently skipped.
+    private sealed class DurableSink : IScraperSink, IAsyncInitializable, IAsyncDisposable
+    {
+        public int Inits;
+        public int Disposes;
+        public List<ParsedData> Emitted { get; } = new();
+        public bool DataCleanupOnStart { get; set; }
+        public Task InitializeAsync() { Inits++; return Task.CompletedTask; }
+        public Task EmitAsync(ParsedData entity, CancellationToken ct = default)
+        {
+            Emitted.Add(entity);
+            return Task.CompletedTask;
+        }
+        public ValueTask DisposeAsync() { Disposes++; return ValueTask.CompletedTask; }
+    }
 
     private async Task<AgentEngine> BuildEngine(IAgentBrain brain, IPageLoader loader, IAgentRunStore store)
         => await AgentEngineBuilder

--- a/WebReaper.Tests/WebReaper.UnitTests/PostExtractionPipelineTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/PostExtractionPipelineTests.cs
@@ -1,0 +1,257 @@
+using System.Text.Json.Nodes;
+using WebReaper.Infra.Abstract;
+using WebReaper.Processing;
+using WebReaper.Processing.Abstract;
+using WebReaper.Sinks.Abstract;
+using WebReaper.Sinks.Models;
+using Xunit;
+
+namespace WebReaper.UnitTests;
+
+/// <summary>
+/// ADR-0076: the Post-extraction pipeline is the one runtime home for the
+/// Process (page-processor pipeline) + Emit (Sink fan-out) surface, plus the
+/// warm-up and disposal of the held sinks and processors. These tests pin that
+/// contract directly at the module's interface — the test surface the two
+/// drivers previously forced through their heavyweight end-to-end paths.
+/// </summary>
+public class PostExtractionPipelineTests
+{
+    private static ParsedData Record(string url = "https://example.com/p", string key = "k", string value = "v")
+        => new(url, new JsonObject { [key] = value });
+
+    // ---- Fakes --------------------------------------------------------------
+
+    private sealed class CollectingSink : IScraperSink
+    {
+        public List<ParsedData> Emitted { get; } = new();
+        public bool DataCleanupOnStart { get; set; }
+        public Task EmitAsync(ParsedData entity, CancellationToken ct = default)
+        {
+            Emitted.Add(entity);
+            return Task.CompletedTask;
+        }
+    }
+
+    // Mutates the Data it receives — proves the per-sink deep-clone isolates sinks.
+    private sealed class MutatingSink : IScraperSink
+    {
+        private readonly string _tag;
+        public ParsedData? Received;
+        public bool DataCleanupOnStart { get; set; }
+        public MutatingSink(string tag) => _tag = tag;
+        public Task EmitAsync(ParsedData entity, CancellationToken ct = default)
+        {
+            entity.Data["mutated"] = _tag;
+            Received = entity;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeProcessor : IPageProcessor
+    {
+        private readonly Func<PageContext, PageVerdict> _fn;
+        public List<PageContext> Seen { get; } = new();
+        public FakeProcessor(Func<PageContext, PageVerdict> fn) => _fn = fn;
+        public ValueTask<PageVerdict> ProcessAsync(PageContext context, CancellationToken ct)
+        {
+            Seen.Add(context);
+            return ValueTask.FromResult(_fn(context));
+        }
+    }
+
+    private sealed class LifecycleSink : IScraperSink, IAsyncInitializable, IAsyncDisposable
+    {
+        public int Inits;
+        public int Disposes;
+        public bool DataCleanupOnStart { get; set; }
+        public Task InitializeAsync() { Inits++; return Task.CompletedTask; }
+        public Task EmitAsync(ParsedData entity, CancellationToken ct = default) => Task.CompletedTask;
+        public ValueTask DisposeAsync() { Disposes++; return ValueTask.CompletedTask; }
+    }
+
+    // Records its name into a shared list on dispose — pins disposal order.
+    private sealed class OrderSink : IScraperSink, IAsyncDisposable
+    {
+        private readonly List<string> _log;
+        private readonly string _name;
+        public bool DataCleanupOnStart { get; set; }
+        public OrderSink(List<string> log, string name) { _log = log; _name = name; }
+        public Task EmitAsync(ParsedData entity, CancellationToken ct = default) => Task.CompletedTask;
+        public ValueTask DisposeAsync() { _log.Add(_name); return ValueTask.CompletedTask; }
+    }
+
+    private sealed class OrderProcessor : IPageProcessor, IAsyncDisposable
+    {
+        private readonly List<string> _log;
+        private readonly string _name;
+        public OrderProcessor(List<string> log, string name) { _log = log; _name = name; }
+        public ValueTask<PageVerdict> ProcessAsync(PageContext context, CancellationToken ct)
+            => ValueTask.FromResult(PageVerdict.Keep(context.Data));
+        public ValueTask DisposeAsync() { _log.Add(_name); return ValueTask.CompletedTask; }
+    }
+
+    private sealed class ThrowingOnDisposeSink : IScraperSink, IAsyncDisposable
+    {
+        public bool DataCleanupOnStart { get; set; }
+        public Task EmitAsync(ParsedData entity, CancellationToken ct = default) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => throw new InvalidOperationException("boom");
+    }
+
+    // ---- ProcessAndEmit: the fused path -------------------------------------
+
+    [Fact]
+    public async Task No_processors_no_sinks_returns_the_record()
+    {
+        var pipeline = new PostExtractionPipeline(Array.Empty<IScraperSink>());
+        var record = Record();
+
+        var result = await pipeline.ProcessAndEmitAsync(record, "<html>", Array.Empty<string>(), null);
+
+        Assert.Same(record, result);
+    }
+
+    [Fact]
+    public async Task Record_is_emitted_to_every_sink()
+    {
+        var a = new CollectingSink();
+        var b = new CollectingSink();
+        var pipeline = new PostExtractionPipeline(new IScraperSink[] { a, b });
+
+        await pipeline.ProcessAndEmitAsync(Record(), "<html>", Array.Empty<string>(), null);
+
+        Assert.Single(a.Emitted);
+        Assert.Single(b.Emitted);
+    }
+
+    [Fact]
+    public async Task Processors_run_in_order_each_seeing_the_previous_record()
+    {
+        // p1 replaces the record with one carrying "stage"="1"; p2 must see it.
+        var p1 = new FakeProcessor(ctx =>
+        {
+            var data = (JsonObject)ctx.Data.Data.DeepClone();
+            data["stage"] = "1";
+            return PageVerdict.Keep(ctx.Data with { Data = data });
+        });
+        var p2 = new FakeProcessor(ctx => PageVerdict.Keep(ctx.Data));
+        var sink = new CollectingSink();
+        var pipeline = new PostExtractionPipeline(new IScraperSink[] { sink }, new IPageProcessor[] { p1, p2 });
+
+        var result = await pipeline.ProcessAndEmitAsync(Record(), "<html>", Array.Empty<string>(), null);
+
+        // p2 saw the record p1 produced (stage=1), and the survivor carries it.
+        Assert.Equal("1", p2.Seen[0].Data.Data["stage"]?.GetValue<string>());
+        Assert.Equal("1", result!.Data["stage"]?.GetValue<string>());
+        Assert.Equal("1", sink.Emitted[0].Data["stage"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task Drop_verdict_filters_the_page_no_sink_emits_and_returns_null()
+    {
+        var dropper = new FakeProcessor(_ => PageVerdict.Drop("not wanted"));
+        var sink = new CollectingSink();
+        var pipeline = new PostExtractionPipeline(new IScraperSink[] { sink }, new IPageProcessor[] { dropper });
+
+        var result = await pipeline.ProcessAndEmitAsync(Record(), "<html>", Array.Empty<string>(), null);
+
+        Assert.Null(result);
+        Assert.Empty(sink.Emitted);
+    }
+
+    [Fact]
+    public async Task A_throwing_processor_drops_the_page_without_aborting()
+    {
+        var thrower = new FakeProcessor(_ => throw new InvalidOperationException("processor bug"));
+        var sink = new CollectingSink();
+        var pipeline = new PostExtractionPipeline(new IScraperSink[] { sink }, new IPageProcessor[] { thrower });
+
+        var result = await pipeline.ProcessAndEmitAsync(Record(), "<html>", Array.Empty<string>(), null);
+
+        Assert.Null(result);
+        Assert.Empty(sink.Emitted);
+    }
+
+    [Fact]
+    public async Task A_cancelling_processor_propagates_OperationCanceledException()
+    {
+        var canceller = new FakeProcessor(_ => throw new OperationCanceledException());
+        var pipeline = new PostExtractionPipeline(Array.Empty<IScraperSink>(), new IPageProcessor[] { canceller });
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            pipeline.ProcessAndEmitAsync(Record(), "<html>", Array.Empty<string>(), null));
+    }
+
+    [Fact]
+    public async Task Each_sink_receives_its_own_clone_of_the_data()
+    {
+        var a = new MutatingSink("A");
+        var b = new MutatingSink("B");
+        var pipeline = new PostExtractionPipeline(new IScraperSink[] { a, b });
+        var record = Record();
+
+        var result = await pipeline.ProcessAndEmitAsync(record, "<html>", Array.Empty<string>(), null);
+
+        // Each sink mutated only its own clone.
+        Assert.Equal("A", a.Received!.Data["mutated"]?.GetValue<string>());
+        Assert.Equal("B", b.Received!.Data["mutated"]?.GetValue<string>());
+        // The returned survivor and the caller's original are untouched.
+        Assert.Null(result!.Data["mutated"]);
+        Assert.Null(record.Data["mutated"]);
+    }
+
+    // ---- Warm-up ------------------------------------------------------------
+
+    [Fact]
+    public async Task InitializeAsync_warms_capable_sinks_once_and_is_idempotent()
+    {
+        var sink = new LifecycleSink();
+        var pipeline = new PostExtractionPipeline(new IScraperSink[] { sink });
+
+        await pipeline.InitializeAsync();
+        await pipeline.InitializeAsync();
+
+        Assert.Equal(1, sink.Inits);
+    }
+
+    // ---- Disposal -----------------------------------------------------------
+
+    [Fact]
+    public async Task DisposeAsync_disposes_processors_then_sinks_each_in_reverse_order()
+    {
+        var log = new List<string>();
+        var pipeline = new PostExtractionPipeline(
+            new IScraperSink[] { new OrderSink(log, "sinkA"), new OrderSink(log, "sinkB") },
+            new IPageProcessor[] { new OrderProcessor(log, "procA"), new OrderProcessor(log, "procB") });
+
+        await pipeline.DisposeAsync();
+
+        // Processors first (reverse), then sinks (reverse): procB, procA, sinkB, sinkA.
+        Assert.Equal(new[] { "procB", "procA", "sinkB", "sinkA" }, log);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_swallows_per_adapter_exceptions_and_disposes_the_rest()
+    {
+        var survivor = new LifecycleSink();
+        var pipeline = new PostExtractionPipeline(
+            new IScraperSink[] { survivor, new ThrowingOnDisposeSink() });
+
+        // Does not throw despite the sink whose DisposeAsync throws.
+        await pipeline.DisposeAsync();
+
+        Assert.Equal(1, survivor.Disposes);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_is_idempotent()
+    {
+        var sink = new LifecycleSink();
+        var pipeline = new PostExtractionPipeline(new IScraperSink[] { sink });
+
+        await pipeline.DisposeAsync();
+        await pipeline.DisposeAsync();
+
+        Assert.Equal(1, sink.Disposes);
+    }
+}

--- a/WebReaper/Core/Agent/Concrete/AgentEngine.cs
+++ b/WebReaper/Core/Agent/Concrete/AgentEngine.cs
@@ -13,6 +13,7 @@ using WebReaper.Domain.PageActions;
 using WebReaper.Domain.Selectors;
 using WebReaper.Domain.Telemetry;
 using WebReaper.Extensions;
+using WebReaper.Infra.Abstract;
 using WebReaper.Processing;
 using WebReaper.Processing.Abstract;
 using WebReaper.Sinks.Abstract;
@@ -49,7 +50,7 @@ namespace WebReaper.Core.Agent.Concrete;
 /// to free the snapshot.
 /// </para>
 /// </summary>
-public sealed class AgentEngine
+public sealed class AgentEngine : IAsyncDisposable
 {
     private readonly IAgentBrain _brain;
     private readonly IAgentRunStore _runStore;
@@ -58,8 +59,13 @@ public sealed class AgentEngine
     private readonly ISchemaValidator _validator;
     private readonly IActionResolver _actionResolver;
     private readonly IVisitedLinkTracker _visitedTracker;
-    private readonly List<IScraperSink> _sinks;
-    private readonly IReadOnlyList<IPageProcessor> _processors;
+    // ADR-0076: the post-extraction surface (page-processor pipeline + Sink
+    // fan-out) and the warm-up + disposal of its sinks and processors live in
+    // one module the driver delegates to — the same module the Crawl driver
+    // uses. Closes the pre-0076 gap where the agent never warmed or disposed
+    // its sinks (durable sinks silently lost their flush-on-dispose).
+    private readonly PostExtractionPipeline _pipeline;
+    private bool _disposed;
     private readonly AgentEngineOptions _options;
     private readonly ILogger _logger;
     private readonly string _startUrl;
@@ -117,8 +123,8 @@ public sealed class AgentEngine
         _validator = validator;
         _actionResolver = actionResolver;
         _visitedTracker = visitedTracker;
-        _sinks = sinks;
-        _processors = processors;
+        // ADR-0076: one module owns the processors + sinks and their lifecycle.
+        _pipeline = new PostExtractionPipeline(sinks, processors, logger);
         _options = options;
         _logger = logger;
         _explicitRunId = runId;
@@ -146,6 +152,13 @@ public sealed class AgentEngine
         // independent reports. Wall-clock measured entry-to-return.
         _telemetryHooks?.Reset();
         var sw = Stopwatch.StartNew();
+
+        // ADR-0033 / ADR-0076: warm up the durable adapters the agent holds —
+        // the Agent run store and the Post-extraction pipeline's sinks +
+        // processors — once, before the loop. Pre-0076 the agent warmed
+        // nothing, so a durable run store or sink (Redis / Mongo / Sqlite /
+        // Cosmos) never ran its InitializeAsync.
+        await WarmUpAdaptersAsync();
 
         var runId = _explicitRunId ?? Guid.NewGuid().ToString("N");
 
@@ -406,21 +419,30 @@ public sealed class AgentEngine
                             // extracted is non-null here; the compiler's
                             // narrowing doesn't span the verdict variable so
                             // a forgiving operator surfaces the invariant.
-                            var processed = await RunProcessorsAsync(currentUrl, pageHtml, extracted!, extract.Schema, cancellationToken);
+                            // ADR-0076: one fused call runs the page-processor
+                            // pipeline then fans the survivor out to the sinks,
+                            // returning the surviving record (or null if a
+                            // processor dropped it). The agent uses the return
+                            // for its run-scoped record bookkeeping; the crawl
+                            // driver ignores it.
+                            var processed = await _pipeline.ProcessAndEmitAsync(
+                                new ParsedData(currentUrl, extracted!),
+                                pageHtml,
+                                Array.Empty<string>(),
+                                extract.Schema,
+                                cancellationToken);
                             if (processed is not null)
                             {
                                 records.Add(processed.Data);
-                                await FanOutSinksAsync(processed, cancellationToken);
                                 lastOutcome = new AgentDecisionOutcome.Extracted(
                                     Record: processed.Data,
                                     RecordCount: records.Count);
                             }
                             else
                             {
-                                // Page processor dropped — the record was
-                                // emitted in principle but pipeline rejected
-                                // it. Brain sees Extracted(null, count) —
-                                // count unchanged.
+                                // Page processor dropped — no sink emitted it.
+                                // Brain sees Extracted(null, count) — count
+                                // unchanged.
                                 lastOutcome = new AgentDecisionOutcome.Extracted(
                                     Record: null,
                                     RecordCount: records.Count);
@@ -547,49 +569,49 @@ public sealed class AgentEngine
         }
     }
 
-    private async Task<ParsedData?> RunProcessorsAsync(
-        string url, string html, JsonObject extracted, WebReaper.Domain.Parsing.Schema schema,
-        CancellationToken cancellationToken)
+    // ADR-0033 / ADR-0076: warm up the durable adapters the agent owns — the
+    // Agent run store and the Post-extraction pipeline (its sinks + processors)
+    // — once, before the loop. Idempotent; adapters with no warm-up are skipped.
+    private async Task WarmUpAdaptersAsync()
     {
-        var record = new ParsedData(url, extracted);
-        if (_processors.Count == 0) return record;
+        if (_runStore is IAsyncInitializable runStore)
+            await runStore.InitializeAsync();
 
-        foreach (var processor in _processors)
-        {
-            var context = new PageContext(record, html, new List<string>(), schema);
-            PageVerdict verdict;
-            try
-            {
-                verdict = await processor.ProcessAsync(context, cancellationToken);
-            }
-            catch (OperationCanceledException) { throw; }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Page processor {Processor} threw on agent step for {Url}; dropping record",
-                    processor.GetType().Name, url);
-                return null;
-            }
-            switch (verdict)
-            {
-                case PageVerdict.Dropped dropped:
-                    _logger.LogInformation("Agent record from {Url} dropped by {Processor}: {Reason}",
-                        url, processor.GetType().Name, dropped.Reason);
-                    return null;
-                case PageVerdict.Kept kept:
-                    record = kept.Data;
-                    break;
-            }
-        }
-        return record;
+        // ADR-0076: warms every sink + processor that opts into ADR-0033.
+        await _pipeline.InitializeAsync();
     }
 
-    private async Task FanOutSinksAsync(ParsedData record, CancellationToken cancellationToken)
+    /// <summary>
+    /// ADR-0076 / ADR-0058: dispose the durable adapters the agent owns — the
+    /// Post-extraction pipeline (its processors then sinks, reverse order) and
+    /// the Agent run store. The recommended consumer pattern is
+    /// <c>await using var engine = await builder.BuildAsync();</c> so a durable
+    /// sink's flush-on-dispose runs on scope exit. Per-adapter disposal
+    /// exceptions log at Warning and are swallowed (ADR-0058). Idempotent.
+    /// </summary>
+    public async ValueTask DisposeAsync()
     {
-        if (_sinks.Count == 0) return;
-        // ADR-0031: hand each sink its own deep-cloned Data (sinks may mutate).
-        var sinkTasks = _sinks.Select(sink => sink.EmitAsync(
-            record with { Data = (JsonObject)record.Data.DeepClone() }, cancellationToken));
-        await Task.WhenAll(sinkTasks);
+        if (_disposed) return;
+        _disposed = true;
+
+        await _pipeline.DisposeAsync();
+        await SafeDisposeAsync(_runStore);
+    }
+
+    private async ValueTask SafeDisposeAsync(object? obj)
+    {
+        try
+        {
+            switch (obj)
+            {
+                case IAsyncDisposable a: await a.DisposeAsync(); break;
+                case IDisposable d: d.Dispose(); break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Disposal of {Type} threw", obj?.GetType().Name ?? "(null)");
+        }
     }
 
     private static IReadOnlyList<T> TailOf<T>(IReadOnlyList<T> source, int max)

--- a/WebReaper/Core/ScraperEngine.cs
+++ b/WebReaper/Core/ScraperEngine.cs
@@ -78,9 +78,12 @@ public class ScraperEngine : IAsyncDisposable
         ArgumentNullException.ThrowIfNull(sinks);
         ArgumentNullException.ThrowIfNull(logger);
 
-        (Scheduler, Spider, LinkTracker, Sinks, Logger, ConfigStorage) =
-            (jobScheduler, spider, linkTracker, sinks, logger, configStorage);
-        PageProcessors = pageProcessors ?? Array.Empty<IPageProcessor>();
+        (Scheduler, Spider, LinkTracker, Logger, ConfigStorage) =
+            (jobScheduler, spider, linkTracker, logger, configStorage);
+        // ADR-0076: the post-extraction surface — the page-processor pipeline,
+        // the Sink fan-out, and the warm-up + disposal of those sinks and
+        // processors — lives in one module the driver delegates to.
+        _pipeline = new PostExtractionPipeline(sinks, pageProcessors, logger);
         Latch = latch ?? new InMemoryOutstandingWorkLatch();
         // ADR-0026: the Crawl driver's retry around the per-Job Spider call
         // is now a named seam; default is the fixed-attempts core adapter
@@ -103,9 +106,9 @@ public class ScraperEngine : IAsyncDisposable
     private IScheduler Scheduler { get; }
     private ISpider Spider { get; }
     private IVisitedLinkTracker LinkTracker { get; }
-    private List<IScraperSink> Sinks { get; }
     private ILogger Logger { get; }
-    private IReadOnlyList<IPageProcessor> PageProcessors { get; }
+    // ADR-0076: owns the page-processor pipeline + Sink fan-out + their lifecycle.
+    private readonly PostExtractionPipeline _pipeline;
     private IOutstandingWorkLatch Latch { get; }
     private IRetryPolicy RetryPolicy { get; }
     private readonly List<IAsyncDisposable> _ownedDisposables;
@@ -231,8 +234,14 @@ public class ScraperEngine : IAsyncDisposable
                         // ADR-0037: per-Job work runs on the iteration token,
                         // so a Crawl concluding mid-flight cancels the in-flight
                         // page-processor pipeline and Sink fan-out too.
-                        await ProcessTargetPage(job, report.Document, parsed.Data,
-                            config.ParsingScheme, token);
+                        // ADR-0076: the page-processor pipeline + Sink fan-out
+                        // is the Post-extraction pipeline's job; the driver only
+                        // routes the Target page's record into it (and ignores
+                        // the surviving-record return — the crawl path fires and
+                        // forgets).
+                        Logger.LogInvocationCount();
+                        await _pipeline.ProcessAndEmitAsync(parsed.Data, report.Document,
+                            job.ParentBacklinks.ToList(), config.ParsingScheme, token);
                         newJobs = new List<Job>();
                     }
                     else
@@ -297,11 +306,11 @@ public class ScraperEngine : IAsyncDisposable
     }
 
     // ADR-0033: warm up every adapter the driver holds that declares the
-    // IAsyncInitializable capability — the scheduler, the visited-link tracker,
-    // every sink and every page processor — once, before the crawl loop.
-    // Adapters with no async warm-up (the in-memory defaults, the console and
-    // file sinks) implement nothing and are skipped. InitializeAsync is
-    // idempotent, so a sink shared with a distributed driver stays correct.
+    // IAsyncInitializable capability — once, before the crawl loop. The driver
+    // warms the scheduler and the visited-link tracker; the sinks and page
+    // processors are warmed through the Post-extraction pipeline (ADR-0076),
+    // which owns their lifecycle. InitializeAsync is idempotent, so a sink
+    // shared with a distributed driver stays correct.
     private async Task WarmUpAdaptersAsync()
     {
         if (Scheduler is IAsyncInitializable scheduler)
@@ -310,86 +319,20 @@ public class ScraperEngine : IAsyncDisposable
         if (LinkTracker is IAsyncInitializable linkTracker)
             await linkTracker.InitializeAsync();
 
-        foreach (var sink in Sinks)
-            if (sink is IAsyncInitializable initializableSink)
-                await initializableSink.InitializeAsync();
-
-        // ADR-0038: a page processor that holds an LLM client (or any durable
-        // resource) opts into the same warm-up capability — warm it here too.
-        foreach (var processor in PageProcessors)
-            if (processor is IAsyncInitializable initializableProcessor)
-                await initializableProcessor.InitializeAsync();
-    }
-
-    private async Task ProcessTargetPage(Job job, string doc, ParsedData result,
-        Schema? schema, CancellationToken cancellationToken = default)
-    {
-        Logger.LogInvocationCount();
-
-        // ADR-0038: the page-processor pipeline runs over the extracted record
-        // BEFORE the Sink fan-out — enrich / observe / filter / repair, in
-        // registration order, each processor handed the previous one's record.
-        // A Drop verdict, or a processor that throws (anything but
-        // OperationCanceledException), drops the page: no Sink emits it and the
-        // crawl continues — a noisy page never aborts the crawl (ADR-0029).
-        var record = result;
-        foreach (var processor in PageProcessors)
-        {
-            var context = new PageContext(record, doc, job.ParentBacklinks.ToList(), schema);
-
-            PageVerdict verdict;
-            try
-            {
-                verdict = await processor.ProcessAsync(context, cancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "Page processor {Processor} threw on {Url}; dropping the page",
-                    processor.GetType().Name, job.Url);
-                return;
-            }
-
-            switch (verdict)
-            {
-                case PageVerdict.Dropped dropped:
-                    Logger.LogInformation("Page {Url} dropped by {Processor}: {Reason}",
-                        job.Url, processor.GetType().Name, dropped.Reason);
-                    return;
-                case PageVerdict.Kept kept:
-                    record = kept.Data;
-                    break;
-            }
-        }
-
-        Logger.LogInformation("Sending scraped data to sinks...");
-        // ADR-0031: hand each sink its own deep-cloned Data. The fan-out runs
-        // sinks concurrently (Task.WhenAll) and JsonObject is not thread-safe,
-        // so a shared instance would race — e.g. CosmosSink writes "id", and
-        // BufferedFileSink queues the object to drain later. The `with` copy
-        // bypasses ParsedData's merge initializer (the clone is of the
-        // already-merged Data), so there is no double-merge.
-        var sinkTasks = Sinks.Select(sink => sink.EmitAsync(
-            record with { Data = (JsonObject)record.Data.DeepClone() }, cancellationToken));
-
-        Logger.LogInformation("Waiting for sinks ...");
-        await Task.WhenAll(sinkTasks);
-        Logger.LogInformation("Finished waiting for sinks");
+        // ADR-0076: warms every sink + processor that opts into ADR-0033.
+        await _pipeline.InitializeAsync();
     }
 
     /// <summary>
     /// ADR-0058: dispose every adapter the driver holds that implements
     /// <see cref="IAsyncDisposable"/> or <see cref="IDisposable"/>, in
     /// REVERSE warm-up order (so dependents see their dependencies still
-    /// valid mid-flush): page processors → sinks → link tracker →
-    /// scheduler → spider. Then dispose builder-registered teardown hooks
-    /// in LIFO order (satellite-spawned subprocesses like CloakBrowser).
-    /// Per-adapter disposal exceptions are swallowed with a Warning log —
-    /// a scrape that succeeded should not retroactively fail because a
-    /// Redis-connection close timed out.
+    /// valid mid-flush): the Post-extraction pipeline (page processors → sinks,
+    /// ADR-0076) → link tracker → scheduler → spider. Then dispose
+    /// builder-registered teardown hooks in LIFO order (satellite-spawned
+    /// subprocesses like CloakBrowser). Per-adapter disposal exceptions are
+    /// swallowed with a Warning log — a scrape that succeeded should not
+    /// retroactively fail because a Redis-connection close timed out.
     /// </summary>
     /// <remarks>
     /// Idempotent: a second call short-circuits on <c>_disposed</c>.
@@ -399,10 +342,10 @@ public class ScraperEngine : IAsyncDisposable
         if (_disposed) return;
         _disposed = true;
 
-        foreach (var p in PageProcessors.Reverse())
-            await SafeDisposeAsync(p);
-        foreach (var s in Enumerable.Reverse(Sinks))
-            await SafeDisposeAsync(s);
+        // ADR-0076: the pipeline disposes its processors then sinks, each in
+        // reverse registration order — the same order this driver did inline
+        // pre-0076, now owned in one place.
+        await _pipeline.DisposeAsync();
         await SafeDisposeAsync(LinkTracker);
         await SafeDisposeAsync(Scheduler);
         await SafeDisposeAsync(Spider);

--- a/WebReaper/Processing/PostExtractionPipeline.cs
+++ b/WebReaper/Processing/PostExtractionPipeline.cs
@@ -1,0 +1,199 @@
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using WebReaper.Domain.Parsing;
+using WebReaper.Infra.Abstract;
+using WebReaper.Processing.Abstract;
+using WebReaper.Sinks.Abstract;
+using WebReaper.Sinks.Models;
+
+namespace WebReaper.Processing;
+
+/// <summary>
+/// The one runtime home for the post-extraction surface (ADR-0076): run a
+/// <see cref="ParsedData"/> through the <see cref="IPageProcessor"/> pipeline
+/// (Process), and if it survives, fan it out to every <see cref="IScraperSink"/>
+/// (Emit). Both the in-process Crawl driver
+/// (<see cref="WebReaper.Core.ScraperEngine"/>) and the Agent driver
+/// (<see cref="WebReaper.Core.Agent.Concrete.AgentEngine"/>) delegate here, and
+/// the consumer-authored distributed driver (ADR-0009) can reuse it rather than
+/// re-deriving the deep-clone fan-out and the disposal order by hand.
+/// <para>
+/// It <b>holds</b> the processors and sinks and owns their lifecycle: it is an
+/// <see cref="IAsyncInitializable"/> (ADR-0033) and <see cref="IAsyncDisposable"/>
+/// (ADR-0058) participant, so a driver warms and disposes the whole
+/// post-extraction slice as one adapter. The ADR-0058 reverse order holds by
+/// composition — the driver disposes this module ahead of the
+/// <c>IVisitedLinkTracker</c> / scheduler, and inside it processors are disposed
+/// before sinks.
+/// </para>
+/// </summary>
+public sealed class PostExtractionPipeline : IAsyncInitializable, IAsyncDisposable
+{
+    private readonly IReadOnlyList<IPageProcessor> _processors;
+    private readonly IReadOnlyList<IScraperSink> _sinks;
+    private readonly ILogger _logger;
+    private bool _warmedUp;
+    private bool _disposed;
+
+    /// <summary>
+    /// Construct over the sinks and (optional) page processors the driver holds.
+    /// </summary>
+    /// <param name="sinks">The Sink fan-out targets, in registration order.</param>
+    /// <param name="processors">The page-processor pipeline, in registration
+    /// order; processor N sees processor N-1's record. Null or empty means no
+    /// processing — the record passes straight to the sinks.</param>
+    /// <param name="logger">Diagnostics sink; defaults to
+    /// <see cref="NullLogger.Instance"/>.</param>
+    public PostExtractionPipeline(
+        IReadOnlyList<IScraperSink> sinks,
+        IReadOnlyList<IPageProcessor>? processors = null,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(sinks);
+        _sinks = sinks;
+        _processors = processors ?? Array.Empty<IPageProcessor>();
+        _logger = logger ?? NullLogger.Instance;
+    }
+
+    /// <summary>
+    /// ADR-0033 warm-up: initialise every held sink and processor that declares
+    /// the <see cref="IAsyncInitializable"/> capability — once, before first use.
+    /// Idempotent: a second call is a no-op. Adapters with no async warm-up (the
+    /// console / file sinks) are skipped.
+    /// </summary>
+    public async Task InitializeAsync()
+    {
+        if (_warmedUp) return;
+        _warmedUp = true;
+
+        foreach (var sink in _sinks)
+            if (sink is IAsyncInitializable initializableSink)
+                await initializableSink.InitializeAsync();
+
+        // ADR-0038: a page processor holding a durable resource (an LLM client)
+        // opts into the same warm-up capability.
+        foreach (var processor in _processors)
+            if (processor is IAsyncInitializable initializableProcessor)
+                await initializableProcessor.InitializeAsync();
+    }
+
+    /// <summary>
+    /// Run <paramref name="record"/> through the page-processor pipeline, then,
+    /// if it survived, fan the result out to every sink and return it; if a
+    /// processor dropped the page (a <see cref="PageVerdict.Dropped"/> verdict,
+    /// or a processor that threw anything but
+    /// <see cref="OperationCanceledException"/>), emit to no sink and return
+    /// <c>null</c>. The drop-means-no-emit invariant lives here, in one place.
+    /// <para>
+    /// Each sink receives its own deep-clone of <see cref="ParsedData.Data"/>
+    /// (ADR-0031) — the fan-out runs the sinks concurrently and
+    /// <see cref="JsonObject"/> is not thread-safe, so a shared instance would
+    /// race. A processor that throws drops the page and the run continues — a
+    /// noisy page never aborts the crawl (ADR-0029).
+    /// </para>
+    /// </summary>
+    /// <param name="record">The extracted record to process and emit, with the
+    /// page URL already folded into <c>Data["url"]</c> (ADR-0031).</param>
+    /// <param name="html">The raw page body the record was extracted from —
+    /// the input a re-extraction or confidence-scoring processor reads.</param>
+    /// <param name="backLinks">Ancestor URLs that led to this page, oldest
+    /// first (empty for the Agent driver, which is page-spanning not
+    /// link-following).</param>
+    /// <param name="schema">The extraction Schema the fold ran, or null.</param>
+    /// <param name="cancellationToken">Cancels the pipeline and the fan-out.</param>
+    /// <returns>The surviving record (the value the last processor kept, or
+    /// <paramref name="record"/> when no processor ran), or <c>null</c> when the
+    /// page was dropped.</returns>
+    public async Task<ParsedData?> ProcessAndEmitAsync(
+        ParsedData record,
+        string html,
+        IReadOnlyList<string> backLinks,
+        Schema? schema,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        // ADR-0038: the page-processor pipeline runs over the extracted record
+        // BEFORE the Sink fan-out — enrich / observe / filter / repair, in
+        // registration order, each processor handed the previous one's record.
+        var current = record;
+        foreach (var processor in _processors)
+        {
+            var context = new PageContext(current, html, backLinks, schema);
+
+            PageVerdict verdict;
+            try
+            {
+                verdict = await processor.ProcessAsync(context, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Page processor {Processor} threw on {Url}; dropping the page",
+                    processor.GetType().Name, current.Url);
+                return null;
+            }
+
+            switch (verdict)
+            {
+                case PageVerdict.Dropped dropped:
+                    _logger.LogInformation("Page {Url} dropped by {Processor}: {Reason}",
+                        current.Url, processor.GetType().Name, dropped.Reason);
+                    return null;
+                case PageVerdict.Kept kept:
+                    current = kept.Data;
+                    break;
+            }
+        }
+
+        if (_sinks.Count > 0)
+        {
+            // ADR-0031: hand each sink its own deep-cloned Data. The `with` copy
+            // bypasses ParsedData's merge initializer (the clone is of the
+            // already-merged Data), so there is no double-merge.
+            var sinkTasks = _sinks.Select(sink => sink.EmitAsync(
+                current with { Data = (JsonObject)current.Data.DeepClone() }, cancellationToken));
+            await Task.WhenAll(sinkTasks);
+        }
+
+        return current;
+    }
+
+    /// <summary>
+    /// ADR-0058 teardown: dispose held processors then sinks, each in reverse
+    /// registration order, so a dependent adapter sees its dependency still
+    /// valid mid-flush. Per-adapter disposal exceptions log at Warning and are
+    /// swallowed — a successful run is not retroactively failed by a teardown
+    /// burp. Idempotent.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        for (var i = _processors.Count - 1; i >= 0; i--)
+            await SafeDisposeAsync(_processors[i]);
+        for (var i = _sinks.Count - 1; i >= 0; i--)
+            await SafeDisposeAsync(_sinks[i]);
+    }
+
+    private async ValueTask SafeDisposeAsync(object? obj)
+    {
+        try
+        {
+            switch (obj)
+            {
+                case IAsyncDisposable a: await a.DisposeAsync(); break;
+                case IDisposable d: d.Dispose(); break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Disposal of {Type} threw", obj?.GetType().Name ?? "(null)");
+        }
+    }
+}

--- a/docs/adr/0076-post-extraction-pipeline-module.md
+++ b/docs/adr/0076-post-extraction-pipeline-module.md
@@ -1,0 +1,104 @@
+# 0076. Post-Extraction Pipeline Module
+
+- **Status:** Accepted — implementing (2026-05-29)
+- **Date:** 2026-05-29
+- **Deciders:** Alex (HITL), Claude (architecture pass)
+
+## Context
+
+The in-process **Crawl driver** (`ScraperEngine`) and the **Agent driver**
+(`AgentEngine`) each re-implement the entire post-extraction surface that
+ADR-0038 defines as Process-then-Emit: run a **Target page**'s **ParsedData**
+through the ordered **Page processor** pipeline (the `Kept` / `Dropped`
+**Page verdict** loop, with the swallow-and-log-on-throw policy of ADR-0029),
+then fan the surviving record out to every **Sink** with a per-sink deep-clone
+under `Task.WhenAll`.
+
+- `ScraperEngine.ProcessTargetPage` (`WebReaper/Core/ScraperEngine.cs`) and
+  `AgentEngine.RunProcessorsAsync` + `FanOutSinksAsync`
+  (`WebReaper/Core/Agent/Concrete/AgentEngine.cs`) are two copies of the same
+  logic. The fan-out (deep-clone per sink, `Task.WhenAll`) is byte-identical;
+  the processor loop differs only in how `PageContext` is built and in log
+  strings.
+
+A latent correctness bug was discovered while scoping this: `AgentEngine` is a
+plain `sealed class` (not `IAsyncDisposable`, no warm-up), so the **Sink**s and
+**Page processor**s it holds are never warmed up (ADR-0033) and never disposed
+(ADR-0058). A durable **Sink** on an **Agent run** — a `BufferedFileSink`
+**File sink drain**, or a Redis/Cosmos satellite sink — therefore never receives
+`InitializeAsync` and never gets its flush-on-dispose. Records can be silently
+lost on agent runs. The same gap leaves the **Agent run store** (`_runStore`,
+which may be a durable satellite adapter) unwarmed and undisposed.
+
+## Decision
+
+We will extract a public **Post-extraction pipeline** module (near
+`WebReaper/Core/Processing/`) that owns the whole post-extraction surface for a
+single **ParsedData**:
+
+- A fused `ProcessAndEmitAsync(ParsedData) -> ParsedData?`: run the **Page
+  processor** pipeline; on `Kept`, fan out to every **Sink** and return the
+  surviving record; on `Dropped`, emit to no sink and return `null`. The
+  drop-means-no-emit invariant lives in one place.
+- The module **holds** the processors and sinks and owns their lifecycle: it
+  implements `IAsyncInitializable` (ADR-0033) and `IAsyncDisposable` (ADR-0058)
+  itself, so each driver warms and disposes it as one adapter slotted between
+  the **Visited-link tracker** and the **Scheduler**. The ADR-0058 reverse
+  order holds by composition (processors-then-sinks dispose inside the module).
+- It takes an already-built **ParsedData** (the crawl side has one from the
+  **Spider** with the ADR-0031 url-merge done; the agent builds one in a line),
+  not `(url, json)` — taking the latter would force the crawl side to
+  deconstruct and risk re-merging.
+
+The **Crawl driver** ignores the return; the **Agent driver** uses it for its
+run-scoped record bookkeeping (`records.Add` + `AgentDecisionOutcome.Extracted(
+Record, RecordCount)`), where `RecordCount` is the cumulative run total and
+stays the agent's concern. Three callers justify the public seam: the
+in-process **Crawl driver**, the **Agent driver**, and the consumer-authored
+distributed **Crawl driver** (ADR-0009), which today hand-re-derives the
+deep-clone, the `Task.WhenAll`, and the dispose order.
+
+As part of this, `AgentEngine` becomes a proper warm/dispose citizen
+(`IAsyncInitializable` + `IAsyncDisposable`), with the **Agent run store** as
+its own agent-local adapter — closing the durable-sink and run-store lifecycle
+gap.
+
+## Consequences
+
+Good:
+- One home for Process + Emit + their lifecycle. A new **Page verdict** arm, a
+  metrics hook, or a change to clone semantics is edited once.
+- The agent durable-sink / run-store lifecycle bug is fixed as a structural
+  side effect of consolidation — there is nowhere for it to hide.
+- The pipeline + fan-out + lifecycle assertions (processors-run-in-order,
+  Drop-filters-the-page, throwing-processor-drops-not-aborts,
+  each-sink-gets-its-own-clone, warm-up-once, dispose-flushes-in-reverse) move
+  to the module's interface. Driver tests shrink to "a Target page record is
+  routed into the module"; one new test pins the agent durable-sink flush.
+
+Bad / costs:
+- One new public type, and a contract that it runs after the **Spider** and
+  before the driver enqueues children (implicit ordering in the driver loop).
+- The distributed driver must opt in to gain the shared behaviour (it is
+  consumer-authored; the public seam makes it a first-class caller, not a
+  re-implementer, but does not auto-wire it).
+
+## Alternatives considered
+
+- **A pure per-record function** (stateless; drivers keep owning the
+  processors+sinks and their lifecycle). Rejected: it leaves the same logic
+  split across two ownership stories and forces a *separate* retrofit of
+  `IAsyncInitializable`/`IAsyncDisposable` onto `AgentEngine` to fix the bug.
+  The lifecycle-owning shape makes the fix fall out of consolidation.
+- **Two separately-callable methods** (`RunPipeline` + `FanOut`). Rejected: it
+  re-exposes the "don't emit a dropped record" invariant to every caller. No
+  caller needs pipeline-without-emit or emit-without-pipeline — both collapse
+  to the empty-collection case (zero processors, or zero sinks), which the
+  fused call already handles. A cross-tier split (pipeline on worker A, emit on
+  worker B) is the only thing that would need the two-method shape; it is in no
+  ADR and consumer-authorable directly against `IPageProcessor` / `IScraperSink`
+  if it ever lands.
+- **Merge the two drivers into one execution engine.** Rejected: the **Agent
+  driver** is sequential by design (ADR-0051) and the **Crawl driver** is
+  parallel; only the post-extraction slice is shared, not the seeding/scheduling
+  loop.

--- a/docs/adr/0077-closed-sum-codec-mechanism.md
+++ b/docs/adr/0077-closed-sum-codec-mechanism.md
@@ -1,0 +1,107 @@
+# 0077. Closed-Sum Codec Mechanism
+
+- **Status:** Accepted — design pass; implementation pending (2026-05-29)
+- **Date:** 2026-05-29
+- **Deciders:** Alex (HITL), Claude (architecture pass)
+
+## Context
+
+The flat **closed sum**s persist to JSON through hand-written codecs in
+`WebReaper/Serialization/Converters/`: `PageActionCodec`, `AgentDecisionCodec`,
+`AgentDecisionOutcomeCodec`. They are near-identical boilerplate — the doc
+comments themselves say "same shape as `PageActionCodec`". Each is: `Write`
+opens an object, writes a `type` tag, switches per arm to write fields, closes;
+`Read` hoists a nullable local per possible field, loops `while (r.Read())`
+draining properties, then a final `type switch` constructs the arm via a
+copy-pasted `Require` helper (three verbatim copies). Adding one arm (ADR-0074
+added three) is three edits per codec: the write switch, the read property
+loop, and the read type switch.
+
+ADR-0008 mandates hand-written, reflection-free codecs for AOT safety; that
+posture is not in question. What is in question is why three codecs re-implement
+the *same* hand-written machine. The `WebReaper.AI` satellite already solved the
+analogous problem on the LLM side: one deep **LLM call** mechanism (`LlmCall<T>`)
+that the five `Llm*` adapters describe via thin `LlmCallDescriptor<T>` records.
+The serialization layer never got that treatment.
+
+The load-bearing constraint on any shared mechanism: `Utf8JsonReader` is a `ref
+struct` — it cannot be captured in a delegate, stored, or crossed over `await`
+— so the read side cannot hand per-arm read logic to a mechanism as a `Func<>`
+the way `LlmCall<T>` takes `ParseResponse`. This is precisely why each codec
+hand-streams its own read loop today.
+
+## Decision
+
+We will add a `ClosedSumCodec<T>` mechanism plus a per-arm descriptor — the
+serialization-layer sibling of `LlmCall<T>` + `LlmCallDescriptor<T>`. The
+mechanism owns the object envelope, the `type` discriminator (write + dispatch),
+the **one-time `JsonNode.Parse(ref reader)` materialization** (the ref-struct
+reader is consumed once at the top of `Read`, then per-arm build delegates run
+on a plain `JsonObject`), the single `Require` missing-field contract, the
+unknown-tag throw, and the common-field pass. Each arm's descriptor owns only
+its tag, its field writes, and its build-from-`JsonObject`.
+
+Interface shape (chosen after designing it three ways — see Alternatives): the
+**minimal spine** — `Arm<TArm>(tag, write: (writer, x) => …, build: (obj, ctx)
+=> …)` with an `ArmReaderContext` ref struct owning `Require` / `RequireChild` /
+`Optional*` / `Common` — plus a **field-less one-liner overload**
+(`Arm<TArm>(tag, Func<TArm> create)`) for `ScrollToEnd` / `WaitForNetworkIdle`
+/ `None` / `Stop`. The common `reason` field on `AgentDecision` is consumed
+inside each arm's `build` via `ctx.Common("reason")`, so arms stay immutable and
+construct once.
+
+Scope (full-flat): migrate the three flat tag-sums — `PageAction`,
+`AgentDecisionOutcome`, `AgentDecision`. `Schema` gains a `From(node)` entry so
+a migrated `AgentDecision.Extract` can read it, but **stays bespoke** (it is a
+recursive container/leaf tree discriminated on `$kind`, not a flat tag-sum);
+the mechanism composes with it, it is not built by it. `AgentRunSnapshot` (a
+product type with arrays) and the `ImmutableQueue` selector-chain / backlink
+converters (collections) also stay bespoke. Every existing streaming caller
+(`AgentRunSnapshotCodec`, the selector-chain converter, the source-gen
+`List<PageAction>` wrapper) keeps calling the migrated codecs' streaming
+`Read(ref r)` unchanged — the mechanism exposes that entrypoint, implemented as
+`From(JsonNode.Parse(ref r))`, so migration is incremental, not all-or-nothing.
+
+Drift between the write and read halves is guarded by adjacency (the `write:` /
+`build:` pair per arm) plus a per-sum round-trip test, not by deriving both from
+one declaration.
+
+## Consequences
+
+Good:
+- Adding an arm becomes one descriptor row instead of three edits across a
+  write switch, a read loop, and a read type switch.
+- The `Require` contract, the unknown-tag throw, and the materialize-once
+  discipline live in one place; the three duplicated `Require` helpers collapse
+  to one.
+- One consistent "mechanism + descriptor" idiom across the codebase (LLM calls
+  and closed-sum serialization).
+- AOT held — `System.Text.Json.Nodes` only, no reflection (ADR-0008 stands).
+
+Bad / costs:
+- The read side allocates one `JsonObject` per value (materialize-then-dispatch).
+  Irrelevant at these call frequencies (config load, agent resume, per **Agent
+  step**), and the outcome/snapshot codecs already pay it for their nested
+  payloads; the pure-scalar `PageAction` path is the one that goes from
+  zero-alloc to one-object-per-arm.
+- The common-field / init-only-record wrinkle is handled via `ctx.Common`, one
+  extra clause per arm on the read side of `AgentDecision` only.
+
+## Alternatives considered
+
+- **Design 2 (maximally flexible):** first-class field-codec / custom-field /
+  overridable-discriminator seams. Rejected: that flexibility was sized for
+  `Schema`-like oddballs, which we are deliberately keeping bespoke; the three
+  target sums are all flat `type`-tag shaped.
+- **Design 3 (typed field-chain, one line per flat arm, auto-keyed JSON
+  names).** Rejected: auto-keying the wire name from the property name is a
+  silent wire-compat footgun on *persisted* agent snapshots and configs (the
+  `ms` / `timeoutMs` divergence), it regresses every non-flat arm into raw
+  `ArmCustom`, and it adds arity-overload scaffolding plus a `Reason = ""`
+  placeholder wart for init-only records — mechanism complexity to save
+  characters in the descriptor.
+- **Asymmetric (shared Write mechanism only, leave Read hand-streamed).**
+  Rejected: the read loop is the larger, more error-prone duplicated half.
+- **Source generation.** Rejected: ADR-0008's no-reflection / no-codegen
+  posture, and these are not hot paths — a hand-written shared mechanism is the
+  cheaper, AOT-trivial choice.

--- a/docs/adr/0078-derived-tool-registries-and-dispatch-exhaustiveness.md
+++ b/docs/adr/0078-derived-tool-registries-and-dispatch-exhaustiveness.md
@@ -1,0 +1,96 @@
+# 0078. Derived Tool Registries and Transport Dispatch Exhaustiveness
+
+- **Status:** Accepted — design pass; implementation pending (2026-05-29)
+- **Date:** 2026-05-29
+- **Deciders:** Alex (HITL), Claude (architecture pass)
+
+## Context
+
+A **Page action** arm's meaning is spread across four packages: the `PageAction`
+closed sum (core), its codec (core), the **Page action** builder (core), the two
+browser **Load transport** dispatch switches (`WebReaper.Cdp`,
+`WebReaper.Playwright`), and the AI satellite's tool projections + registries +
+parse switches. ADR-0009 forbids core referencing the satellites, so an arm
+cannot literally live in one file.
+
+The ADR-0060 amendment (2026-05-28) already co-located each arm's three AI
+concerns — `Name`, `Descriptor`, `FromArguments` — into one nested static class
+per arm (`PageActionTools` / `AgentDecisionTools`). That scatter is gone. Two
+problems remain:
+
+1. **Four parallel hand-synced lists** in the satellite: `ForBrain()` (13
+   descriptors), `ForResolver()` (9 descriptors), `ParseDecisionTool` (13-arm
+   switch in `LlmAgentBrain`), `ParseActionTool` (9-arm switch in
+   `LlmActionResolver`). The descriptor list and the parse switch must agree by
+   hand. The failure is **silent**: register an arm in `ForBrain()` but forget
+   `ParseDecisionTool`, and the model calls a tool it is offered, the parse
+   falls through `_ => Stop`, and the model's choice silently becomes
+   termination — no error, no log. (`ParseActionTool` falls through `_ =>
+   null`.)
+2. **The two transport dispatch switches** are switch-*statements* with a
+   runtime `default: throw ArgumentOutOfRangeException`. Adding a `PageAction`
+   arm compiles cleanly with the arm silently unhandled until a page exercises
+   it.
+
+## Decision
+
+Two axes.
+
+**Axis A — exhaustiveness idiom on the transports.** Convert both transport
+dispatch switch-statements (`CdpPageActionDispatcher.PerformAsync`,
+`PlaywrightPageLoadTransport.PerformAsync`) to switch-*expressions* with no
+discard arm. Adding a `PageAction` arm then fails to compile in each satellite
+until handled — the runtime `default: throw` becomes a compile-time guarantee.
+No new module, no core↔satellite seam; each transport keeps its native body
+(CDP's `Runtime.evaluate` JS, Playwright's locator/keyboard APIs). ADR-0009
+untouched.
+
+**Axis B — derived registries in the satellite.** Both the brain and resolver
+registries become derived views of one `PageActionArms` arm list. Each entry is
+a `(Descriptor, Parse)` pair, so the tool offered to the model and the parse
+that decodes its call are the same list seen two ways — `Tools = arms.Select(e
+=> e.Descriptor)` and the parse is keyed off the same list. The registration
+list and the parse dispatch cannot drift. The brain registry is the three
+brain-native arms (`Extract` / `Follow` / `Stop`) plus `PageActionArms` mapped
+through an `Act`-wrapping adapter; the resolver registry is `PageActionArms`
+filtered to entries that expose a resolver adapter.
+
+Fork 8 of ADR-0060 (the resolver must never return `SemanticAct`, which would
+loop the transport's resolution path) is preserved **structurally**:
+`SemanticAct` exposes no resolver adapter, so it cannot appear in a registry
+derived from the arm list — a compile-time absence, not a runtime `.Where(x !=
+SemanticAct)` filter or a hand-maintained second list. The `_ => null`
+(resolver) / `_ => Stop` (brain) fallback remains, but now catches only a
+genuinely hallucinated tool name, never a wiring omission.
+
+## Consequences
+
+Good:
+- Adding a `PageAction` arm drops from four satellite edits (two lists + two
+  switches) to one (`PageActionArms`) plus at most one (a brain-native arm).
+- The silent-drop failure class is eliminated: the descriptor and the parse are
+  the same list, so an arm offered to the model is always parseable.
+- A new arm that a transport forgets is now a compile error in that satellite.
+- Fork 8's loop-prevention stays structural — strengthened from
+  double-omission-from-two-lists to single-absence-of-an-adapter.
+
+Bad / costs:
+- One derived-registry indirection in the satellite (an arm list + a mapping)
+  in place of two literal lists.
+
+## Alternatives considered
+
+- **A shared `IBrowserPrimitives` seam in core, one dispatch parameterized over
+  it, each transport implementing the primitives.** Rejected: it forces
+  Playwright to drop its native methods (`page.FillAsync`,
+  `ScrollIntoViewIfNeededAsync`, `Keyboard.PressAsync`) for generic
+  evaluate-JS compositions — a capability regression — and it introduces a
+  core↔satellite seam that re-litigates ADR-0009. The twin switches are
+  correct-by-design (transport-specific bodies); only their *exhaustiveness
+  enforcement* was weak, which Axis A fixes without a new seam.
+- **Leave Axis B as-is** (the amendment already co-located per-arm concerns).
+  Rejected: the residual four-list sync still allows the silent-drop failure,
+  which is invisible (offered to the model, unparseable, no error).
+- **Move each arm's full definition into one file across packages.** Impossible
+  under ADR-0009 (core cannot reference the satellites); the per-axis approach
+  is the most concentration reachable without breaking the quarantine.

--- a/docs/adr/0079-mapper-retry-proxy-are-coverage-not-deepening.md
+++ b/docs/adr/0079-mapper-retry-proxy-are-coverage-not-deepening.md
@@ -1,0 +1,70 @@
+# 0079. Site Mapper, Retry Policy, and Proxy Provider Are Coverage Gaps, Not Deepening Targets
+
+- **Status:** Accepted
+- **Date:** 2026-05-29
+- **Deciders:** Alex (HITL), Claude (architecture pass)
+
+## Context
+
+An architecture-deepening review applied the "the interface is the test surface"
+lens and flagged three modules as candidates: the **Site mapper** (`SiteMapper`,
+292 loc, no tests), the **Retry policy** (`FixedAttemptsRetryPolicy`, untested),
+and the validated proxy provider (`ValidatedProxyProvider`, reported untested
+and reported to sit behind a single-adapter `IProxyProvider` seam). The implied
+deepening was "put the I/O behind a seam so the logic is testable offline."
+
+Verifying each against source changed the picture.
+
+## Decision
+
+We will treat these as **test-coverage gaps, not architectural deepening
+targets**, and record why so future reviews do not re-propose restructuring
+them.
+
+- **Site mapper.** The seam already exists: `SiteMapper`'s constructor takes a
+  `Func<HttpMessageHandler> handlerFactory` (invoked once per `MapAsync`),
+  explicitly "for proxy support / test substitution." The
+  robots.txt → sitemap → index-recursion → root-link → union → host/substring
+  filter → cap logic is a `local-substitutable` dependency: a stub handler
+  drops in and the whole best-effort decision table is testable offline through
+  `MapAsync` today. It simply has no tests.
+- **Retry policy.** A small module behind `IRetryPolicy` (ADR-0026), testable
+  through `ExecuteAsync` with a counting delegate — the four-attempts /
+  never-retry-`OperationCanceledException` contract is load-bearing and
+  unpinned, but the seam is already the test surface.
+- **Validated proxy provider.** Already tested — `ProxyValidationTests` exercises
+  validation, refresh, timeout, and reuse-on-empty through `IProxySource` /
+  `IProxyValidator` fakes. And `IProxyProvider` already has **two** adapters:
+  `ValidatedProxyProvider` (core) and `WebShareProxyProvider`
+  (`Misc/WebReaper.ProxyProviders`). It is a real seam, not single-adapter; the
+  original "untested / single-adapter" finding was wrong.
+
+The action item is to add offline tests for the **Site mapper** and the **Retry
+policy** (tracked as separate tasks), not to restructure any of the three.
+
+## Consequences
+
+Good:
+- Future architecture reviews will not re-suggest deepening these — the record
+  states the seams already exist and the proxy provider is already a tested
+  two-adapter seam.
+- The remaining work is correctly scoped as fast offline coverage, landing in
+  the unit-test suite rather than relying on the live-site integration tests.
+
+Bad / costs:
+- None architectural. The coverage gap remains until the spawned test tasks
+  land.
+
+## Alternatives considered
+
+- **Introduce a port for the Site mapper's HTTP fetch.** Rejected: the seam
+  (`handlerFactory`) already exists; adding another would be indirection without
+  a second adapter.
+- **Inline `ValidatedProxyProvider` into the transport** (the "shallow
+  single-adapter seam" suggestion). Rejected: it is a genuine two-adapter seam
+  (`ValidatedProxyProvider` + `WebShareProxyProvider`) and is already tested;
+  inlining would delete a real extension point.
+- **A shared stub-`HttpMessageHandler` test fixture** across the Site mapper and
+  any other live-HTTP modules. Noted as a reasonable convenience for the
+  coverage tasks, but deferred — it is a test-project helper, not an
+  architectural change to the library.


### PR DESCRIPTION
## What

The design-pass output of the 2026-05-29 `/improve-codebase-architecture` review. Four candidates were grilled to a decision; this PR lands the ADRs and the CONTEXT.md vocabulary. **Implementation of ADR-0076 follows as commits on this branch**; ADR-0077/0078 are accepted-but-pending (separate PRs); ADR-0079 is a no-code "these are coverage gaps, not deepening targets" record.

## ADRs

- **[ADR-0076](docs/adr/0076-post-extraction-pipeline-module.md) — Post-extraction pipeline module** (implementing). One runtime module owns the **Page processor** pipeline + **Sink** fan-out + their warm-up (ADR-0033) and disposal (ADR-0058), shared by the **Crawl driver**, the **Agent driver**, and the consumer-authored distributed driver. Fused `ProcessAndEmitAsync(ParsedData) -> ParsedData?`. Closes a latent agent-side lifecycle bug: `AgentEngine` is neither `IAsyncInitializable` nor `IAsyncDisposable`, so durable **Sink**s and the **Agent run store** on an agent run are never warmed or flushed (silent record loss).
- **[ADR-0077](docs/adr/0077-closed-sum-codec-mechanism.md) — Closed-sum codec mechanism** (design). `ClosedSumCodec<T>` + per-arm descriptor, the serialization sibling of `LlmCall<T>`. Materialize-then-dispatch on read (the `Utf8JsonReader` ref-struct constraint). Migrates `PageAction`, `AgentDecision`, `AgentDecisionOutcome`; `Schema`/`AgentRunSnapshot`/`ImmutableQueue` stay bespoke. AOT held (ADR-0008).
- **[ADR-0078](docs/adr/0078-derived-tool-registries-and-dispatch-exhaustiveness.md) — Derived tool registries + transport dispatch exhaustiveness** (design). One `PageActionArms` list feeds both AI registries as `(Descriptor, Parse)` views so registration and parse can't drift (kills the silent `_ => Stop` wiring-omission failure); fork-8 preserved structurally (SemanticAct has no resolver adapter). Both transport dispatch switches become exhaustive switch-expressions (compile-time arm coverage).
- **[ADR-0079](docs/adr/0079-mapper-retry-proxy-are-coverage-not-deepening.md) — coverage, not deepening**. The **Site mapper** and **Retry policy** seams already exist (testable through their interfaces, just untested); the proxy provider is already a tested two-adapter seam. Action item is offline tests, tracked separately.

## CONTEXT.md

Adds **Post-extraction pipeline** and **Closed-sum codec** terms; corrects the **Brain tool registry** entry (stale 9/6 -> current 13/9 tool counts, derived registries, structural fork-8 preservation).

## Note

"Post-extraction pipeline" (ADR-0076) sits close to the existing builder-side `ContentExtractorPipeline` (ADR-0072), which had rejected that very name. They are distinct (runtime Process+Emit vs builder-time extractor composition) and the glossary calls out the distinction; renameable if it proves confusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)