### PR TITLE
ADR-0078: derived AI tool registries + transport dispatch coverage

### DIFF
--- a/WebReaper.AI/LlmActionResolver.cs
+++ b/WebReaper.AI/LlmActionResolver.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Microsoft.Extensions.AI;
 using WebReaper.AI.Llm;
 using WebReaper.AI.Tools;
@@ -18,21 +17,23 @@ namespace WebReaper.AI;
 /// interface).
 /// <para>
 /// Asked once per intent string per crawl: the model calls EXACTLY ONE of the
-/// six concrete action tools (<c>ActClick</c>, <c>ActWait</c>,
+/// nine concrete action tools (<c>ActClick</c>, <c>ActWait</c>,
 /// <c>ActWaitForSelector</c>, <c>ActWaitForNetworkIdle</c>,
-/// <c>ActScrollToEnd</c>, <c>ActEvaluate</c>) per ADR-0060. The resolver
-/// constructs the matching <see cref="PageAction"/> arm; the Puppeteer
+/// <c>ActScrollToEnd</c>, <c>ActEvaluate</c>, <c>ActScrollIntoView</c>,
+/// <c>ActPress</c>, <c>ActFill</c>) per ADR-0060 / ADR-0074. The resolver
+/// constructs the matching <see cref="PageAction"/> arm; the browser
 /// transport caches it and dispatches the cached arm on every subsequent
 /// same-intent invocation (the LLM-as-proposer / deterministic-as-decider
 /// pattern, ADR-0046 / ADR-0047 generalised to actions).
 /// </para>
 /// <para>
-/// The resolver's tool registry has seven arms (ADR-0074 adds
-/// <c>ActScrollIntoView</c>); never <c>ActSemanticAct</c>
+/// The resolver's tool registry has nine arms; never <c>ActSemanticAct</c>
 /// (fork 8 verdict: the closed sum is closed at the resolver's tool list,
 /// structurally preventing the resolver from looping the transport's
-/// resolution path). Unknown tool name returns <c>null</c>; the transport
-/// translates that to
+/// resolution path). Post ADR-0078 Axis B the registry and the parse are
+/// derived views of <see cref="WebReaper.AI.Tools.PageActionTools.Arms"/> —
+/// SemanticAct exposes no resolver adapter, so it is absent from both. Unknown
+/// tool name returns <c>null</c>; the transport translates that to
 /// <see cref="WebReaper.Core.Actions.Concrete.SemanticActResolutionException"/>.
 /// </para>
 /// <para>
@@ -87,7 +88,7 @@ public sealed class LlmActionResolver : IActionResolver
             ParseResponse = _ => throw new InvalidOperationException(
                 "LlmActionResolver is tool-call mode; ParseResponse must not be called."),
             Tools = AgentDecisionTools.ForResolver(),
-            ParseToolCall = ParseActionTool,
+            ParseToolCall = AgentDecisionTools.ParseResolverTool,
             Model = _options.Model,
             Temperature = _options.Temperature,
             MaxResponseTokens = _options.MaxResponseTokens,
@@ -129,30 +130,13 @@ public sealed class LlmActionResolver : IActionResolver
         "Intent: " + input.Intent + "\n\n" +
         "Page (HTML, may be truncated):\n" + input.Html;
 
-    // ADR-0060 fork 8 + ADR-0074: the resolver's tool list has seven arms
-    // (ScrollIntoView added); the closed sum is closed structurally (no
-    // ActSemanticAct ever, so the model cannot loop). Each per-arm case
-    // dispatches to the arm-local FromArguments factory (in PageActionTools.cs).
-    // Unknown tool name (the model invented one or called the brain-only
-    // ActSemanticAct arm) -> null; the transport surfaces a typed
-    // SemanticActResolutionException. A factory failure (FromArguments
-    // returned a FailureReason) also reads as null; the resolver's contract
-    // is "concrete arm, or nothing", no per-failure diagnostics beyond what
-    // the transport's exception carries.
-    private static PageAction? ParseActionTool(string toolName, JsonElement args)
-        => toolName switch
-        {
-            PageActionTools.Click.Name => PageActionTools.Click.FromArguments(args).Value,
-            PageActionTools.Wait.Name => PageActionTools.Wait.FromArguments(args).Value,
-            PageActionTools.WaitForSelector.Name => PageActionTools.WaitForSelector.FromArguments(args).Value,
-            PageActionTools.WaitForNetworkIdle.Name => PageActionTools.WaitForNetworkIdle.FromArguments(args).Value,
-            PageActionTools.ScrollToEnd.Name => PageActionTools.ScrollToEnd.FromArguments(args).Value,
-            PageActionTools.ScrollIntoView.Name => PageActionTools.ScrollIntoView.FromArguments(args).Value,
-            PageActionTools.EvaluateExpression.Name => PageActionTools.EvaluateExpression.FromArguments(args).Value,
-            PageActionTools.Press.Name => PageActionTools.Press.FromArguments(args).Value,
-            PageActionTools.Fill.Name => PageActionTools.Fill.FromArguments(args).Value,
-            _ => null,
-        };
-
+    // ADR-0078 Axis B: the resolver's tool list and its parse are both derived
+    // views of PageActionTools.Arms (the entries exposing a resolver adapter),
+    // so ForResolver() and ParseResolverTool cannot drift. Fork 8 is structural:
+    // SemanticAct exposes no resolver adapter, so the resolver neither offers
+    // nor parses ActSemanticAct — the model cannot loop. An unknown tool name
+    // (a hallucination, or the brain-only ActSemanticAct) or a per-arm factory
+    // failure both read as null; the transport surfaces a typed
+    // SemanticActResolutionException.
     private readonly record struct ResolveInput(string Intent, string Html);
 }

--- a/WebReaper.AI/LlmAgentBrain.cs
+++ b/WebReaper.AI/LlmAgentBrain.cs
@@ -1,12 +1,9 @@
 using System.Text;
-using System.Text.Json;
 using Microsoft.Extensions.AI;
 using WebReaper.AI.Llm;
 using WebReaper.AI.Tools;
 using WebReaper.Core.Agent.Abstract;
 using WebReaper.Domain.Agent;
-using WebReaper.Domain.PageActions;
-using WebReaper.Domain.Parsing;
 
 namespace WebReaper.AI;
 
@@ -25,10 +22,10 @@ namespace WebReaper.AI;
 /// translates the model's tool call into one of the four
 /// <see cref="AgentDecision"/> arms — Extract / Follow / Act / Stop —
 /// per ADR-0060. The closed-sum is load-bearing at the LLM boundary:
-/// the registered 10-tool registry IS the schema; the SDK validates the
+/// the registered 13-tool registry IS the schema; the SDK validates the
 /// per-arm args against the per-arm schema before they reach
-/// <see cref="ParseDecisionTool"/>. JSON-mode parsing is gone for this
-/// adapter (ADR-0060 §Decision §5).
+/// <see cref="AgentDecisionTools.ParseBrainTool"/>. JSON-mode parsing is
+/// gone for this adapter (ADR-0060 §Decision §5).
 /// </para>
 /// <para>
 /// Internally delegates to <see cref="LlmCall{TResponse}"/> (ADR-0059) with
@@ -98,7 +95,7 @@ public sealed class LlmAgentBrain : IAgentBrain
             ParseResponse = _ => throw new InvalidOperationException(
                 "LlmAgentBrain is tool-call mode; ParseResponse must not be called."),
             Tools = AgentDecisionTools.ForBrain(),
-            ParseToolCall = ParseDecisionTool,
+            ParseToolCall = AgentDecisionTools.ParseBrainTool,
             Model = opts.Model,
             Temperature = opts.Temperature,
             MaxResponseTokens = opts.MaxResponseTokens,
@@ -193,63 +190,5 @@ public sealed class LlmAgentBrain : IAgentBrain
         AgentDecisionOutcome.Stopped x => $"Stopped (reason={x.Reason})",
         _ => "Unknown"
     };
-
-    // ADR-0060 amendment (2026-05-28): ParseToolCall delegate. Each per-arm
-    // case dispatches to the arm-local FromArguments factory (in
-    // PageActionTools.cs / AgentDecisionToolFragments.cs); a successful arm
-    // becomes the decision verbatim (AgentDecision arms) or is wrapped in
-    // Act (PageAction arms); a failure becomes Stop with the factory's
-    // FailureReason composed into the audit-trail string. Unknown tool
-    // name -> Stop with structural reason. The closed sum is load-bearing
-    // at the LLM boundary — the model picked from a list of ten arm-shaped
-    // tools; "the model emitted a JSON object with an unknown
-    // discriminator" is structurally impossible.
-    private static AgentDecision ParseDecisionTool(string toolName, JsonElement args)
-    {
-        var reason = LlmToolArguments.TryGetString(args, "reason") ?? "";
-
-        return toolName switch
-        {
-            AgentDecisionTools.Extract.Name => Unwrap(AgentDecisionTools.Extract.FromArguments(args, reason), toolName, reason),
-            AgentDecisionTools.Follow.Name => Unwrap(AgentDecisionTools.Follow.FromArguments(args, reason), toolName, reason),
-            AgentDecisionTools.Stop.Name => Unwrap(AgentDecisionTools.Stop.FromArguments(args, reason), toolName, reason),
-
-            PageActionTools.Click.Name => UnwrapAct(PageActionTools.Click.FromArguments(args), toolName, reason),
-            PageActionTools.Wait.Name => UnwrapAct(PageActionTools.Wait.FromArguments(args), toolName, reason),
-            PageActionTools.WaitForSelector.Name => UnwrapAct(PageActionTools.WaitForSelector.FromArguments(args), toolName, reason),
-            PageActionTools.WaitForNetworkIdle.Name => UnwrapAct(PageActionTools.WaitForNetworkIdle.FromArguments(args), toolName, reason),
-            PageActionTools.ScrollToEnd.Name => UnwrapAct(PageActionTools.ScrollToEnd.FromArguments(args), toolName, reason),
-            PageActionTools.ScrollIntoView.Name => UnwrapAct(PageActionTools.ScrollIntoView.FromArguments(args), toolName, reason),
-            PageActionTools.EvaluateExpression.Name => UnwrapAct(PageActionTools.EvaluateExpression.FromArguments(args), toolName, reason),
-            PageActionTools.SemanticAct.Name => UnwrapAct(PageActionTools.SemanticAct.FromArguments(args), toolName, reason),
-            PageActionTools.Press.Name => UnwrapAct(PageActionTools.Press.FromArguments(args), toolName, reason),
-            PageActionTools.Fill.Name => UnwrapAct(PageActionTools.Fill.FromArguments(args), toolName, reason),
-
-            _ => new AgentDecision.Stop
-            {
-                Reason = $"brain called unregistered tool '{toolName}'"
-            },
-        };
-    }
-
-    // Brain wrap for AgentDecision arms: the factory returns the arm with
-    // its Reason already populated (the brain passed reason in); on failure
-    // the freeform FailureReason composes into a Stop matching the
-    // pre-amendment audit-trail format byte-for-byte.
-    private static AgentDecision Unwrap<T>(ToolCallResult<T> result, string toolName, string reason)
-        where T : AgentDecision =>
-        result.Value is { } arm
-            ? arm
-            : new AgentDecision.Stop { Reason = $"brain {toolName} {result.FailureReason}: {reason}" };
-
-    // Brain wrap for Act* arms: the factory returns the PageAction value;
-    // the brain wraps in Act with the audit-trail Reason. Failure -> Stop
-    // with the factory's FailureReason in the same format as the
-    // pre-amendment parser.
-    private static AgentDecision UnwrapAct<T>(ToolCallResult<T> result, string toolName, string reason)
-        where T : PageAction =>
-        result.Value is { } action
-            ? new AgentDecision.Act(action) { Reason = reason }
-            : new AgentDecision.Stop { Reason = $"brain {toolName} {result.FailureReason}: {reason}" };
 
 }

--- a/WebReaper.AI/Tools/AgentDecisionTools.cs
+++ b/WebReaper.AI/Tools/AgentDecisionTools.cs
@@ -10,33 +10,44 @@ namespace WebReaper.AI.Tools;
 
 /// <summary>
 /// The closed-sum-as-tools registries (ADR-0060, ADR-0060 amendment
-/// 2026-05-28). Holds the per-arm tool projections for the three
-/// <see cref="AgentDecision"/> arms whose tool shape is NOT shared with
+/// 2026-05-28, ADR-0078 Axis B). Holds the per-arm tool projections for the
+/// three <see cref="AgentDecision"/> arms whose tool shape is NOT shared with
 /// <see cref="PageAction"/> (<see cref="Extract"/>, <see cref="Follow"/>,
-/// <see cref="Stop"/>), plus the two registration lists
-/// (<see cref="ForBrain"/>, <see cref="ForResolver"/>) that compose the
-/// per-arm <see cref="AIFunction"/> descriptors into the lists the brain
-/// and resolver register with <see cref="ChatOptions.Tools"/>.
+/// <see cref="Stop"/>), and exposes the brain's and resolver's tool registries
+/// (<see cref="ForBrain"/>, <see cref="ForResolver"/>) plus the parse that
+/// decodes each registry's tool calls (<see cref="ParseBrainTool"/>,
+/// <see cref="ParseResolverTool"/>).
 /// <para>
-/// Hand-rolled JSON Schema per arm (fork 4 — AOT-friendly, no
-/// reflection-built schemas). After the amendment each arm's tool
-/// concerns (Name + Descriptor + FromArguments) live in one nested
-/// static class instead of being scattered across this file's factory
-/// list, the brain's parser switch, and the resolver's parser switch.
+/// Hand-rolled JSON Schema per arm (fork 4 — AOT-friendly, no reflection-built
+/// schemas). Each arm's tool concerns (Name + Descriptor + FromArguments) live
+/// in one nested static class: the three <see cref="AgentDecision"/>-native
+/// arms here, the ten <see cref="PageAction"/> arms in
+/// <see cref="PageActionTools"/>.
 /// </para>
 /// <para>
-/// Brain registry: 10 tools — <see cref="Extract"/>, <see cref="Follow"/>,
-/// <see cref="Stop"/>, plus 7 flat <c>Act*</c> arms (the seven
-/// <see cref="PageAction"/> arms including
-/// <see cref="PageAction.SemanticAct"/>). The flat packaging (fork 2)
-/// keeps every arm's schema simple; the model picks one; the SDK
-/// validates the args against the per-arm schema.
+/// Derived registries (ADR-0078 Axis B): both registries and both parse paths
+/// are views over one source list — the three native arms here plus
+/// <see cref="PageActionTools.Arms"/>. Because a registry's offered tool and
+/// the parse that decodes its call come from the same list, the registration
+/// and the parse dispatch cannot drift (the pre-derivation hazard: register an
+/// arm in <c>ForBrain</c> but forget its parse case, and the model's call
+/// silently became <c>Stop</c>).
 /// </para>
 /// <para>
-/// Resolver registry: 6 tools — the six concrete <see cref="PageAction"/>
-/// arms, ever. No <see cref="PageAction.SemanticAct"/> on the resolver
-/// (fork 8 — the closed sum is structural at the resolver tool list; the
-/// model literally cannot emit a <c>SemanticAct</c>-loop arm).
+/// Brain registry: 13 tools — <see cref="Extract"/>, <see cref="Follow"/>,
+/// <see cref="Stop"/>, plus the ten flat <c>Act*</c> arms (every
+/// <see cref="PageAction"/> arm, including
+/// <see cref="PageAction.SemanticAct"/>). The flat packaging (fork 2) keeps
+/// every arm's schema simple; the model picks one; the SDK validates the args
+/// against the per-arm schema.
+/// </para>
+/// <para>
+/// Resolver registry: 9 tools — the nine concrete <see cref="PageAction"/>
+/// arms, ever. No <see cref="PageAction.SemanticAct"/> on the resolver (fork
+/// 8): the arm exposes no resolver adapter
+/// (<see cref="PageActionArm.ResolverToAction"/> is <c>null</c>), so it is
+/// structurally absent from a registry derived from the arm list — the model
+/// literally cannot emit a <c>SemanticAct</c>-loop arm.
 /// </para>
 /// </summary>
 internal static class AgentDecisionTools
@@ -189,45 +200,110 @@ internal static class AgentDecisionTools
             ToolCallResult<AgentDecision.Stop>.Ok(new AgentDecision.Stop { Reason = reason });
     }
 
-    // ---- Registration lists --------------------------------------------------
+    // ---- Brain-native arms ---------------------------------------------------
 
-    /// <summary>The brain's 13-tool registry: every <see cref="AgentDecision"/>
-    /// arm with the ten <see cref="PageAction"/> arms flat-packed (seven
-    /// original + <see cref="PageAction.Press"/>,
-    /// <see cref="PageAction.ScrollIntoView"/>, and <see cref="PageAction.Fill"/>
-    /// from ADR-0074).</summary>
+    // The three AgentDecision arms whose tool shape is not a PageAction. Each
+    // entry pairs the arm's descriptor with the parse that decodes its call to
+    // an AgentDecision (Reason already populated from the audit-trail string).
+    private sealed record NativeArm(
+        AIFunction Descriptor,
+        Func<JsonElement, string, AgentDecision> Parse);
+
+    private static IReadOnlyList<NativeArm> NativeArms { get; } =
+    [
+        new(Extract.Descriptor, (args, reason) => Unwrap(Extract.FromArguments(args, reason), Extract.Name, reason)),
+        new(Follow.Descriptor,  (args, reason) => Unwrap(Follow.FromArguments(args, reason),  Follow.Name,  reason)),
+        new(Stop.Descriptor,    (args, reason) => Unwrap(Stop.FromArguments(args, reason),    Stop.Name,    reason)),
+    ];
+
+    // ---- Derived registries (ADR-0078 Axis B) --------------------------------
+
+    /// <summary>The brain's 13-tool registry: a derived view over the three
+    /// brain-native arms plus <see cref="PageActionTools.Arms"/> (the ten
+    /// <see cref="PageAction"/> arms, flat-packed). Built from the same list as
+    /// <see cref="ParseBrainTool"/>, so the offered tool and the parse that
+    /// decodes it cannot drift.</summary>
     public static IReadOnlyList<AIFunction> ForBrain() =>
-    [
-        Extract.Descriptor,
-        Follow.Descriptor,
-        Stop.Descriptor,
-        PageActionTools.Click.Descriptor,
-        PageActionTools.Wait.Descriptor,
-        PageActionTools.WaitForSelector.Descriptor,
-        PageActionTools.WaitForNetworkIdle.Descriptor,
-        PageActionTools.ScrollToEnd.Descriptor,
-        PageActionTools.ScrollIntoView.Descriptor,
-        PageActionTools.EvaluateExpression.Descriptor,
-        PageActionTools.SemanticAct.Descriptor,
-        PageActionTools.Press.Descriptor,
-        PageActionTools.Fill.Descriptor,
-    ];
+        [.. NativeArms.Select(a => a.Descriptor), .. PageActionTools.Arms.Select(a => a.Descriptor)];
 
-    /// <summary>The resolver's 9-tool registry: the nine concrete
-    /// <see cref="PageAction"/> arms (six original + <see cref="PageAction.Press"/>,
-    /// <see cref="PageAction.ScrollIntoView"/>, and <see cref="PageAction.Fill"/>
-    /// from ADR-0074). No <see cref="PageAction.SemanticAct"/>; structurally
-    /// prevents the resolver from looping the transport (fork 8).</summary>
+    /// <summary>The resolver's 9-tool registry: <see cref="PageActionTools.Arms"/>
+    /// restricted to the entries that expose a resolver adapter. No
+    /// <see cref="PageAction.SemanticAct"/> (fork 8) — it has no resolver
+    /// adapter, so it is structurally absent here and from
+    /// <see cref="ParseResolverTool"/>, which derive from the same predicate.</summary>
     public static IReadOnlyList<AIFunction> ForResolver() =>
-    [
-        PageActionTools.Click.Descriptor,
-        PageActionTools.Wait.Descriptor,
-        PageActionTools.WaitForSelector.Descriptor,
-        PageActionTools.WaitForNetworkIdle.Descriptor,
-        PageActionTools.ScrollToEnd.Descriptor,
-        PageActionTools.ScrollIntoView.Descriptor,
-        PageActionTools.EvaluateExpression.Descriptor,
-        PageActionTools.Press.Descriptor,
-        PageActionTools.Fill.Descriptor,
-    ];
+        [.. PageActionTools.Arms.Where(a => a.ResolverToAction is not null).Select(a => a.Descriptor)];
+
+    // ---- Derived parse dispatch (ADR-0078 Axis B) ----------------------------
+
+    // name -> brain parse, derived from the same list as ForBrain. Native arms
+    // decode to their AgentDecision directly; PageAction arms decode to a
+    // PageAction wrapped in Act. Keyed by the descriptor name the model emits.
+    private static readonly Dictionary<string, Func<JsonElement, string, AgentDecision>> BrainParsers =
+        BuildBrainParsers();
+
+    // name -> resolver parse, derived from the SAME predicate as ForResolver
+    // (entries with a resolver adapter), so offered <-> parseable. SemanticAct,
+    // having no resolver adapter, is in neither.
+    private static readonly Dictionary<string, Func<JsonElement, PageAction?>> ResolverParsers =
+        PageActionTools.Arms
+            .Where(a => a.ResolverToAction is not null)
+            .ToDictionary(
+                a => a.Descriptor.Name,
+                a => (Func<JsonElement, PageAction?>)(args => a.ResolverToAction!(args).Value),
+                StringComparer.Ordinal);
+
+    private static Dictionary<string, Func<JsonElement, string, AgentDecision>> BuildBrainParsers()
+    {
+        var map = new Dictionary<string, Func<JsonElement, string, AgentDecision>>(StringComparer.Ordinal);
+        foreach (var native in NativeArms)
+            map[native.Descriptor.Name] = native.Parse;
+        foreach (var arm in PageActionTools.Arms)
+            map[arm.Descriptor.Name] = (args, reason) => UnwrapAct(arm.ToAction(args), arm.Descriptor.Name, reason);
+        return map;
+    }
+
+    /// <summary>Decode a brain tool call into its <see cref="AgentDecision"/>
+    /// arm (ADR-0060 amendment, ADR-0078 Axis B). The audit-trail <c>reason</c>
+    /// is read once and threaded into every arm; a <see cref="PageAction"/> arm
+    /// is wrapped in <see cref="AgentDecision.Act"/>; a per-arm
+    /// <c>FromArguments</c> failure becomes <see cref="AgentDecision.Stop"/>
+    /// with the failure reason composed into the audit string. An unregistered
+    /// tool name (a genuine model hallucination — never a wiring omission now
+    /// that the registry and this dispatch derive from one list) becomes
+    /// <c>Stop</c>.</summary>
+    public static AgentDecision ParseBrainTool(string toolName, JsonElement args)
+    {
+        var reason = LlmToolArguments.TryGetString(args, "reason") ?? "";
+        return BrainParsers.TryGetValue(toolName, out var parse)
+            ? parse(args, reason)
+            : new AgentDecision.Stop { Reason = $"brain called unregistered tool '{toolName}'" };
+    }
+
+    /// <summary>Decode a resolver tool call into a concrete
+    /// <see cref="PageAction"/> arm (ADR-0060, ADR-0078 Axis B), or <c>null</c>
+    /// when the model invented a tool name or called the brain-only
+    /// <c>ActSemanticAct</c> (which the resolver never registers — fork 8). A
+    /// per-arm <c>FromArguments</c> failure also reads as <c>null</c>; the
+    /// resolver's contract is "concrete arm, or nothing".</summary>
+    public static PageAction? ParseResolverTool(string toolName, JsonElement args)
+        => ResolverParsers.TryGetValue(toolName, out var parse) ? parse(args) : null;
+
+    // Brain wrap for AgentDecision arms: the factory returns the arm with its
+    // Reason already populated (the brain passed reason in); on failure the
+    // freeform FailureReason composes into a Stop matching the pre-amendment
+    // audit-trail format byte-for-byte.
+    private static AgentDecision Unwrap<T>(ToolCallResult<T> result, string toolName, string reason)
+        where T : AgentDecision =>
+        result.Value is { } arm
+            ? arm
+            : new AgentDecision.Stop { Reason = $"brain {toolName} {result.FailureReason}: {reason}" };
+
+    // Brain wrap for Act* arms: the factory returns the PageAction value; the
+    // brain wraps it in Act with the audit-trail Reason. Failure -> Stop with
+    // the factory's FailureReason in the same format as the pre-amendment parser.
+    private static AgentDecision UnwrapAct(ToolCallResult<PageAction> result, string toolName, string reason) =>
+        result.Value is { } action
+            ? new AgentDecision.Act(action) { Reason = reason }
+            : new AgentDecision.Stop { Reason = $"brain {toolName} {result.FailureReason}: {reason}" };
 }

--- a/WebReaper.AI/Tools/PageActionTools.cs
+++ b/WebReaper.AI/Tools/PageActionTools.cs
@@ -462,4 +462,89 @@ internal static class PageActionTools
                 : ToolCallResult<PageAction.SemanticAct>.Ok(new PageAction.SemanticAct(intent));
         }
     }
+
+    // ---- Derived-registry arm list (ADR-0078 Axis B) ------------------------
+
+    /// <summary>
+    /// The single source list both AI tool registries derive from (ADR-0078
+    /// Axis B). Each entry pairs an arm's <see cref="PageActionArm.Descriptor"/>
+    /// (the tool offered to the model) with the parse that decodes the model's
+    /// call (<see cref="PageActionArm.ToAction"/> /
+    /// <see cref="PageActionArm.ResolverToAction"/>), so the tool offered and
+    /// the parse that decodes it are the same list seen two ways and cannot
+    /// drift. <see cref="AgentDecisionTools.ForBrain"/> maps every entry through
+    /// an <see cref="WebReaper.Domain.Agent.AgentDecision.Act"/> wrapper;
+    /// <see cref="AgentDecisionTools.ForResolver"/> is the subset whose entries
+    /// expose a resolver adapter.
+    /// <para>
+    /// Fork 8 (ADR-0060): <see cref="SemanticAct"/> is the one
+    /// <see cref="BrainOnly"/> entry — its <see cref="PageActionArm.ResolverToAction"/>
+    /// is <c>null</c>, so it cannot appear in a registry derived from this list.
+    /// The resolver's "never return SemanticAct" rule is a structural absence,
+    /// not a runtime name filter.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<PageActionArm> Arms { get; } =
+    [
+        Concrete(Click.Descriptor, Click.FromArguments),
+        Concrete(Wait.Descriptor, Wait.FromArguments),
+        Concrete(WaitForSelector.Descriptor, WaitForSelector.FromArguments),
+        Concrete(WaitForNetworkIdle.Descriptor, WaitForNetworkIdle.FromArguments),
+        Concrete(ScrollToEnd.Descriptor, ScrollToEnd.FromArguments),
+        Concrete(ScrollIntoView.Descriptor, ScrollIntoView.FromArguments),
+        Concrete(EvaluateExpression.Descriptor, EvaluateExpression.FromArguments),
+        Concrete(Press.Descriptor, Press.FromArguments),
+        Concrete(Fill.Descriptor, Fill.FromArguments),
+        BrainOnly(SemanticAct.Descriptor, SemanticAct.FromArguments),
+    ];
+
+    // A concrete arm: one parse serves both the brain (which wraps the result
+    // in Act) and the resolver (raw). The same delegate is referenced twice, so
+    // the brain-offered and resolver-offered shapes cannot decode differently.
+    private static PageActionArm Concrete<T>(
+        AIFunction descriptor, Func<JsonElement, ToolCallResult<T>> fromArguments)
+        where T : PageAction
+    {
+        Func<JsonElement, ToolCallResult<PageAction>> parse = args => Widen(fromArguments(args));
+        return new PageActionArm(descriptor, parse, parse);
+    }
+
+    // A brain-only arm (SemanticAct, fork 8): a brain parse but NO resolver
+    // adapter, so it is structurally absent from the derived resolver registry.
+    private static PageActionArm BrainOnly<T>(
+        AIFunction descriptor, Func<JsonElement, ToolCallResult<T>> fromArguments)
+        where T : PageAction
+        => new(descriptor, args => Widen(fromArguments(args)), ResolverToAction: null);
+
+    // Widen a per-arm ToolCallResult<TArm> to the erased ToolCallResult<PageAction>
+    // so every arm shares one list-element type. Success and failure carry
+    // through unchanged.
+    private static ToolCallResult<PageAction> Widen<T>(ToolCallResult<T> result)
+        where T : PageAction
+        => result.Value is { } arm
+            ? ToolCallResult<PageAction>.Ok(arm)
+            : ToolCallResult<PageAction>.Failed(result.FailureReason!);
 }
+
+/// <summary>
+/// One entry in <see cref="PageActionTools.Arms"/> (ADR-0078 Axis B): a
+/// <see cref="PageAction"/> arm's tool <see cref="Descriptor"/> paired with the
+/// parse(s) that decode a tool call into the arm.
+/// <para>
+/// <see cref="ToAction"/> is the brain-side parse (the brain wraps the result
+/// in <see cref="WebReaper.Domain.Agent.AgentDecision.Act"/>); present for
+/// every arm. <see cref="ResolverToAction"/> is the resolver-side parse, and is
+/// <c>null</c> for a brain-only arm (<see cref="PageAction.SemanticAct"/>, fork
+/// 8) so the arm stays out of the derived resolver registry structurally rather
+/// than via a runtime name filter.
+/// </para>
+/// </summary>
+/// <param name="Descriptor">The hand-rolled tool schema offered to the model.</param>
+/// <param name="ToAction">Decodes a tool call's arguments into the
+/// <see cref="PageAction"/> arm (or a failure); the brain consumes this.</param>
+/// <param name="ResolverToAction">The resolver-side decode; <c>null</c> for
+/// brain-only arms, which the resolver registry derivation then omits.</param>
+internal sealed record PageActionArm(
+    AIFunction Descriptor,
+    Func<JsonElement, ToolCallResult<PageAction>> ToAction,
+    Func<JsonElement, ToolCallResult<PageAction>>? ResolverToAction);

--- a/WebReaper.Tests/WebReaper.AI.Tests/AgentDecisionToolsTests.cs
+++ b/WebReaper.Tests/WebReaper.AI.Tests/AgentDecisionToolsTests.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 using WebReaper.AI.Tools;
+using WebReaper.Domain.Agent;
+using WebReaper.Domain.PageActions;
 
 namespace WebReaper.AI.Tests;
 
@@ -218,6 +220,85 @@ public class AgentDecisionToolsTests
                 $"resolver tool {tool.Name} must have a description");
         }
     }
+
+    // ---- Derived-registry parse coverage (ADR-0078 Axis B) -----------------
+    //
+    // The anti-drift invariant: both registries and both parse paths derive
+    // from one PageActionTools.Arms list, so every offered tool is parseable.
+    // Pre-derivation this could silently break — an arm in ForBrain() but not
+    // in the brain's switch fell through to Stop; in ForResolver() but not the
+    // resolver's switch fell through to null — with no error.
+
+    [Fact]
+    public void Every_brain_tool_name_resolves_through_ParseBrainTool()
+    {
+        // Empty args: arms with required fields return Stop("brain X missing
+        // ..."), which is fine. The point is that none fall through to the
+        // "unregistered tool" branch — every offered tool is recognized.
+        foreach (var tool in AgentDecisionTools.ForBrain())
+        {
+            var decision = AgentDecisionTools.ParseBrainTool(tool.Name, Args("{}"));
+            if (decision is AgentDecision.Stop stop)
+            {
+                Assert.DoesNotContain("unregistered tool", stop.Reason);
+            }
+        }
+    }
+
+    [Fact]
+    public void Unregistered_brain_tool_name_is_the_only_unregistered_path()
+    {
+        var decision = AgentDecisionTools.ParseBrainTool("NotARealTool", Args("{}"));
+        var stop = Assert.IsType<AgentDecision.Stop>(decision);
+        Assert.Contains("unregistered tool 'NotARealTool'", stop.Reason);
+    }
+
+    [Fact]
+    public void Every_resolver_tool_name_resolves_through_ParseResolverTool()
+    {
+        // The resolver returns null for BOTH an unknown tool and a per-arm
+        // failure, so the only way to prove "recognized" is valid args ->
+        // non-null. ValidArgs must carry an entry per resolver tool; a new
+        // resolver arm without one trips the indexer (and this assertion).
+        foreach (var tool in AgentDecisionTools.ForResolver())
+        {
+            var action = AgentDecisionTools.ParseResolverTool(tool.Name, ValidArgs[tool.Name]);
+            Assert.NotNull(action);
+        }
+    }
+
+    [Fact]
+    public void Resolver_does_not_parse_ActSemanticAct_even_with_valid_args()
+    {
+        // Fork 8 at the parse level (registry-absence is pinned above): the
+        // brain parses ActSemanticAct into Act(SemanticAct); the resolver does
+        // not recognize it at all, even with otherwise-valid arguments.
+        var intent = Args("""{ "intent": "open the menu" }""");
+
+        var brain = AgentDecisionTools.ParseBrainTool("ActSemanticAct", intent);
+        var act = Assert.IsType<AgentDecision.Act>(brain);
+        Assert.IsType<PageAction.SemanticAct>(act.Action);
+
+        Assert.Null(AgentDecisionTools.ParseResolverTool("ActSemanticAct", intent));
+    }
+
+    // Minimal valid arguments per resolver tool — enough for FromArguments to
+    // succeed so a recognized tool returns a non-null arm.
+    private static readonly IReadOnlyDictionary<string, JsonElement> ValidArgs =
+        new Dictionary<string, JsonElement>
+        {
+            ["ActClick"] = Args("""{ "selector": ".x" }"""),
+            ["ActWait"] = Args("""{ "ms": 0 }"""),
+            ["ActWaitForSelector"] = Args("""{ "selector": ".x" }"""),
+            ["ActWaitForNetworkIdle"] = Args("{}"),
+            ["ActScrollToEnd"] = Args("{}"),
+            ["ActEvaluate"] = Args("""{ "expression": "1" }"""),
+            ["ActScrollIntoView"] = Args("""{ "selector": ".x" }"""),
+            ["ActPress"] = Args("""{ "key": "Enter" }"""),
+            ["ActFill"] = Args("""{ "selector": ".x", "value": "y" }"""),
+        };
+
+    private static JsonElement Args(string json) => JsonDocument.Parse(json).RootElement;
 
     // ---- Helpers -----------------------------------------------------------
 

--- a/WebReaper.Tests/WebReaper.Cdp.Tests/CdpPageActionDispatchTests.cs
+++ b/WebReaper.Tests/WebReaper.Cdp.Tests/CdpPageActionDispatchTests.cs
@@ -172,6 +172,63 @@ public class CdpPageActionDispatchTests
         Assert.Contains("ReferenceError", ex.Message);
     }
 
+    // ADR-0078 Axis A: C# has no closed-hierarchy exhaustiveness — a
+    // discard-less switch expression over PageAction warns CS8509 even when
+    // every arm is handled, so it cannot be both clean today and a compile
+    // error when an arm is added (verified). This is the CI substitute for the
+    // CDP transport: dispatch every PageAction arm and assert none reaches the
+    // switch's `default: throw ArgumentOutOfRangeException`. The reflection
+    // check forces a sample to be added when a PageAction arm is added, and the
+    // dispatch then proves the transport actually handles it.
+    [Fact]
+    public async Task Every_PageAction_arm_dispatches_without_hitting_the_default()
+    {
+        PageAction[] samples =
+        [
+            new PageAction.Click(".x"),
+            new PageAction.Wait(1),
+            new PageAction.WaitForSelector(".x", 1000),
+            new PageAction.WaitForNetworkIdle(),
+            new PageAction.ScrollToEnd(),
+            new PageAction.ScrollIntoView(".x"),
+            new PageAction.EvaluateExpression("1"),
+            new PageAction.Press("Enter"),
+            new PageAction.Fill(".x", "y"),
+            new PageAction.SemanticAct("do it"),
+        ];
+
+        // Completeness: the samples cover every concrete PageAction arm, so a
+        // newly-added arm trips this until a sample is added here.
+        var armTypes = typeof(PageAction).GetNestedTypes()
+            .Where(t => t.IsSealed && t.IsSubclassOf(typeof(PageAction)))
+            .ToHashSet();
+        var sampled = samples.Select(s => s.GetType()).ToHashSet();
+        Assert.True(armTypes.SetEquals(sampled),
+            "Sample set must cover every PageAction arm. Add a sample for the new arm. " +
+            $"Uncovered: [{string.Join(", ", armTypes.Except(sampled).Select(t => t.Name))}]");
+
+        foreach (var arm in samples)
+        {
+            var session = new FakeCdpSession();
+            // Every querySelector poll finds its element; every evaluate succeeds.
+            session.OnSend("Runtime.evaluate", _ => new JsonObject
+            {
+                ["result"] = new JsonObject { ["value"] = true }
+            });
+            // SemanticAct resolves to a concrete arm via the resolver.
+            var coord = new SemanticActCoordinator(
+                new RecordingResolver(_ => new PageAction.Click(".resolved")),
+                NullLogger.Instance);
+
+            var ex = await Record.ExceptionAsync(() =>
+                CdpPageActionDispatcher.PerformAsync(session, SessionId, arm, coord, default));
+
+            Assert.False(ex is ArgumentOutOfRangeException,
+                $"{arm.GetType().Name} fell through to the dispatcher's default (unhandled arm)");
+            Assert.Null(ex);
+        }
+    }
+
     private sealed class RecordingResolver : IActionResolver
     {
         private readonly Func<string, PageAction?> _resolve;

--- a/WebReaper.Tests/WebReaper.UnitTests/PageActionArmCensusTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/PageActionArmCensusTests.cs
@@ -1,0 +1,50 @@
+using WebReaper.Domain.PageActions;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0078 Axis A: a PageAction arm is interpreted in several packages that
+// core cannot reference (ADR-0009) — the two browser transports' dispatch
+// switches and the AI tool registries — so an arm cannot live in one file, and
+// C# has no closed-hierarchy exhaustiveness to make a forgotten arm a compile
+// error (a discard-less switch expression warns CS8509 even when every arm is
+// handled). This census is the cheap, transport-agnostic tripwire: when the
+// arm set changes it fails with a checklist of every consumer to update. It is
+// the primary guard for the Playwright transport, which (unlike CDP) has no
+// unit-test seam for its private IPage dispatch; CDP additionally proves it
+// handles every arm in WebReaper.Cdp.Tests.CdpPageActionDispatchTests.
+public class PageActionArmCensusTests
+{
+    [Fact]
+    public void PageAction_arm_set_is_pinned_so_a_new_arm_forces_updating_every_consumer()
+    {
+        var arms = typeof(PageAction).GetNestedTypes()
+            .Where(t => t.IsSealed && t.IsSubclassOf(typeof(PageAction)))
+            .Select(t => t.Name)
+            .ToHashSet();
+
+        var expected = new HashSet<string>
+        {
+            nameof(PageAction.Click),
+            nameof(PageAction.Wait),
+            nameof(PageAction.WaitForSelector),
+            nameof(PageAction.WaitForNetworkIdle),
+            nameof(PageAction.ScrollToEnd),
+            nameof(PageAction.ScrollIntoView),
+            nameof(PageAction.EvaluateExpression),
+            nameof(PageAction.Press),
+            nameof(PageAction.Fill),
+            nameof(PageAction.SemanticAct),
+        };
+
+        Assert.True(arms.SetEquals(expected),
+            "PageAction's arm set changed. An arm is interpreted in places core cannot " +
+            "reference, so update ALL of them, then this census:\n" +
+            "  - WebReaper.Cdp/CdpPageActionDispatcher.PerformAsync (switch arm)\n" +
+            "  - WebReaper.Playwright/PlaywrightPageLoadTransport.PerformAsync (switch arm)\n" +
+            "  - WebReaper.AI Tools/PageActionTools.Arms (brain + resolver registries derive from it)\n" +
+            "  - WebReaper.Builders.PageActionBuilder (if user-constructable)\n" +
+            "  - the PageAction closed-sum codec under WebReaper/Serialization/Converters\n" +
+            $"Expected: [{string.Join(", ", expected.OrderBy(x => x))}]\n" +
+            $"Actual:   [{string.Join(", ", arms.OrderBy(x => x))}]");
+    }
+}

--- a/docs/adr/0078-derived-tool-registries-and-dispatch-exhaustiveness.md
+++ b/docs/adr/0078-derived-tool-registries-and-dispatch-exhaustiveness.md
@@ -1,6 +1,8 @@
 # 0078. Derived Tool Registries and Transport Dispatch Exhaustiveness
 
-- **Status:** Accepted — design pass; implementation pending (2026-05-29)
+- **Status:** Accepted — implemented 2026-05-29. Axis A's original
+  switch-expression mechanism proved infeasible in C# and was re-decided as a
+  CI coverage guard (see Decision + Alternatives).
 - **Date:** 2026-05-29
 - **Deciders:** Alex (HITL), Claude (architecture pass)
 
@@ -36,14 +38,42 @@ problems remain:
 
 Two axes.
 
-**Axis A — exhaustiveness idiom on the transports.** Convert both transport
-dispatch switch-statements (`CdpPageActionDispatcher.PerformAsync`,
-`PlaywrightPageLoadTransport.PerformAsync`) to switch-*expressions* with no
-discard arm. Adding a `PageAction` arm then fails to compile in each satellite
-until handled — the runtime `default: throw` becomes a compile-time guarantee.
-No new module, no core↔satellite seam; each transport keeps its native body
-(CDP's `Runtime.evaluate` JS, Playwright's locator/keyboard APIs). ADR-0009
-untouched.
+**Axis A — exhaustiveness guard on the transports.** The two transport dispatch
+switch-*statements* (`CdpPageActionDispatcher.PerformAsync`,
+`PlaywrightPageLoadTransport.PerformAsync`) keep their `default: throw
+ArgumentOutOfRangeException`, and a CI test asserts every `PageAction` arm
+dispatches without reaching that default. No new module, no core/satellite
+seam; each transport keeps its native body (CDP's `Runtime.evaluate` JS,
+Playwright's locator/keyboard APIs). ADR-0009 untouched.
+
+This re-decides the design pass's original plan (convert the switch-*statements*
+to discard-less switch-*expressions* so a new arm fails to compile). That plan
+rests on a compiler capability C# does not have. C# has no closed-hierarchy
+exhaustiveness (discriminated unions are unshipped as of C# 14 / .NET 10), so a
+discard-less switch expression over `PageAction` reports CS8509 ("not
+exhaustive") even when every arm is handled; the closed sum's private
+constructor does not change this. CS8509 is therefore present identically
+whether or not a new arm has been added, so as a warning it carries no
+incremental signal, and promoting it to an error breaks the already-complete
+switch today. A discard-less switch expression cannot be both clean now and a
+compile error on a new arm. (Verified empirically on the .NET 10 SDK across
+`LangVersion` 12 and `latest`.)
+
+The achievable guard is a test, run in CI:
+- **CDP** gets an execution-coverage test
+  (`WebReaper.Cdp.Tests.CdpPageActionDispatchTests`): it reflects every
+  `PageAction` arm, dispatches each through `PerformAsync` against the
+  `FakeCdpSession`, and asserts none throws `ArgumentOutOfRangeException`. A new
+  arm trips a reflection completeness check (forcing a sample), and the sample
+  then proves the CDP transport handles it.
+- **Playwright** has no unit-test seam (its `PerformAsync` is private over a
+  real Microsoft.Playwright `IPage`, which the repo's hand-fake convention
+  cannot stand up without a mocking dependency). It is guarded by a core-side
+  arm-census test (`WebReaper.UnitTests.PageActionArmCensusTests`) that pins the
+  `PageAction` arm set and fails with a checklist of every consumer to update
+  (both transports, the AI registries, the builder, the codec), plus the
+  runtime `default: throw` as the backstop. Giving Playwright its own
+  execution-coverage test (a faked or mocked `IPage`) is a deferred follow-up.
 
 **Axis B — derived registries in the satellite.** Both the brain and resolver
 registries become derived views of one `PageActionArms` arm list. Each entry is
@@ -57,11 +87,13 @@ filtered to entries that expose a resolver adapter.
 
 Fork 8 of ADR-0060 (the resolver must never return `SemanticAct`, which would
 loop the transport's resolution path) is preserved **structurally**:
-`SemanticAct` exposes no resolver adapter, so it cannot appear in a registry
-derived from the arm list — a compile-time absence, not a runtime `.Where(x !=
-SemanticAct)` filter or a hand-maintained second list. The `_ => null`
-(resolver) / `_ => Stop` (brain) fallback remains, but now catches only a
-genuinely hallucinated tool name, never a wiring omission.
+`SemanticAct`'s arm entry carries no resolver adapter (`ResolverToAction` is
+`null`), so the resolver registry and the resolver parse, both derived from
+`Arms.Where(a => a.ResolverToAction is not null)`, omit it together. The absence
+is structural (the entry has nothing for the derivation to include), not a
+runtime identity filter (`.Where(x != SemanticAct)`) or a hand-maintained second
+list. The `_ => null` (resolver) / `_ => Stop` (brain) fallback remains, but now
+catches only a genuinely hallucinated tool name, never a wiring omission.
 
 ## Consequences
 
@@ -70,13 +102,19 @@ Good:
   switches) to one (`PageActionArms`) plus at most one (a brain-native arm).
 - The silent-drop failure class is eliminated: the descriptor and the parse are
   the same list, so an arm offered to the model is always parseable.
-- A new arm that a transport forgets is now a compile error in that satellite.
+- A new arm a transport forgets is caught in CI: by the CDP execution-coverage
+  test for CDP, and by the core arm-census tripwire (which lists every consumer
+  to update) for Playwright and the rest.
 - Fork 8's loop-prevention stays structural — strengthened from
   double-omission-from-two-lists to single-absence-of-an-adapter.
 
 Bad / costs:
 - One derived-registry indirection in the satellite (an arm list + a mapping)
   in place of two literal lists.
+- Axis A's guard is CI-time, not compile-time (C# cannot give the latter for a
+  closed sum), and Playwright's coverage is a census tripwire plus the runtime
+  throw rather than execution-proven. A faked/mocked `IPage` execution test for
+  Playwright is a deferred follow-up.
 
 ## Alternatives considered
 
@@ -87,7 +125,25 @@ Bad / costs:
   evaluate-JS compositions — a capability regression — and it introduces a
   core↔satellite seam that re-litigates ADR-0009. The twin switches are
   correct-by-design (transport-specific bodies); only their *exhaustiveness
-  enforcement* was weak, which Axis A fixes without a new seam.
+  enforcement* was weak, which Axis A's CI coverage test addresses without a new
+  seam.
+- **Discard-less switch expressions on the transports (the design pass's
+  original Axis A).** Rejected: infeasible in C#. A switch expression over a
+  class hierarchy is never provably exhaustive to Roslyn, so CS8509 fires even
+  when every arm is handled (the `PageAction` private constructor does not help)
+  and it cannot be both clean today and a compile error when an arm is added.
+  Verified on the .NET 10 SDK. The CI coverage test is the achievable
+  substitute. Details in the Decision.
+- **An exhaustive `Match`/visitor on `PageAction` in core** (an abstract
+  `Match<T>(Func<Click,T>, …)` each arm overrides; both transports dispatch
+  through it with native-body lambdas). This *would* give a true compile-time
+  guarantee, symmetric across both transports, without generic primitives.
+  Rejected for this ADR: it adds a generic visitor to core public API and grows
+  per-arm boilerplate (a new arm means a new override plus a signature change
+  plus every call site), which cuts against the design pass's "no new core
+  machinery, transports keep native bodies" intent. The CI test gives most of
+  the protection at a fraction of the surface. Revisit if a third transport
+  lands or C# ships discriminated unions.
 - **Leave Axis B as-is** (the amendment already co-located per-arm concerns).
   Rejected: the residual four-list sync still allows the silent-drop failure,
   which is invisible (offered to the model, unparseable, no error).


### PR DESCRIPTION
Implements [ADR-0078](docs/adr/0078-derived-tool-registries-and-dispatch-exhaustiveness.md). The two axes are independent; both are here.

## Axis B — derived registries (the core of the ADR)

Collapses the four hand-synced AI tool lists into one source list `PageActionTools.Arms` (each entry a `(Descriptor, Parse)` pair). Both registries and both parse paths are now derived views:

- `AgentDecisionTools.ForBrain()` (13) and `ParseBrainTool` derive from the three native arms + `Arms`.
- `AgentDecisionTools.ForResolver()` (9) and `ParseResolverTool` derive from `Arms.Where(a => a.ResolverToAction is not null)`.

Because each registry's offered tool and the parse that decodes it come from the same list, they cannot drift. The prior hazard (register an arm in `ForBrain()` but forget its parse case, and the model's call silently became `Stop`; resolver side silently `null`) is eliminated. `LlmAgentBrain`/`LlmActionResolver` lose their parse switches and delegate to `AgentDecisionTools`.

**Fork 8 stays structural:** `SemanticAct` carries no resolver adapter (`ResolverToAction == null`), so it is absent from both the resolver registry and the resolver parse, which derive from the same predicate. Not a runtime `.Where(x != SemanticAct)`.

## Axis A — re-decided (please read)

The design pass's mechanism (convert the transport switch-*statements* to discard-less switch-*expressions* so a new `PageAction` arm fails to compile) **is not achievable in C#**. I verified empirically on the .NET 10 SDK (LangVersion 12 and `latest`): C# has no closed-hierarchy exhaustiveness, so a discard-less switch expression over `PageAction` reports CS8509 *even when every arm is handled* (the private constructor does not help). CS8509 is therefore identical with or without a new arm (no incremental signal as a warning), and promoting it to an error breaks the already-complete switch today. It cannot be both clean now and a compile error on a new arm.

Re-decided as a **CI guard** (transports keep their switch statements and native bodies):

- **CDP** gets a real execution-coverage test: reflect every `PageAction` arm, dispatch each through `CdpPageActionDispatcher.PerformAsync` against `FakeCdpSession`, assert none hits the `default: throw`. A reflection completeness check forces a sample when an arm is added; the sample then proves CDP handles it.
- **Playwright** has no unit-test seam (`PerformAsync` is private over a real `IPage`; the repo uses no mocking framework). Guarded by a core-side **arm-census** test (`PageActionArmCensusTests`) that pins the `PageAction` arm set and fails with a checklist of every consumer to update, plus the runtime throw as backstop. A faked/mocked-`IPage` Playwright coverage test is a deferred follow-up.

The ADR has been updated: Axis A's Decision, Consequences, and Alternatives now record the CS8509 finding and the re-decision (including a rejected `Match`/visitor option, which would give compile-time exhaustiveness at the cost of core public-API surface and per-arm boilerplate).

## Verification

- `dotnet build WebReaper.sln`: clean (0 errors, no new warnings).
- Unit 446, AI 274 (+4 Axis B parse-coverage tests), CDP 17 (+1 coverage test). New tests confirmed registered by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)