### PR TITLE
ADR-0078: Playwright dispatch execution-coverage (close deferred follow-up)

### DIFF
--- a/WebReaper.Playwright/PlaywrightPageActionDispatcher.cs
+++ b/WebReaper.Playwright/PlaywrightPageActionDispatcher.cs
@@ -1,0 +1,87 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Playwright;
+using WebReaper.Core.Actions.Concrete;
+using WebReaper.Domain.PageActions;
+
+[assembly: InternalsVisibleTo("WebReaper.Playwright.Tests")]
+
+namespace WebReaper.Playwright;
+
+/// <summary>
+/// The ADR-0035 closed-sum dispatch table for the Playwright transport.
+/// Extracted from <see cref="PlaywrightPageLoadTransport"/> (mirroring the CDP
+/// transport's <c>CdpPageActionDispatcher</c>) so the table is unit-testable
+/// against a mocked <see cref="IPage"/> — see
+/// <c>WebReaper.Playwright.Tests.PlaywrightPageActionDispatchTests</c>. That
+/// closes ADR-0078 Axis A's deferred follow-up: the "every <see cref="PageAction"/>
+/// arm is handled" guarantee is now execution-proven for this transport too,
+/// not only CDP. The transport composes by delegating each arm.
+/// </summary>
+/// <remarks>
+/// Internal: the dispatch shape is an implementation detail of the satellite,
+/// not part of its public contract. All ten arms use Playwright's native
+/// methods (the four-arm Puppeteer gap closed in ADR-0053).
+/// </remarks>
+internal static class PlaywrightPageActionDispatcher
+{
+    /// <summary>Dispatch one <see cref="PageAction"/> arm against
+    /// <paramref name="page"/>. Recursive only via
+    /// <see cref="PageAction.SemanticAct"/> → resolver → concrete arm; the
+    /// recursion terminates after at most one re-dispatch (ADR-0050
+    /// <see cref="SemanticActCoordinator"/> rejects nested <c>SemanticAct</c>).</summary>
+    public static async Task PerformAsync(
+        IPage page,
+        PageAction action,
+        SemanticActCoordinator semanticActCoordinator,
+        CancellationToken ct)
+    {
+        switch (action)
+        {
+            case PageAction.Click a:
+                await page.ClickAsync(a.Selector);
+                break;
+            case PageAction.Wait a:
+                await Task.Delay(a.Milliseconds, ct);
+                break;
+            case PageAction.ScrollToEnd:
+                await page.EvaluateAsync("window.scrollTo(0, document.body.scrollHeight)");
+                break;
+            case PageAction.EvaluateExpression a:
+                await page.EvaluateAsync(a.Expression);
+                break;
+            case PageAction.WaitForSelector a:
+                await page.WaitForSelectorAsync(a.Selector, new PageWaitForSelectorOptions
+                {
+                    Timeout = a.TimeoutMs,
+                });
+                break;
+            case PageAction.WaitForNetworkIdle:
+                await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+                break;
+            case PageAction.ScrollIntoView a:
+                // ADR-0074: Playwright's ScrollIntoViewIfNeededAsync natively
+                // auto-waits for the element and scrolls it into the viewport.
+                await page.Locator(a.Selector).ScrollIntoViewIfNeededAsync();
+                break;
+            case PageAction.SemanticAct a:
+                await semanticActCoordinator.DispatchAsync(
+                    a.Intent,
+                    getHtmlAsync: _ => page.ContentAsync(),
+                    dispatch: (arm, token) => PerformAsync(page, arm, semanticActCoordinator, token),
+                    ct);
+                break;
+            case PageAction.Press a:
+                // ADR-0074: Playwright accepts the same key-string format natively.
+                await page.Keyboard.PressAsync(a.Key);
+                break;
+            case PageAction.Fill a:
+                // ADR-0074: one line; native auto-wait + clear + framework events
+                // handled by Playwright's page.FillAsync.
+                await page.FillAsync(a.Selector, a.Value);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(action), action.GetType().Name, "unhandled PageAction arm");
+        }
+    }
+}

--- a/WebReaper.Playwright/PlaywrightPageLoadTransport.cs
+++ b/WebReaper.Playwright/PlaywrightPageLoadTransport.cs
@@ -16,9 +16,11 @@ namespace WebReaper.Playwright;
 /// <summary>
 /// Microsoft.Playwright-backed <see cref="IPageLoadTransport"/> (ADR-0053).
 /// Replaces the deleted Puppeteer transport (<c>BrowserPageLoadTransport</c>).
-/// Multi-browser via the <see cref="PlaywrightBrowser"/> enum; all seven
-/// <see cref="PageAction"/> arms (ADR-0035) including <c>SemanticAct</c>
-/// (ADR-0050).
+/// Multi-browser via the <see cref="PlaywrightBrowser"/> enum; all ten
+/// <see cref="PageAction"/> arms (ADR-0035, ADR-0074) including
+/// <c>SemanticAct</c> (ADR-0050). The per-arm dispatch lives in
+/// <see cref="PlaywrightPageActionDispatcher"/> (extracted for unit-test
+/// coverage, ADR-0078 Axis A); this transport composes by delegating to it.
 /// </summary>
 public sealed class PlaywrightPageLoadTransport : IPageLoadTransport, IAsyncDisposable
 {
@@ -95,66 +97,12 @@ public sealed class PlaywrightPageLoadTransport : IPageLoadTransport, IAsyncDisp
                 _logger.LogInformation(
                     "Performing page action {Current} of {Count}: {Action}",
                     i, request.PageActions.Count - 1, action.GetType().Name);
-                await PerformAsync(page, action, cancellationToken);
+                await PlaywrightPageActionDispatcher.PerformAsync(
+                    page, action, _semanticActCoordinator, cancellationToken);
             }
         }
 
         return await page.ContentAsync();
-    }
-
-    // ADR-0035 closed-sum dispatch. All seven arms implemented — Puppeteer's
-    // four-arm coverage that threw at runtime on WaitForSelector and
-    // EvaluateExpression is closed here.
-    private async Task PerformAsync(IPage page, PageAction action, CancellationToken ct)
-    {
-        switch (action)
-        {
-            case PageAction.Click a:
-                await page.ClickAsync(a.Selector);
-                break;
-            case PageAction.Wait a:
-                await Task.Delay(a.Milliseconds, ct);
-                break;
-            case PageAction.ScrollToEnd:
-                await page.EvaluateAsync("window.scrollTo(0, document.body.scrollHeight)");
-                break;
-            case PageAction.EvaluateExpression a:
-                await page.EvaluateAsync(a.Expression);
-                break;
-            case PageAction.WaitForSelector a:
-                await page.WaitForSelectorAsync(a.Selector, new PageWaitForSelectorOptions
-                {
-                    Timeout = a.TimeoutMs,
-                });
-                break;
-            case PageAction.WaitForNetworkIdle:
-                await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-                break;
-            case PageAction.ScrollIntoView a:
-                // ADR-0074: Playwright's ScrollIntoViewIfNeededAsync natively
-                // auto-waits for the element and scrolls it into the viewport.
-                await page.Locator(a.Selector).ScrollIntoViewIfNeededAsync();
-                break;
-            case PageAction.SemanticAct a:
-                await _semanticActCoordinator.DispatchAsync(
-                    a.Intent,
-                    getHtmlAsync: _ => page.ContentAsync(),
-                    dispatch: (arm, token) => PerformAsync(page, arm, token),
-                    ct);
-                break;
-            case PageAction.Press a:
-                // ADR-0074: Playwright accepts the same key-string format natively.
-                await page.Keyboard.PressAsync(a.Key);
-                break;
-            case PageAction.Fill a:
-                // ADR-0074: one line; native auto-wait + clear + framework events
-                // handled by Playwright's page.FillAsync.
-                await page.FillAsync(a.Selector, a.Value);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(
-                    nameof(action), action.GetType().Name, "unhandled PageAction arm");
-        }
     }
 
     private async Task ApplyCookiesAsync(IBrowserContext context, string url)

--- a/WebReaper.Tests/WebReaper.Playwright.Tests/PlaywrightPageActionDispatchTests.cs
+++ b/WebReaper.Tests/WebReaper.Playwright.Tests/PlaywrightPageActionDispatchTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Playwright;
+using NSubstitute;
+using WebReaper.Core.Actions.Abstract;
+using WebReaper.Core.Actions.Concrete;
+using WebReaper.Domain.PageActions;
+using WebReaper.Playwright;
+
+namespace WebReaper.Playwright.Tests;
+
+/// <summary>
+/// ADR-0078 Axis A, deferred follow-up. C# has no closed-hierarchy
+/// exhaustiveness, so a forgotten <see cref="PageAction"/> arm in a transport
+/// compiles silently. The CDP transport proves arm coverage by executing every
+/// arm against a <c>FakeCdpSession</c>; this is the Playwright equivalent,
+/// against a mocked <see cref="IPage"/> (NSubstitute — IPage is far too large
+/// to hand-stub). Reflect every arm, dispatch each through
+/// <see cref="PlaywrightPageActionDispatcher.PerformAsync"/>, and assert none
+/// reaches the switch's <c>default: throw</c>. The reflection completeness
+/// check forces a sample to be added when a <see cref="PageAction"/> arm is
+/// added, and the dispatch then proves the transport handles it.
+/// </summary>
+public class PlaywrightPageActionDispatchTests
+{
+    [Fact]
+    public async Task Every_PageAction_arm_dispatches_without_hitting_the_default()
+    {
+        PageAction[] samples =
+        [
+            new PageAction.Click(".x"),
+            new PageAction.Wait(1),
+            new PageAction.WaitForSelector(".x", 1000),
+            new PageAction.WaitForNetworkIdle(),
+            new PageAction.ScrollToEnd(),
+            new PageAction.ScrollIntoView(".x"),
+            new PageAction.EvaluateExpression("1"),
+            new PageAction.Press("Enter"),
+            new PageAction.Fill(".x", "y"),
+            new PageAction.SemanticAct("do it"),
+        ];
+
+        // Completeness: the samples cover every concrete PageAction arm, so a
+        // newly-added arm trips this until a sample is added here.
+        var armTypes = typeof(PageAction).GetNestedTypes()
+            .Where(t => t.IsSealed && t.IsSubclassOf(typeof(PageAction)))
+            .ToHashSet();
+        var sampled = samples.Select(s => s.GetType()).ToHashSet();
+        Assert.True(armTypes.SetEquals(sampled),
+            "Sample set must cover every PageAction arm. Add a sample for the new arm. " +
+            $"Uncovered: [{string.Join(", ", armTypes.Except(sampled).Select(t => t.Name))}]");
+
+        foreach (var arm in samples)
+        {
+            // NSubstitute auto-returns completed tasks for async members and
+            // recursive substitutes for Locator / Keyboard, so every native
+            // Playwright call on the mock succeeds without per-member setup.
+            var page = Substitute.For<IPage>();
+            page.ContentAsync().Returns("<html></html>");
+            // SemanticAct resolves to a concrete arm via the resolver.
+            var coord = new SemanticActCoordinator(
+                new StubResolver(new PageAction.Click(".resolved")), NullLogger.Instance);
+
+            var ex = await Record.ExceptionAsync(() =>
+                PlaywrightPageActionDispatcher.PerformAsync(page, arm, coord, default));
+
+            Assert.False(ex is ArgumentOutOfRangeException,
+                $"{arm.GetType().Name} fell through to the dispatcher's default (unhandled arm)");
+            Assert.Null(ex);
+        }
+    }
+
+    [Fact]
+    public async Task Click_delegates_to_native_ClickAsync()
+    {
+        // A representative behavioural pin (mirrors the CDP per-arm tests):
+        // the dispatch wires the arm to the native Playwright call, not just
+        // avoiding the default.
+        var page = Substitute.For<IPage>();
+        var coord = new SemanticActCoordinator(
+            new StubResolver(new PageAction.Click(".resolved")), NullLogger.Instance);
+
+        await PlaywrightPageActionDispatcher.PerformAsync(
+            page, new PageAction.Click("button.signin"), coord, default);
+
+        await page.Received(1).ClickAsync("button.signin");
+    }
+
+    private sealed class StubResolver : IActionResolver
+    {
+        private readonly PageAction _arm;
+        public StubResolver(PageAction arm) => _arm = arm;
+        public Task<PageAction?> ResolveAsync(
+            string intent, string pageHtml, CancellationToken cancellationToken = default)
+            => Task.FromResult<PageAction?>(_arm);
+    }
+}

--- a/WebReaper.Tests/WebReaper.Playwright.Tests/Usings.cs
+++ b/WebReaper.Tests/WebReaper.Playwright.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/WebReaper.Tests/WebReaper.Playwright.Tests/WebReaper.Playwright.Tests.csproj
+++ b/WebReaper.Tests/WebReaper.Playwright.Tests/WebReaper.Playwright.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <!-- Microsoft.Playwright's IPage is a ~100-member interface; unlike the
+         repo's small hand-faked seams (ICdpSession), it is impractical to stub
+         by hand, so this single satellite-test project uses NSubstitute. The
+         dep is test-only and never shipped. -->
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WebReaper.Playwright\WebReaper.Playwright.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/WebReaper.Tests/WebReaper.UnitTests/PageActionArmCensusTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/PageActionArmCensusTests.cs
@@ -8,10 +8,10 @@ namespace WebReaper.UnitTests;
 // C# has no closed-hierarchy exhaustiveness to make a forgotten arm a compile
 // error (a discard-less switch expression warns CS8509 even when every arm is
 // handled). This census is the cheap, transport-agnostic tripwire: when the
-// arm set changes it fails with a checklist of every consumer to update. It is
-// the primary guard for the Playwright transport, which (unlike CDP) has no
-// unit-test seam for its private IPage dispatch; CDP additionally proves it
-// handles every arm in WebReaper.Cdp.Tests.CdpPageActionDispatchTests.
+// arm set changes it fails with a checklist of every consumer to update (the AI
+// registries, the builder, the codec). Both transports additionally prove they
+// handle every arm by execution — WebReaper.Cdp.Tests.CdpPageActionDispatchTests
+// and WebReaper.Playwright.Tests.PlaywrightPageActionDispatchTests.
 public class PageActionArmCensusTests
 {
     [Fact]

--- a/WebReaper.sln
+++ b/WebReaper.sln
@@ -86,6 +86,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.TestServer", "Web
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.Perf", "WebReaper.Tests\WebReaper.Perf\WebReaper.Perf.csproj", "{363D15C8-D7B3-4783-8F0B-C0ABD6456F84}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.Playwright.Tests", "WebReaper.Tests\WebReaper.Playwright.Tests\WebReaper.Playwright.Tests.csproj", "{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -516,6 +518,18 @@ Global
 		{363D15C8-D7B3-4783-8F0B-C0ABD6456F84}.Release|x64.Build.0 = Release|Any CPU
 		{363D15C8-D7B3-4783-8F0B-C0ABD6456F84}.Release|x86.ActiveCfg = Release|Any CPU
 		{363D15C8-D7B3-4783-8F0B-C0ABD6456F84}.Release|x86.Build.0 = Release|Any CPU
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}.Debug|x64.Build.0 = Debug|Any CPU
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}.Debug|x86.Build.0 = Debug|Any CPU
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}.Release|x64.ActiveCfg = Release|Any CPU
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}.Release|x64.Build.0 = Release|Any CPU
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}.Release|x86.ActiveCfg = Release|Any CPU
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -541,6 +555,7 @@ Global
 		{75F812A2-98D1-42CD-885E-2496F614667C} = {75C97094-26FC-484A-A354-E33BBD6355A8}
 		{DE72E7F2-D328-451C-B512-C9CCEF5B2E0C} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
 		{363D15C8-D7B3-4783-8F0B-C0ABD6456F84} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
+		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8413198B-8D26-4E30-A5E2-E0FBC4DCEA59}

--- a/docs/adr/0078-derived-tool-registries-and-dispatch-exhaustiveness.md
+++ b/docs/adr/0078-derived-tool-registries-and-dispatch-exhaustiveness.md
@@ -66,14 +66,17 @@ The achievable guard is a test, run in CI:
   `FakeCdpSession`, and asserts none throws `ArgumentOutOfRangeException`. A new
   arm trips a reflection completeness check (forcing a sample), and the sample
   then proves the CDP transport handles it.
-- **Playwright** has no unit-test seam (its `PerformAsync` is private over a
-  real Microsoft.Playwright `IPage`, which the repo's hand-fake convention
-  cannot stand up without a mocking dependency). It is guarded by a core-side
-  arm-census test (`WebReaper.UnitTests.PageActionArmCensusTests`) that pins the
-  `PageAction` arm set and fails with a checklist of every consumer to update
-  (both transports, the AI registries, the builder, the codec), plus the
-  runtime `default: throw` as the backstop. Giving Playwright its own
-  execution-coverage test (a faked or mocked `IPage`) is a deferred follow-up.
+- **Playwright** gets the same execution-coverage test
+  (`WebReaper.Playwright.Tests.PlaywrightPageActionDispatchTests`): the dispatch
+  was extracted into an internal `PlaywrightPageActionDispatcher` (mirroring the
+  CDP extraction) so it is reachable, and `Microsoft.Playwright`'s `IPage` is
+  mocked with NSubstitute (a ~100-member interface, too large to hand-stub like
+  the small `ICdpSession`; the dep is test-only and isolated to that one
+  project). Originally deferred; closed in a follow-up.
+- A core-side arm-census test (`WebReaper.UnitTests.PageActionArmCensusTests`)
+  remains as the transport-agnostic tripwire: it pins the `PageAction` arm set
+  and fails with a checklist of every consumer to update (both transports, the
+  AI registries, the builder, the codec) when an arm is added.
 
 **Axis B — derived registries in the satellite.** Both the brain and resolver
 registries become derived views of one `PageActionArms` arm list. Each entry is
@@ -102,9 +105,10 @@ Good:
   switches) to one (`PageActionArms`) plus at most one (a brain-native arm).
 - The silent-drop failure class is eliminated: the descriptor and the parse are
   the same list, so an arm offered to the model is always parseable.
-- A new arm a transport forgets is caught in CI: by the CDP execution-coverage
-  test for CDP, and by the core arm-census tripwire (which lists every consumer
-  to update) for Playwright and the rest.
+- A new arm a transport forgets is caught in CI: both transports have an
+  execution-coverage test (CDP via `FakeCdpSession`, Playwright via an
+  NSubstitute `IPage`), and the core arm-census tripwire lists every other
+  consumer to update.
 - Fork 8's loop-prevention stays structural — strengthened from
   double-omission-from-two-lists to single-absence-of-an-adapter.
 
@@ -112,9 +116,9 @@ Bad / costs:
 - One derived-registry indirection in the satellite (an arm list + a mapping)
   in place of two literal lists.
 - Axis A's guard is CI-time, not compile-time (C# cannot give the latter for a
-  closed sum), and Playwright's coverage is a census tripwire plus the runtime
-  throw rather than execution-proven. A faked/mocked `IPage` execution test for
-  Playwright is a deferred follow-up.
+  closed sum). The Playwright execution-coverage test costs one test-only
+  dependency (NSubstitute, isolated to `WebReaper.Playwright.Tests`), accepted
+  because `IPage` is too large to hand-stub.
 
 ## Alternatives considered
 


### PR DESCRIPTION
Closes the one deferred follow-up from [ADR-0078](docs/adr/0078-derived-tool-registries-and-dispatch-exhaustiveness.md): the Playwright transport now has the same **execution-coverage** guard as CDP, so both transports prove they handle every `PageAction` arm (not just the census tripwire + runtime throw).

## What

- **Extracted `PlaywrightPageActionDispatcher`** (internal static, mirroring the CDP transport's `CdpPageActionDispatcher`) so the per-arm dispatch is reachable for a unit test. The transport's `LoadAsync` now delegates to it; the dispatch body is unchanged (native Playwright calls). `[assembly: InternalsVisibleTo("WebReaper.Playwright.Tests")]` added.
- **New `WebReaper.Playwright.Tests`** project with the same reflection-coverage shape as `CdpPageActionDispatchTests`: reflect every `PageAction` arm, dispatch each through `PerformAsync` against a mocked `IPage`, assert none hits the `default: throw`. A reflection completeness check forces a sample when a new arm is added; the dispatch then proves the transport handles it. Plus one behavioural pin (`Click` → native `ClickAsync`).

## The IPage-faking decision

`Microsoft.Playwright.IPage` is a ~100-member interface — unlike the small custom `ICdpSession` the repo hand-fakes — so this one satellite-test project uses **NSubstitute** (test-only, never shipped, isolated to this project). NSubstitute auto-returns completed tasks for async members and recursive substitutes for `Locator`/`Keyboard`, so the native calls succeed with no per-member setup. This is the first mocking-framework use in the repo; it earns its place here because hand-stubbing `IPage` + `ILocator` + `IKeyboard` would be hundreds of throw-lines.

## Docs

ADR-0078's Axis A (Decision + Consequences) updated: the deferred follow-up is closed, both transports are execution-proven, and the core `PageActionArmCensusTests` is reframed as the cross-consumer tripwire (AI registries, builder, codec). The census test's comment updated to match.

## Verification

- `dotnet build WebReaper.sln`: clean (new project + NSubstitute resolve).
- `WebReaper.Playwright.Tests`: 2/2 green; core census test still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)