### PR TITLE
ADR-0077: ClosedSumCodec mechanism for the flat closed-sum codecs

### DIFF
--- a/WebReaper.Tests/WebReaper.UnitTests/ClosedSumCodecTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/ClosedSumCodecTests.cs
@@ -1,0 +1,159 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using WebReaper.Domain.Agent;
+using WebReaper.Domain.PageActions;
+using WebReaper.Domain.Parsing;
+using WebReaper.Serialization.Converters;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0077: the three flat closed sums (PageAction, AgentDecision,
+// AgentDecisionOutcome) serialize through the shared ClosedSumCodec mechanism.
+// These are characterization tests written against the wire format and kept
+// green across the migration. Byte-stability is load-bearing (persisted agent
+// snapshots and configs must round-trip), so the exact-bytes tests pin field
+// order (type-first for PageAction / AgentDecisionOutcome, reason-before-type
+// for AgentDecision) and the round-trips pin every arm. They exercise the
+// public *Codec.Write / Read facades, which stay byte-identical through the
+// migration.
+public class ClosedSumCodecTests
+{
+    // ---- exact wire format (field order is load-bearing) -------------------
+
+    [Fact]
+    public void PageAction_writes_type_first()
+        => Assert.Equal(
+            """{"type":"waitForSelector","selector":".m","timeoutMs":42}""",
+            WritePageAction(new PageAction.WaitForSelector(".m", 42)));
+
+    [Fact]
+    public void AgentDecision_writes_reason_before_type()
+        // The ADR pins this ordering: reason is the common field, emitted
+        // before the discriminator. Persisted snapshots depend on it.
+        => Assert.Equal(
+            """{"reason":"because","type":"follow","url":"https://x/"}""",
+            WriteDecision(new AgentDecision.Follow("https://x/") { Reason = "because" }));
+
+    [Fact]
+    public void AgentDecisionOutcome_writes_type_first()
+        => Assert.Equal(
+            """{"type":"followed","actualUrl":"https://x/","statusCode":200}""",
+            WriteOutcome(new AgentDecisionOutcome.Followed("https://x/", 200)));
+
+    [Fact]
+    public void Extracted_outcome_omits_record_when_null_but_keeps_count()
+        => Assert.Equal(
+            """{"type":"extracted","recordCount":2}""",
+            WriteOutcome(new AgentDecisionOutcome.Extracted(null, 2)));
+
+    // ---- round-trip every arm ----------------------------------------------
+
+    [Fact]
+    public void Every_PageAction_arm_round_trips()
+    {
+        PageAction[] arms =
+        [
+            new PageAction.Click(".c"),
+            new PageAction.Wait(7),
+            new PageAction.ScrollToEnd(),
+            new PageAction.EvaluateExpression("1+1"),
+            new PageAction.WaitForSelector(".s", 99),
+            new PageAction.WaitForNetworkIdle(),
+            new PageAction.ScrollIntoView(".v"),
+            new PageAction.SemanticAct("do it"),
+            new PageAction.Press("Enter"),
+            new PageAction.Fill(".f", "val"),
+        ];
+        foreach (var a in arms)
+            Assert.Equal(a, RoundTripPageAction(a)); // records: value equality
+    }
+
+    [Fact]
+    public void Every_AgentDecision_arm_round_trips()
+    {
+        var schema = new Schema();
+        schema.Add(new SchemaElement("title", "h1"));
+        AgentDecision[] arms =
+        [
+            new AgentDecision.Extract(schema) { Reason = "r1" },
+            new AgentDecision.Follow("https://x/") { Reason = "r2" },
+            new AgentDecision.Act(new PageAction.Click(".a")) { Reason = "r3" },
+            new AgentDecision.Stop { Reason = "r4" },
+        ];
+        foreach (var d in arms)
+        {
+            var rt = RoundTripDecision(d);
+            Assert.Equal(d.GetType(), rt.GetType());
+            Assert.Equal(d.Reason, rt.Reason);
+        }
+
+        // The Act arm carries its nested PageAction across the round-trip.
+        var act = Assert.IsType<AgentDecision.Act>(RoundTripDecision(arms[2]));
+        Assert.Equal(".a", Assert.IsType<PageAction.Click>(act.Action).Selector);
+        // The Extract arm carries its nested Schema (a container, not a leaf).
+        var ext = Assert.IsType<AgentDecision.Extract>(RoundTripDecision(arms[0]));
+        Assert.Single(ext.Schema.Children);
+    }
+
+    // ---- unknown tag throws ------------------------------------------------
+
+    [Fact]
+    public void PageAction_unknown_tag_throws()
+        => Assert.Throws<JsonException>(() => ReadPageAction("""{"type":"nope"}"""));
+
+    [Fact]
+    public void AgentDecision_unknown_tag_throws()
+        => Assert.Throws<JsonException>(() => ReadDecision("""{"reason":"r","type":"nope"}"""));
+
+    [Fact]
+    public void AgentDecisionOutcome_unknown_tag_throws()
+        => Assert.Throws<JsonException>(() => ReadOutcome("""{"type":"nope"}"""));
+
+    // ---- missing-field messages --------------------------------------------
+
+    [Fact]
+    public void PageAction_missing_required_field_names_the_sum_arm_and_field()
+    {
+        var ex = Assert.Throws<JsonException>(() => ReadPageAction("""{"type":"click"}"""));
+        Assert.Equal("PageAction 'click' is missing required 'selector'", ex.Message);
+    }
+
+    [Fact]
+    public void AgentDecisionOutcome_actDispatched_missing_action_preserves_its_message()
+    {
+        // ActDispatched uses a bespoke message, not the shared Require format —
+        // pinned so the migration preserves it verbatim.
+        var ex = Assert.Throws<JsonException>(() => ReadOutcome("""{"type":"actDispatched"}"""));
+        Assert.Equal("AgentDecisionOutcome.ActDispatched missing 'resolvedAction'", ex.Message);
+    }
+
+    // ---- helpers (the public codec facades, stable across the migration) ----
+
+    private static string WritePageAction(PageAction a) => Write(w => PageActionCodec.Write(w, a));
+    private static string WriteDecision(AgentDecision d) => Write(w => AgentDecisionCodec.Write(w, d));
+    private static string WriteOutcome(AgentDecisionOutcome o) => Write(w => AgentDecisionOutcomeCodec.Write(w, o));
+
+    private static PageAction RoundTripPageAction(PageAction a) => ReadPageAction(WritePageAction(a));
+    private static AgentDecision RoundTripDecision(AgentDecision d) => ReadDecision(WriteDecision(d));
+
+    private static PageAction ReadPageAction(string json) => Read(json, (ref Utf8JsonReader r) => PageActionCodec.Read(ref r));
+    private static AgentDecision ReadDecision(string json) => Read(json, (ref Utf8JsonReader r) => AgentDecisionCodec.Read(ref r));
+    private static AgentDecisionOutcome ReadOutcome(string json) => Read(json, (ref Utf8JsonReader r) => AgentDecisionOutcomeCodec.Read(ref r));
+
+    private static string Write(Action<Utf8JsonWriter> write)
+    {
+        using var stream = new MemoryStream();
+        using (var w = new Utf8JsonWriter(stream)) write(w);
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private delegate T ReadFn<T>(ref Utf8JsonReader r);
+
+    private static T Read<T>(string json, ReadFn<T> read)
+    {
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+        Assert.True(reader.Read());
+        return read(ref reader);
+    }
+}

--- a/WebReaper/Serialization/Codecs/ClosedSumCodec.cs
+++ b/WebReaper/Serialization/Codecs/ClosedSumCodec.cs
@@ -1,0 +1,206 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace WebReaper.Serialization.Codecs;
+
+/// <summary>
+/// Read-side helpers for one materialized closed-sum arm (ADR-0077). A thin
+/// readonly struct over the <see cref="JsonObject"/> that
+/// <see cref="ClosedSumCodec{T}.Read"/> parsed once from the
+/// <c>ref struct</c> <see cref="Utf8JsonReader"/>; each arm's
+/// <c>build</c> delegate reads its fields through these helpers instead of
+/// hand-draining the reader. Carries the sum name and the resolved tag so the
+/// missing-field message reads exactly as the hand-written codecs did
+/// (<c>"&lt;Sum&gt; '&lt;tag&gt;' is missing required '&lt;field&gt;'"</c>).
+/// </summary>
+internal readonly struct ArmReaderContext
+{
+    private readonly JsonObject _obj;
+    private readonly string _sumName;
+    private readonly string _tag;
+
+    internal ArmReaderContext(JsonObject obj, string sumName, string tag)
+    {
+        _obj = obj;
+        _sumName = sumName;
+        _tag = tag;
+    }
+
+    /// <summary>The whole materialized arm object, for arms that need raw access.</summary>
+    public JsonObject Object => _obj;
+
+    /// <summary>A required string field; throws the shared missing-field
+    /// message when the field is absent or JSON null.</summary>
+    public string Require(string field)
+        => _obj[field]?.GetValue<string>() ?? throw Missing(field);
+
+    /// <summary>An optional string field; <c>null</c> when absent.</summary>
+    public string? OptionalString(string field)
+        => _obj[field]?.GetValue<string>();
+
+    /// <summary>An optional integer field; <paramref name="fallback"/> when
+    /// absent (matching the hand-written codecs' zero-initialised locals).</summary>
+    public int OptionalInt(string field, int fallback = 0)
+        => _obj[field] is { } n ? n.GetValue<int>() : fallback;
+
+    /// <summary>The common pre-discriminator field every arm of the sum shares
+    /// (AgentDecision's <c>reason</c>); empty string when absent, matching the
+    /// hand-written <c>reason ??= ""</c>.</summary>
+    public string Common(string field)
+        => _obj[field]?.GetValue<string>() ?? "";
+
+    /// <summary>A required nested value, built from its already-materialized
+    /// child node via <paramref name="from"/> (a migrated codec's <c>From</c>
+    /// or the bespoke <c>SchemaCodec.From</c>) — the composition seam. Throws
+    /// the shared missing-field message when the field is absent.</summary>
+    public TChild RequireChild<TChild>(string field, Func<JsonNode, TChild> from)
+        => _obj[field] is { } node ? from(node) : throw Missing(field);
+
+    /// <summary>An optional nested value; <c>null</c> when absent or JSON null.
+    /// The arm supplies its own message if it treats absence as an error (the
+    /// <c>ActDispatched.resolvedAction</c> bespoke message).</summary>
+    public TChild? OptionalChild<TChild>(string field, Func<JsonNode, TChild> from)
+        where TChild : class
+        => _obj[field] is { } node && node.GetValueKind() != JsonValueKind.Null
+            ? from(node)
+            : null;
+
+    /// <summary>An optional object field, returned as a detached deep clone so
+    /// it carries no parent — matching the fresh-node semantics of the
+    /// hand-written <c>JsonNode.Parse</c> on a streamed payload.</summary>
+    public JsonObject? OptionalObjectClone(string field)
+        => _obj[field] is JsonObject o ? (JsonObject)o.DeepClone() : null;
+
+    private JsonException Missing(string field)
+        => new($"{_sumName} '{_tag}' is missing required '{field}'");
+}
+
+/// <summary>
+/// The one hand-written-but-shared JSON mechanism the flat closed sums
+/// (<c>PageAction</c>, <c>AgentDecision</c>, <c>AgentDecisionOutcome</c>)
+/// describe their arms to (ADR-0077, ADR-0008's reflection-free posture). The
+/// serialization-layer sibling of the <c>WebReaper.AI</c> <c>LlmCall&lt;T&gt;</c>
+/// mechanism.
+/// <para>
+/// The mechanism owns the object envelope, the <c>type</c> discriminator (write
+/// + dispatch), the one-time <see cref="JsonNode.Parse(ref Utf8JsonReader, JsonNodeOptions?)"/>
+/// materialization (the <c>ref struct</c> reader can't be handed to a per-arm
+/// delegate, so the read side materializes once then dispatches on a plain
+/// <see cref="JsonObject"/>), the single missing-field contract (via
+/// <see cref="ArmReaderContext"/>), the unknown-tag throw, and the optional
+/// common-field pass. Each arm's descriptor owns only its tag, its field
+/// writes, and its build-from-object.
+/// </para>
+/// <para>
+/// AOT-clean (<c>System.Text.Json.Nodes</c> only, no reflection). The
+/// materialize-then-dispatch allocates one <see cref="JsonObject"/> per value;
+/// irrelevant at these call frequencies (config load, agent resume, per agent
+/// step). Bespoke codecs (<c>Schema</c>, <c>AgentRunSnapshot</c>, the
+/// <c>ImmutableQueue</c> chains) compose with this via the migrated codecs'
+/// <see cref="From"/> entry or their streaming <see cref="Read"/> shim.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The closed-sum base type.</typeparam>
+internal sealed class ClosedSumCodec<T> where T : class
+{
+    /// <summary>One arm's descriptor: its wire tag, its CLR type, how to write
+    /// its own fields, and how to build it from the materialized object.</summary>
+    internal sealed class ArmDescriptor
+    {
+        /// <summary>The <c>type</c> discriminator value for this arm.</summary>
+        public required string Tag { get; init; }
+
+        /// <summary>The concrete arm CLR type, the write-dispatch key.</summary>
+        public required Type ArmType { get; init; }
+
+        /// <summary>Writes only the arm's own fields (the mechanism writes the
+        /// envelope, any common field, and the type tag).</summary>
+        public required Action<Utf8JsonWriter, T> WriteFields { get; init; }
+
+        /// <summary>Builds the arm from the materialized object.</summary>
+        public required Func<ArmReaderContext, T> Build { get; init; }
+    }
+
+    /// <summary>Describe one arm. <typeparamref name="TArm"/> is the concrete
+    /// sealed arm; <paramref name="write"/> writes only the arm's own fields;
+    /// <paramref name="build"/> constructs the arm from the materialized object
+    /// via the <see cref="ArmReaderContext"/> helpers.</summary>
+    public static ArmDescriptor Arm<TArm>(
+        string tag,
+        Action<Utf8JsonWriter, TArm> write,
+        Func<ArmReaderContext, TArm> build) where TArm : T
+        => new()
+        {
+            Tag = tag,
+            ArmType = typeof(TArm),
+            WriteFields = (w, v) => write(w, (TArm)v),
+            Build = ctx => build(ctx),
+        };
+
+    /// <summary>Field-less arm: a one-liner for arms that carry no fields and
+    /// no common field (PageAction's <c>ScrollToEnd</c> / <c>WaitForNetworkIdle</c>,
+    /// AgentDecisionOutcome's <c>None</c>). Writes the tag only and constructs
+    /// via <paramref name="create"/>.</summary>
+    public static ArmDescriptor Arm<TArm>(string tag, Func<TArm> create) where TArm : T
+        => new()
+        {
+            Tag = tag,
+            ArmType = typeof(TArm),
+            WriteFields = (_, _) => { },
+            Build = _ => create(),
+        };
+
+    private readonly string _sumName;
+    private readonly Action<Utf8JsonWriter, T>? _writeCommon;
+    private readonly Dictionary<Type, ArmDescriptor> _byType;
+    private readonly Dictionary<string, ArmDescriptor> _byTag;
+
+    /// <param name="sumName">The sum's name, used verbatim in error messages
+    /// (<c>"PageAction"</c>, <c>"AgentDecision"</c>, <c>"AgentDecisionOutcome"</c>).</param>
+    /// <param name="arms">One descriptor per arm.</param>
+    /// <param name="writeCommon">Optional fields written after StartObject and
+    /// BEFORE the type tag — AgentDecision's <c>reason</c>. Byte order is
+    /// load-bearing; this is how reason-before-type is preserved.</param>
+    public ClosedSumCodec(
+        string sumName,
+        IReadOnlyList<ArmDescriptor> arms,
+        Action<Utf8JsonWriter, T>? writeCommon = null)
+    {
+        _sumName = sumName;
+        _writeCommon = writeCommon;
+        _byType = arms.ToDictionary(a => a.ArmType);
+        _byTag = arms.ToDictionary(a => a.Tag, StringComparer.Ordinal);
+    }
+
+    /// <summary>Write <paramref name="value"/> as
+    /// <c>{ [common…,] "type": tag, fields… }</c>.</summary>
+    public void Write(Utf8JsonWriter w, T value)
+    {
+        w.WriteStartObject();
+        _writeCommon?.Invoke(w, value);
+        if (!_byType.TryGetValue(value.GetType(), out var arm))
+            throw new JsonException($"unhandled {_sumName} arm '{value.GetType().Name}'");
+        w.WriteString("type", arm.Tag);
+        arm.WriteFields(w, value);
+        w.WriteEndObject();
+    }
+
+    /// <summary>Streaming entry: materialize one value from the reader and
+    /// dispatch. The <c>ref struct</c> reader is consumed once here. Leaves the
+    /// reader positioned on the value's closing token, exactly like a
+    /// hand-drained loop — so streaming consumers (the selector chain, the
+    /// agent snapshot) read a sequence of these unchanged.</summary>
+    public T Read(ref Utf8JsonReader r)
+        => From(JsonNode.Parse(ref r) ?? throw new JsonException("expected object"));
+
+    /// <summary>Materialized entry: build the arm from an already-parsed node —
+    /// the composition seam a parent arm uses for a nested child.</summary>
+    public T From(JsonNode node)
+    {
+        var obj = node as JsonObject ?? throw new JsonException("expected object");
+        var tag = obj["type"]?.GetValue<string>();
+        if (tag is null || !_byTag.TryGetValue(tag, out var arm))
+            throw new JsonException($"unknown {_sumName} type '{tag}'");
+        return arm.Build(new ArmReaderContext(obj, _sumName, tag));
+    }
+}

--- a/WebReaper/Serialization/Converters/AgentDecisionJsonConverter.cs
+++ b/WebReaper/Serialization/Converters/AgentDecisionJsonConverter.cs
@@ -1,88 +1,78 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using WebReaper.Domain.Agent;
-using WebReaper.Domain.PageActions;
+using WebReaper.Domain.Parsing;
+using WebReaper.Serialization.Codecs;
 
 namespace WebReaper.Serialization.Converters;
 
 /// <summary>
-/// <see cref="AgentDecision"/> codec (ADR-0051). Same shape as
-/// <see cref="PageActionCodec"/>: a <c>type</c> discriminator plus the arm's
-/// typed fields, with <c>reason</c> on every arm. Recursively uses
-/// <see cref="SchemaCodec"/> for the Extract arm's Schema and
-/// <see cref="PageActionCodec"/> for the Act arm's nested action — fully
-/// manual recursion, no nested serializer calls (AOT-trivially-safe).
+/// <see cref="AgentDecision"/> codec (ADR-0051). A <c>type</c> discriminator
+/// plus the arm's typed fields, with <c>reason</c> as the common field on every
+/// arm — written BEFORE the discriminator, a byte-order the persisted snapshots
+/// depend on.
+/// <para>
+/// Migrated to the shared <see cref="ClosedSumCodec{T}"/> mechanism (ADR-0077).
+/// The Extract arm composes <see cref="SchemaCodec.From"/> for its nested Schema
+/// and the Act arm composes <see cref="PageActionCodec.From"/> for its nested
+/// action — manual recursion via the mechanism's materialized child seam, no
+/// reflection (AOT-trivially-safe). The static <see cref="Write"/> /
+/// <see cref="Read"/> facade stays byte-identical so streaming callers (the
+/// agent snapshot codec) are unchanged.
+/// </para>
 /// </summary>
 internal static class AgentDecisionCodec
 {
-    public static void Write(Utf8JsonWriter w, AgentDecision d)
-    {
-        w.WriteStartObject();
-        w.WriteString("reason", d.Reason);
-        switch (d)
-        {
-            case AgentDecision.Extract x:
-                w.WriteString("type", "extract");
-                w.WritePropertyName("schema");
-                SchemaCodec.Write(w, x.Schema);
-                break;
-            case AgentDecision.Follow x:
-                w.WriteString("type", "follow");
-                w.WriteString("url", x.Url);
-                break;
-            case AgentDecision.Act x:
-                w.WriteString("type", "act");
-                w.WritePropertyName("action");
-                PageActionCodec.Write(w, x.Action);
-                break;
-            case AgentDecision.Stop:
-                w.WriteString("type", "stop");
-                break;
-            default:
-                throw new JsonException($"unhandled AgentDecision arm '{d.GetType().Name}'");
-        }
-        w.WriteEndObject();
-    }
+    private static readonly ClosedSumCodec<AgentDecision> Codec = new(
+        "AgentDecision",
+        [
+            ClosedSumCodec<AgentDecision>.Arm<AgentDecision.Extract>(
+                "extract",
+                (w, x) =>
+                {
+                    w.WritePropertyName("schema");
+                    SchemaCodec.Write(w, x.Schema);
+                },
+                ctx => new AgentDecision.Extract(ReadSchema(ctx)) { Reason = ctx.Common("reason") }),
+            ClosedSumCodec<AgentDecision>.Arm<AgentDecision.Follow>(
+                "follow",
+                (w, x) => w.WriteString("url", x.Url),
+                ctx => new AgentDecision.Follow(ctx.Require("url")) { Reason = ctx.Common("reason") }),
+            ClosedSumCodec<AgentDecision>.Arm<AgentDecision.Act>(
+                "act",
+                (w, x) =>
+                {
+                    w.WritePropertyName("action");
+                    PageActionCodec.Write(w, x.Action);
+                },
+                ctx => new AgentDecision.Act(ctx.RequireChild("action", PageActionCodec.From))
+                {
+                    Reason = ctx.Common("reason")
+                }),
+            ClosedSumCodec<AgentDecision>.Arm<AgentDecision.Stop>(
+                "stop",
+                (_, _) => { },
+                ctx => new AgentDecision.Stop { Reason = ctx.Common("reason") }),
+        ],
+        // The common field every arm shares, written before the discriminator.
+        writeCommon: (w, d) => w.WriteString("reason", d.Reason));
 
-    public static AgentDecision Read(ref Utf8JsonReader r)
-    {
-        if (r.TokenType != JsonTokenType.StartObject) throw new JsonException("expected object");
-        string? type = null;
-        string? reason = null;
-        string? url = null;
-        WebReaper.Domain.Parsing.Schema? schema = null;
-        PageAction? action = null;
-        while (r.Read() && r.TokenType != JsonTokenType.EndObject)
-        {
-            var prop = r.GetString();
-            r.Read();
-            switch (prop)
-            {
-                case "type": type = r.GetString(); break;
-                case "reason": reason = r.GetString(); break;
-                case "url": url = r.GetString(); break;
-                case "schema":
-                    var schemaElement = SchemaCodec.Read(ref r);
-                    schema = schemaElement as WebReaper.Domain.Parsing.Schema
-                        ?? throw new JsonException("AgentDecision.Extract schema must be a Schema container, not a leaf SchemaElement");
-                    break;
-                case "action": action = PageActionCodec.Read(ref r); break;
-                default: r.Skip(); break;
-            }
-        }
-        reason ??= "";
-        return type switch
-        {
-            "extract" => new AgentDecision.Extract(Require(schema, "schema", type)) { Reason = reason },
-            "follow" => new AgentDecision.Follow(Require(url, "url", type)) { Reason = reason },
-            "act" => new AgentDecision.Act(Require(action, "action", type)) { Reason = reason },
-            "stop" => new AgentDecision.Stop { Reason = reason },
-            _ => throw new JsonException($"unknown AgentDecision type '{type}'")
-        };
-    }
+    public static void Write(Utf8JsonWriter w, AgentDecision d) => Codec.Write(w, d);
 
-    private static T Require<T>(T? value, string field, string? type) where T : class =>
-        value ?? throw new JsonException($"AgentDecision '{type}' is missing required '{field}'");
+    public static AgentDecision Read(ref Utf8JsonReader r) => Codec.Read(ref r);
+
+    /// <summary>Build an <see cref="AgentDecision"/> from an already-materialized
+    /// node — the composition seam the agent snapshot codec could use for a
+    /// history entry (ADR-0077).</summary>
+    public static AgentDecision From(JsonNode node) => Codec.From(node);
+
+    // Extract's schema is a Schema container, never a leaf SchemaElement; the
+    // cast preserves the pre-migration error message verbatim.
+    private static Schema ReadSchema(ArmReaderContext ctx)
+        => ctx.RequireChild("schema", SchemaCodec.From) as Schema
+           ?? throw new JsonException(
+               "AgentDecision.Extract schema must be a Schema container, not a leaf SchemaElement");
 }
 
 internal sealed class AgentDecisionJsonConverter : JsonConverter<AgentDecision>

--- a/WebReaper/Serialization/Converters/AgentDecisionOutcomeJsonConverter.cs
+++ b/WebReaper/Serialization/Converters/AgentDecisionOutcomeJsonConverter.cs
@@ -3,120 +3,86 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using WebReaper.Domain.Agent;
 using WebReaper.Domain.PageActions;
+using WebReaper.Serialization.Codecs;
 
 namespace WebReaper.Serialization.Converters;
 
 /// <summary>
-/// <see cref="AgentDecisionOutcome"/> codec (ADR-0061). Same shape as
-/// <see cref="AgentDecisionCodec"/>: a <c>type</c> discriminator plus the
-/// arm's typed fields. Recursively uses
-/// <see cref="JsonNode.Parse(ref Utf8JsonReader, JsonNodeOptions?)"/> /
-/// <see cref="JsonObject.WriteTo(Utf8JsonWriter, JsonSerializerOptions)"/> for
-/// the <c>Extracted.Record</c> payload and <see cref="PageActionCodec"/> for
-/// the <c>ActDispatched.ResolvedAction</c> — fully manual recursion, no
-/// nested serializer calls (AOT-trivially-safe).
+/// <see cref="AgentDecisionOutcome"/> codec (ADR-0061). A <c>type</c>
+/// discriminator plus the arm's typed fields.
+/// <para>
+/// Migrated to the shared <see cref="ClosedSumCodec{T}"/> mechanism (ADR-0077).
+/// The Extracted arm carries an optional <see cref="JsonObject"/> record
+/// (cloned detached on read, matching the prior fresh-parse), and the
+/// ActDispatched arm composes <see cref="PageActionCodec.From"/> for its nested
+/// action while keeping its bespoke missing-field message. The static
+/// <see cref="Write"/> / <see cref="Read"/> facade stays byte-identical so the
+/// agent snapshot codec's streaming reader is unchanged.
+/// </para>
 /// </summary>
 internal static class AgentDecisionOutcomeCodec
 {
-    public static void Write(Utf8JsonWriter w, AgentDecisionOutcome o)
-    {
-        w.WriteStartObject();
-        switch (o)
-        {
-            case AgentDecisionOutcome.None:
-                w.WriteString("type", "none");
-                break;
-            case AgentDecisionOutcome.Extracted x:
-                w.WriteString("type", "extracted");
-                w.WriteNumber("recordCount", x.RecordCount);
-                if (x.Record is not null)
+    private static readonly ClosedSumCodec<AgentDecisionOutcome> Codec = new(
+        "AgentDecisionOutcome",
+        [
+            ClosedSumCodec<AgentDecisionOutcome>.Arm<AgentDecisionOutcome.None>(
+                "none", () => new AgentDecisionOutcome.None()),
+            ClosedSumCodec<AgentDecisionOutcome>.Arm<AgentDecisionOutcome.Extracted>(
+                "extracted",
+                (w, x) =>
                 {
-                    w.WritePropertyName("record");
-                    x.Record.WriteTo(w);
-                }
-                break;
-            case AgentDecisionOutcome.Followed x:
-                w.WriteString("type", "followed");
-                w.WriteString("actualUrl", x.ActualUrl);
-                w.WriteNumber("statusCode", x.StatusCode);
-                break;
-            case AgentDecisionOutcome.ActDispatched x:
-                w.WriteString("type", "actDispatched");
-                w.WritePropertyName("resolvedAction");
-                PageActionCodec.Write(w, x.ResolvedAction);
-                break;
-            case AgentDecisionOutcome.Failed x:
-                w.WriteString("type", "failed");
-                w.WriteString("reason", x.Reason);
-                if (x.ExceptionType is not null)
-                    w.WriteString("exceptionType", x.ExceptionType);
-                break;
-            case AgentDecisionOutcome.Stopped x:
-                w.WriteString("type", "stopped");
-                w.WriteString("reason", x.Reason);
-                break;
-            default:
-                throw new JsonException($"unhandled AgentDecisionOutcome arm '{o.GetType().Name}'");
-        }
-        w.WriteEndObject();
-    }
+                    w.WriteNumber("recordCount", x.RecordCount);
+                    if (x.Record is not null)
+                    {
+                        w.WritePropertyName("record");
+                        x.Record.WriteTo(w);
+                    }
+                },
+                ctx => new AgentDecisionOutcome.Extracted(
+                    ctx.OptionalObjectClone("record"), ctx.OptionalInt("recordCount"))),
+            ClosedSumCodec<AgentDecisionOutcome>.Arm<AgentDecisionOutcome.Followed>(
+                "followed",
+                (w, x) =>
+                {
+                    w.WriteString("actualUrl", x.ActualUrl);
+                    w.WriteNumber("statusCode", x.StatusCode);
+                },
+                ctx => new AgentDecisionOutcome.Followed(
+                    ctx.Require("actualUrl"), ctx.OptionalInt("statusCode"))),
+            ClosedSumCodec<AgentDecisionOutcome>.Arm<AgentDecisionOutcome.ActDispatched>(
+                "actDispatched",
+                (w, x) =>
+                {
+                    w.WritePropertyName("resolvedAction");
+                    PageActionCodec.Write(w, x.ResolvedAction);
+                },
+                ctx => new AgentDecisionOutcome.ActDispatched(
+                    ctx.OptionalChild("resolvedAction", PageActionCodec.From)
+                    ?? throw new JsonException("AgentDecisionOutcome.ActDispatched missing 'resolvedAction'"))),
+            ClosedSumCodec<AgentDecisionOutcome>.Arm<AgentDecisionOutcome.Failed>(
+                "failed",
+                (w, x) =>
+                {
+                    w.WriteString("reason", x.Reason);
+                    if (x.ExceptionType is not null)
+                        w.WriteString("exceptionType", x.ExceptionType);
+                },
+                ctx => new AgentDecisionOutcome.Failed(
+                    ctx.Require("reason"), ctx.OptionalString("exceptionType"))),
+            ClosedSumCodec<AgentDecisionOutcome>.Arm<AgentDecisionOutcome.Stopped>(
+                "stopped",
+                (w, x) => w.WriteString("reason", x.Reason),
+                ctx => new AgentDecisionOutcome.Stopped(ctx.Require("reason"))),
+        ]);
 
-    public static AgentDecisionOutcome Read(ref Utf8JsonReader r)
-    {
-        if (r.TokenType != JsonTokenType.StartObject) throw new JsonException("expected object");
-        string? type = null;
-        string? reason = null;
-        string? exceptionType = null;
-        string? actualUrl = null;
-        int statusCode = 0;
-        int recordCount = 0;
-        JsonObject? record = null;
-        PageAction? resolvedAction = null;
+    public static void Write(Utf8JsonWriter w, AgentDecisionOutcome o) => Codec.Write(w, o);
 
-        while (r.Read() && r.TokenType != JsonTokenType.EndObject)
-        {
-            var prop = r.GetString();
-            r.Read();
-            switch (prop)
-            {
-                case "type": type = r.GetString(); break;
-                case "reason": reason = r.GetString(); break;
-                case "exceptionType": exceptionType = r.GetString(); break;
-                case "actualUrl": actualUrl = r.GetString(); break;
-                case "statusCode": statusCode = r.GetInt32(); break;
-                case "recordCount": recordCount = r.GetInt32(); break;
-                case "record":
-                    if (r.TokenType == JsonTokenType.Null) { record = null; break; }
-                    var node = JsonNode.Parse(ref r);
-                    record = node as JsonObject
-                        ?? throw new JsonException("AgentDecisionOutcome.Extracted record was not a JSON object");
-                    break;
-                case "resolvedAction":
-                    resolvedAction = PageActionCodec.Read(ref r);
-                    break;
-                default: r.Skip(); break;
-            }
-        }
+    public static AgentDecisionOutcome Read(ref Utf8JsonReader r) => Codec.Read(ref r);
 
-        return type switch
-        {
-            "none" => new AgentDecisionOutcome.None(),
-            "extracted" => new AgentDecisionOutcome.Extracted(record, recordCount),
-            "followed" => new AgentDecisionOutcome.Followed(
-                Require(actualUrl, "actualUrl", type), statusCode),
-            "actDispatched" => new AgentDecisionOutcome.ActDispatched(
-                resolvedAction
-                    ?? throw new JsonException("AgentDecisionOutcome.ActDispatched missing 'resolvedAction'")),
-            "failed" => new AgentDecisionOutcome.Failed(
-                Require(reason, "reason", type), exceptionType),
-            "stopped" => new AgentDecisionOutcome.Stopped(
-                Require(reason, "reason", type)),
-            _ => throw new JsonException($"unknown AgentDecisionOutcome type '{type}'")
-        };
-    }
-
-    private static string Require(string? value, string field, string? type) =>
-        value ?? throw new JsonException($"AgentDecisionOutcome '{type}' is missing required '{field}'");
+    /// <summary>Build an <see cref="AgentDecisionOutcome"/> from an
+    /// already-materialized node — the composition seam the agent snapshot codec
+    /// could use for the LastOutcome field (ADR-0077).</summary>
+    public static AgentDecisionOutcome From(JsonNode node) => Codec.From(node);
 }
 
 internal sealed class AgentDecisionOutcomeJsonConverter : JsonConverter<AgentDecisionOutcome>

--- a/WebReaper/Serialization/Converters/PageActionJsonConverter.cs
+++ b/WebReaper/Serialization/Converters/PageActionJsonConverter.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using WebReaper.Domain.PageActions;
+using WebReaper.Serialization.Codecs;
 
 namespace WebReaper.Serialization.Converters;
 
@@ -11,108 +13,81 @@ namespace WebReaper.Serialization.Converters;
 /// discriminator plus the arm's typed fields, and the pre-0035 per-value
 /// kind-tagging (the workaround for a genuinely-polymorphic <c>object[]</c>)
 /// is gone.
+/// <para>
+/// Migrated to the shared <see cref="ClosedSumCodec{T}"/> mechanism (ADR-0077):
+/// each arm is one <c>(tag, write, build)</c> row instead of a hand-written
+/// write switch + read loop + read switch. The static <see cref="Write"/> /
+/// <see cref="Read"/> facade stays byte-identical so callers (the converter
+/// wrapper, the selector-chain streaming reader) are unchanged; <see cref="From"/>
+/// is the composition seam a parent sum uses for a nested action.
+/// </para>
 /// </summary>
 internal static class PageActionCodec
 {
-    public static void Write(Utf8JsonWriter w, PageAction a)
-    {
-        w.WriteStartObject();
-        switch (a)
-        {
-            case PageAction.Click x:
-                w.WriteString("type", "click");
-                w.WriteString("selector", x.Selector);
-                break;
-            case PageAction.Wait x:
-                w.WriteString("type", "wait");
-                w.WriteNumber("ms", x.Milliseconds);
-                break;
-            case PageAction.ScrollToEnd:
-                w.WriteString("type", "scrollToEnd");
-                break;
-            case PageAction.EvaluateExpression x:
-                w.WriteString("type", "evaluateExpression");
-                w.WriteString("expression", x.Expression);
-                break;
-            case PageAction.WaitForSelector x:
-                w.WriteString("type", "waitForSelector");
-                w.WriteString("selector", x.Selector);
-                w.WriteNumber("timeoutMs", x.TimeoutMs);
-                break;
-            case PageAction.WaitForNetworkIdle:
-                w.WriteString("type", "waitForNetworkIdle");
-                break;
-            case PageAction.ScrollIntoView x:
-                w.WriteString("type", "scrollIntoView");
-                w.WriteString("selector", x.Selector);
-                break;
-            case PageAction.SemanticAct x:
-                // ADR-0050: persisted as the intent string only — the
-                // resolved arm is a per-crawl runtime concern and is
-                // intentionally never persisted (it'd freeze the LLM's
-                // selector across crawls, defeating the resolve-on-cache-miss
-                // recovery path).
-                w.WriteString("type", "semanticAct");
-                w.WriteString("intent", x.Intent);
-                break;
-            case PageAction.Press x:
-                // ADR-0074: key string is the only field; no selector.
-                w.WriteString("type", "press");
-                w.WriteString("key", x.Key);
-                break;
-            case PageAction.Fill x:
-                // ADR-0074: wire tag "fill" with selector + value fields.
-                w.WriteString("type", "fill");
-                w.WriteString("selector", x.Selector);
-                w.WriteString("value", x.Value);
-                break;
-            default:
-                throw new JsonException($"unhandled PageAction arm '{a.GetType().Name}'");
-        }
-        w.WriteEndObject();
-    }
+    private static readonly ClosedSumCodec<PageAction> Codec = new(
+        "PageAction",
+        [
+            ClosedSumCodec<PageAction>.Arm<PageAction.Click>(
+                "click",
+                (w, x) => w.WriteString("selector", x.Selector),
+                ctx => new PageAction.Click(ctx.Require("selector"))),
+            ClosedSumCodec<PageAction>.Arm<PageAction.Wait>(
+                "wait",
+                (w, x) => w.WriteNumber("ms", x.Milliseconds),
+                ctx => new PageAction.Wait(ctx.OptionalInt("ms"))),
+            ClosedSumCodec<PageAction>.Arm<PageAction.ScrollToEnd>(
+                "scrollToEnd", () => new PageAction.ScrollToEnd()),
+            ClosedSumCodec<PageAction>.Arm<PageAction.EvaluateExpression>(
+                "evaluateExpression",
+                (w, x) => w.WriteString("expression", x.Expression),
+                ctx => new PageAction.EvaluateExpression(ctx.Require("expression"))),
+            ClosedSumCodec<PageAction>.Arm<PageAction.WaitForSelector>(
+                "waitForSelector",
+                (w, x) =>
+                {
+                    w.WriteString("selector", x.Selector);
+                    w.WriteNumber("timeoutMs", x.TimeoutMs);
+                },
+                ctx => new PageAction.WaitForSelector(ctx.Require("selector"), ctx.OptionalInt("timeoutMs"))),
+            ClosedSumCodec<PageAction>.Arm<PageAction.WaitForNetworkIdle>(
+                "waitForNetworkIdle", () => new PageAction.WaitForNetworkIdle()),
+            ClosedSumCodec<PageAction>.Arm<PageAction.ScrollIntoView>(
+                "scrollIntoView",
+                (w, x) => w.WriteString("selector", x.Selector),
+                ctx => new PageAction.ScrollIntoView(ctx.Require("selector"))),
+            // ADR-0050: persisted as the intent string only — the resolved arm
+            // is a per-crawl runtime concern and is intentionally never
+            // persisted (it would freeze the LLM's selector across crawls,
+            // defeating the resolve-on-cache-miss recovery path).
+            ClosedSumCodec<PageAction>.Arm<PageAction.SemanticAct>(
+                "semanticAct",
+                (w, x) => w.WriteString("intent", x.Intent),
+                ctx => new PageAction.SemanticAct(ctx.Require("intent"))),
+            // ADR-0074: key string is the only field; no selector.
+            ClosedSumCodec<PageAction>.Arm<PageAction.Press>(
+                "press",
+                (w, x) => w.WriteString("key", x.Key),
+                ctx => new PageAction.Press(ctx.Require("key"))),
+            // ADR-0074: wire tag "fill" with selector + value fields.
+            ClosedSumCodec<PageAction>.Arm<PageAction.Fill>(
+                "fill",
+                (w, x) =>
+                {
+                    w.WriteString("selector", x.Selector);
+                    w.WriteString("value", x.Value);
+                },
+                ctx => new PageAction.Fill(ctx.Require("selector"), ctx.Require("value"))),
+        ]);
 
-    public static PageAction Read(ref Utf8JsonReader r)
-    {
-        if (r.TokenType != JsonTokenType.StartObject) throw new JsonException("expected object");
-        string? type = null, selector = null, expression = null, intent = null, key = null, value = null;
-        int ms = 0, timeoutMs = 0;
-        while (r.Read() && r.TokenType != JsonTokenType.EndObject)
-        {
-            var prop = r.GetString();
-            r.Read();
-            switch (prop)
-            {
-                case "type": type = r.GetString(); break;
-                case "selector": selector = r.GetString(); break;
-                case "expression": expression = r.GetString(); break;
-                case "intent": intent = r.GetString(); break;
-                case "key": key = r.GetString(); break;
-                case "value": value = r.GetString(); break;
-                case "ms": ms = r.GetInt32(); break;
-                case "timeoutMs": timeoutMs = r.GetInt32(); break;
-                default: r.Skip(); break;
-            }
-        }
-        return type switch
-        {
-            "click" => new PageAction.Click(Require(selector, "selector", type)),
-            "wait" => new PageAction.Wait(ms),
-            "scrollToEnd" => new PageAction.ScrollToEnd(),
-            "evaluateExpression" => new PageAction.EvaluateExpression(Require(expression, "expression", type)),
-            "waitForSelector" => new PageAction.WaitForSelector(Require(selector, "selector", type), timeoutMs),
-            "waitForNetworkIdle" => new PageAction.WaitForNetworkIdle(),
-            "scrollIntoView" => new PageAction.ScrollIntoView(Require(selector, "selector", type)),
-            "semanticAct" => new PageAction.SemanticAct(Require(intent, "intent", type)),
-            "press" => new PageAction.Press(Require(key, "key", type)),
-            // ADR-0074: fill arm; both fields required.
-            "fill" => new PageAction.Fill(Require(selector, "selector", type), Require(value, "value", type)),
-            _ => throw new JsonException($"unknown PageAction type '{type}'")
-        };
-    }
+    public static void Write(Utf8JsonWriter w, PageAction a) => Codec.Write(w, a);
 
-    private static string Require(string? value, string field, string? type) =>
-        value ?? throw new JsonException($"PageAction '{type}' is missing required '{field}'");
+    public static PageAction Read(ref Utf8JsonReader r) => Codec.Read(ref r);
+
+    /// <summary>Build a <see cref="PageAction"/> from an already-materialized
+    /// node — the composition seam <c>AgentDecision.Act</c> and
+    /// <c>AgentDecisionOutcome.ActDispatched</c> use for their nested action
+    /// (ADR-0077).</summary>
+    public static PageAction From(JsonNode node) => Codec.From(node);
 }
 
 internal sealed class PageActionJsonConverter : JsonConverter<PageAction>

--- a/WebReaper/Serialization/Converters/SchemaJsonConverter.cs
+++ b/WebReaper/Serialization/Converters/SchemaJsonConverter.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using WebReaper.Domain.Parsing;
 
@@ -41,44 +42,38 @@ internal static class SchemaCodec
     public static SchemaElement Read(ref Utf8JsonReader r)
     {
         if (r.TokenType != JsonTokenType.StartObject) throw new JsonException("expected object");
-        string? kind = null, field = null, selector = null, attr = null, typeName = null;
-        bool getHtml = false, isList = false;
+        // Stays bespoke (a recursive container/leaf tree on $kind, not a flat
+        // tag-sum), but routes through From so the materialized and streaming
+        // paths share one reader and cannot drift (ADR-0077).
+        return From(JsonNode.Parse(ref r) ?? throw new JsonException("expected object"));
+    }
+
+    /// <summary>
+    /// Build a <see cref="Schema"/>/<see cref="SchemaElement"/> from an
+    /// already-materialized node — the composition seam a migrated flat sum
+    /// (<c>AgentDecision.Extract</c>) uses to read its nested schema after the
+    /// <see cref="WebReaper.Serialization.Codecs.ClosedSumCodec{T}"/> mechanism
+    /// materialized the parent (ADR-0077). Recurses on the children array.
+    /// </summary>
+    public static SchemaElement From(JsonNode node)
+    {
+        if (node is not JsonObject obj) throw new JsonException("expected object");
+
+        var kind = obj["$kind"]?.GetValue<string>();
+        var field = obj["field"]?.GetValue<string>();
+        var selector = obj["selector"]?.GetValue<string>();
+        var attr = obj["attr"]?.GetValue<string>();
+        var type = ParseDataType(obj["type"]?.GetValue<string>());
+        var getHtml = obj["getHtml"]?.GetValue<bool>() ?? false;
+        var isList = obj["isList"]?.GetValue<bool>() ?? false;
+
         List<SchemaElement>? children = null;
-
-        while (r.Read() && r.TokenType != JsonTokenType.EndObject)
+        if (obj["children"] is JsonArray arr)
         {
-            var prop = r.GetString();
-            r.Read();
-            switch (prop)
-            {
-                case "$kind": kind = r.GetString(); break;
-                case "field": field = r.GetString(); break;
-                case "selector": selector = r.GetString(); break;
-                case "attr": attr = r.GetString(); break;
-                case "type": typeName = r.GetString(); break;
-                case "getHtml": getHtml = r.GetBoolean(); break;
-                case "isList": isList = r.GetBoolean(); break;
-                case "children":
-                    children = new List<SchemaElement>();
-                    while (r.Read() && r.TokenType != JsonTokenType.EndArray)
-                        children.Add(Read(ref r));
-                    break;
-                default: r.Skip(); break;
-            }
+            children = new List<SchemaElement>(arr.Count);
+            foreach (var child in arr)
+                children.Add(From(child ?? throw new JsonException("null schema child")));
         }
-
-        DataType? type = typeName switch
-        {
-            null => null,
-            "None" => DataType.None,
-            "Integer" => DataType.Integer,
-            "Float" => DataType.Float,
-            "Boolean" => DataType.Boolean,
-            "String" => DataType.String,
-            "DataTime" => DataType.DataTime,
-            "Object" => DataType.Object,
-            _ => throw new JsonException($"unknown DataType '{typeName}'")
-        };
 
         if (kind == "container")
         {
@@ -95,6 +90,19 @@ internal static class SchemaCodec
             Type = type, GetHtml = getHtml, IsList = isList
         };
     }
+
+    private static DataType? ParseDataType(string? typeName) => typeName switch
+    {
+        null => null,
+        "None" => DataType.None,
+        "Integer" => DataType.Integer,
+        "Float" => DataType.Float,
+        "Boolean" => DataType.Boolean,
+        "String" => DataType.String,
+        "DataTime" => DataType.DataTime,
+        "Object" => DataType.Object,
+        _ => throw new JsonException($"unknown DataType '{typeName}'")
+    };
 }
 
 internal sealed class SchemaJsonConverter : JsonConverter<Schema>

--- a/docs/adr/0077-closed-sum-codec-mechanism.md
+++ b/docs/adr/0077-closed-sum-codec-mechanism.md
@@ -1,6 +1,6 @@
 # 0077. Closed-Sum Codec Mechanism
 
-- **Status:** Accepted — design pass; implementation pending (2026-05-29)
+- **Status:** Accepted — implemented 2026-05-29.
 - **Date:** 2026-05-29
 - **Deciders:** Alex (HITL), Claude (architecture pass)
 
@@ -42,13 +42,28 @@ unknown-tag throw, and the common-field pass. Each arm's descriptor owns only
 its tag, its field writes, and its build-from-`JsonObject`.
 
 Interface shape (chosen after designing it three ways — see Alternatives): the
-**minimal spine** — `Arm<TArm>(tag, write: (writer, x) => …, build: (obj, ctx)
-=> …)` with an `ArmReaderContext` ref struct owning `Require` / `RequireChild` /
-`Optional*` / `Common` — plus a **field-less one-liner overload**
-(`Arm<TArm>(tag, Func<TArm> create)`) for `ScrollToEnd` / `WaitForNetworkIdle`
-/ `None` / `Stop`. The common `reason` field on `AgentDecision` is consumed
-inside each arm's `build` via `ctx.Common("reason")`, so arms stay immutable and
-construct once.
+**minimal spine** — `Arm<TArm>(tag, write: (writer, x) => …, build: ctx => …)`
+with an `ArmReaderContext` owning `Require` / `RequireChild` / `Optional*` /
+`Common` (plus `Object` for raw access) — plus a **field-less one-liner
+overload** (`Arm<TArm>(tag, Func<TArm> create)`) for the truly empty arms
+(`ScrollToEnd` / `WaitForNetworkIdle` / `None`). The common `reason` field on
+`AgentDecision` is consumed inside each arm's `build` via `ctx.Common("reason")`,
+so arms stay immutable and construct once.
+
+As-built clarifications (the sketch above is the design intent; these are how it
+landed):
+- `ArmReaderContext` is a **`readonly struct`, not a `ref struct`**. The
+  ref-struct constraint is on the `Utf8JsonReader`, which the mechanism consumes
+  once via `JsonNode.Parse(ref r)`; the context then wraps the materialized
+  `JsonObject` (a heap object), so it needs no ref-struct lifetime and a plain
+  readonly struct lets the build delegate be a standard `Func<ArmReaderContext,
+  TArm>` (a `ref struct` cannot be a `Func<>` type argument).
+- `build` takes one parameter (`ctx`), not `(obj, ctx)`: the object is reached
+  through `ctx.Object` when an arm needs it raw (the Extracted record clone),
+  keeping the common case a single `ctx`.
+- `Stop` is **not** field-less — it reads the common `reason` via
+  `ctx.Common("reason")`, so it uses the spine `Arm` form, not the one-liner
+  overload. Only `ScrollToEnd` / `WaitForNetworkIdle` / `None` are truly empty.
 
 Scope (full-flat): migrate the three flat tag-sums — `PageAction`,
 `AgentDecisionOutcome`, `AgentDecision`. `Schema` gains a `From(node)` entry so


### PR DESCRIPTION
Implements [ADR-0077](docs/adr/0077-closed-sum-codec-mechanism.md). Independent of [#157](https://github.com/pavlovtech/WebReaper/pull/157) (ADR-0078); both branch off `master`.

## What

The three flat closed-sum codecs (`PageActionCodec`, `AgentDecisionCodec`, `AgentDecisionOutcomeCodec`) were near-identical hand-written machines (the doc comments literally said "same shape as `PageActionCodec`"). This collapses them onto one shared `ClosedSumCodec<T>` mechanism + per-arm descriptors — the serialization-layer sibling of the AI satellite's `LlmCall<T>`.

The mechanism owns the object envelope, the `type` discriminator (write + dispatch), the one-time `JsonNode.Parse(ref reader)` materialization, the single `Require` missing-field contract, the unknown-tag throw, and the optional common-field pass. Each arm becomes one `(tag, write, build)` row instead of three edits across a write switch, a read loop, and a read type switch.

## The load-bearing constraint, handled

`Utf8JsonReader` is a `ref struct` and can't be handed to a per-arm delegate. So the read side materializes once (`JsonNode.Parse(ref r)`), then per-arm `build` runs on a plain `JsonObject` via an `ArmReaderContext` (a `readonly struct`, not a ref struct — the ref-struct is the reader, already consumed). The streaming `Read(ref r)` facade is `From(JsonNode.Parse(ref r))`.

I verified empirically that `JsonNode.Parse(ref r)` leaves the reader positioned on the value's `EndObject` — **positionally identical to the old hand-loop** — so the streaming consumers (`AgentRunSnapshotCodec`, the selector-chain converter) that read a sequence of these are untouched.

## Scope

- **Migrated:** the three flat tag-sums.
- **Stays bespoke:** `Schema` (recursive `$kind` tree) gains a `From(JsonNode)` entry so a migrated `AgentDecision.Extract` reads its nested schema, and routes its own streaming `Read` through `From` to avoid drift. `AgentRunSnapshot` and the `ImmutableQueue` chains keep their streaming `Read(ref r)` calls unchanged.

## Wire-format stability (load-bearing)

Persisted agent snapshots + configs must round-trip. Byte-identical preserved: field order (including **`reason` before `type`** on `AgentDecision`, and `Extracted` omitting a null `record`), and the one bespoke `ActDispatched` missing-field message. The new `ClosedSumCodecTests` pins exact bytes + every-arm round-trips + unknown-tag throws + missing-field messages — written as characterization tests (green before *and* after the migration).

## Verification

- `dotnet build WebReaper.sln`: clean.
- Unit **456** (+11 characterization tests); existing snapshot, selector-chain, and outcome round-trip tests stay green.
- **AOT smoke test**: `dotnet publish` (native) succeeds with no IL warnings and the binary reports `ALL PASS` — reflection-free held (ADR-0008).

🤖 Generated with [Claude Code](https://claude.com/claude-code)