### PR TITLE
test: pin FixedAttemptsRetryPolicy default of four attempts on exhaustion

### DIFF
--- a/WebReaper.Tests/WebReaper.UnitTests/RetryPolicyTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/RetryPolicyTests.cs
@@ -59,6 +59,28 @@ public class RetryPolicyTests
     }
 
     [Fact]
+    public async Task Default_policy_makes_four_attempts_on_exhaustion()
+    {
+        // ADR-0026: the core default is four attempts (one initial + three
+        // retries), the exact pre-0026 Polly behaviour. The sibling
+        // exhaustion test pins maxAttempts:3; this one pins the literal
+        // default constant, which is otherwise only exercised on the
+        // success path, so a regression to that default can't slip past.
+        var calls = 0;
+        var policy = new FixedAttemptsRetryPolicy(); // default maxAttempts = 4
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            policy.ExecuteAsync<int>(_ =>
+            {
+                calls++;
+                throw new InvalidOperationException($"attempt {calls}");
+            }, CancellationToken.None));
+
+        Assert.Equal("attempt 4", ex.Message);
+        Assert.Equal(4, calls);
+    }
+
+    [Fact]
     public async Task OperationCanceledException_thrown_by_action_propagates_immediately()
     {
         var calls = 0;


### PR DESCRIPTION
## What

Adds one offline unit test, `Default_policy_makes_four_attempts_on_exhaustion`, to `RetryPolicyTests`.

## Why

The ADR-0026 retry contract (`IRetryPolicy` / `FixedAttemptsRetryPolicy`) is already well covered: 10 passing tests landed with the seam itself in `6800d25`, pinning bounded attempts, "cancellation is never retried", and last-exception-propagates-on-exhaustion.

The one case not directly asserted was the **literal default of four attempts** (one initial + three retries) on full exhaustion. The existing exhaustion test uses `maxAttempts: 3`, so the default constant was only exercised on the success path. A regression that changed the default (for example back to 3) would not have been caught. This test pins it: default policy, action always throws, expect exactly 4 invocations and the 4th exception propagating.

## Test

```
dotnet test WebReaper.Tests/WebReaper.UnitTests/WebReaper.UnitTests.csproj
Passed!  -  Failed: 0, Passed: 428, Skipped: 0, Total: 428
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)