### PR TITLE
fix(cli): accept bare-host URLs (default missing scheme to https)

### DIFF
--- a/WebReaper.Cli/Commands/MapCommand.cs
+++ b/WebReaper.Cli/Commands/MapCommand.cs
@@ -12,7 +12,7 @@ internal static class MapCommand
         if (args.Positional.Count < 1)
             throw new CliException("Missing <url>. Usage: webreaper map <url> [flags]");
 
-        var url = args.Positional[0];
+        var url = Urls.Normalize(args.Positional[0]);
         var options = new MapOptions(
             MaxUrls: args.GetIntFlag("max-urls", 1000),
             IncludeSitemap: !args.HasFlag("no-sitemap"),

--- a/WebReaper.Cli/Commands/ScrapeCommand.cs
+++ b/WebReaper.Cli/Commands/ScrapeCommand.cs
@@ -264,7 +264,7 @@ internal static class ScrapeCommand
 
     internal static ScrapeContext ParseContext(ParsedArgs args)
     {
-        var url = args.Positional[0];
+        var url = Urls.Normalize(args.Positional[0]);
         var cdpUrl = args.GetFlag("browser-cdp-url");
         var browser = args.HasFlag("browser") || cdpUrl is not null;
         var stealth = args.HasFlag("stealth");

--- a/WebReaper.Cli/Urls.cs
+++ b/WebReaper.Cli/Urls.cs
@@ -1,0 +1,25 @@
+namespace WebReaper.Cli;
+
+// Bare-host ergonomics for the CLI. `webreaper scrape alexpavlov.dev` should
+// Just Work; the library's Crawl / MapAsync require an absolute URI (an
+// HttpClient handed "alexpavlov.dev" throws "An invalid request URI was
+// provided"), so the CLI defaults a missing scheme to https:// at the arg
+// boundary. Kept out of the library on purpose: Crawl(string) is an API whose
+// absolute-URI contract is reasonable; this is a typed-at-a-terminal nicety.
+internal static class Urls
+{
+    /// <summary>
+    /// Normalize a user-typed URL. A bare host ("example.com",
+    /// "example.com/path") gets an https:// scheme; an explicit scheme
+    /// ("http://", "https://", or any "scheme://") is left untouched, as is a
+    /// protocol-relative "//host" (defaulted to https:). Whitespace is trimmed.
+    /// </summary>
+    public static string Normalize(string raw)
+    {
+        var url = raw.Trim();
+        if (url.Length == 0) return url;                                   // let downstream report the empty
+        if (url.Contains("://", StringComparison.Ordinal)) return url;      // explicit scheme
+        if (url.StartsWith("//", StringComparison.Ordinal)) return "https:" + url; // protocol-relative
+        return "https://" + url;
+    }
+}

--- a/WebReaper.Tests/WebReaper.Cli.Tests/ScrapeContextTests.cs
+++ b/WebReaper.Tests/WebReaper.Cli.Tests/ScrapeContextTests.cs
@@ -28,6 +28,20 @@ public class ScrapeContextTests
     }
 
     [Fact]
+    public void Bare_host_url_defaults_to_https()
+    {
+        var ctx = Parse("scrape", "alexpavlov.dev");
+        Assert.Equal("https://alexpavlov.dev", ctx.Url);
+    }
+
+    [Fact]
+    public void Explicit_scheme_url_is_preserved()
+    {
+        var ctx = Parse("scrape", "http://example.com");
+        Assert.Equal("http://example.com", ctx.Url);
+    }
+
+    [Fact]
     public void Cdp_url_flag_implies_browser()
     {
         var ctx = Parse("scrape", "https://example.com", "--browser-cdp-url", "ws://localhost:9222");

--- a/WebReaper.Tests/WebReaper.Cli.Tests/UrlsTests.cs
+++ b/WebReaper.Tests/WebReaper.Cli.Tests/UrlsTests.cs
@@ -1,0 +1,38 @@
+using WebReaper.Cli;
+
+namespace WebReaper.Cli.Tests;
+
+/// <summary>
+/// Bare-host URL ergonomics: a user-typed `webreaper scrape alexpavlov.dev`
+/// must reach the library as an absolute URI. Urls.Normalize defaults a
+/// missing scheme to https:// while leaving explicit schemes untouched.
+/// </summary>
+public class UrlsTests
+{
+    [Theory]
+    [InlineData("alexpavlov.dev", "https://alexpavlov.dev")]
+    [InlineData("example.com/path?q=1", "https://example.com/path?q=1")]
+    [InlineData("sub.example.co.uk", "https://sub.example.co.uk")]
+    [InlineData("localhost:3000", "https://localhost:3000")]
+    public void Bare_host_gets_https_scheme(string input, string expected)
+        => Assert.Equal(expected, Urls.Normalize(input));
+
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("http://example.com")]
+    [InlineData("http://localhost:9222")]
+    public void Explicit_scheme_is_preserved(string input)
+        => Assert.Equal(input, Urls.Normalize(input));
+
+    [Fact]
+    public void Whitespace_is_trimmed_before_scheme_defaulting()
+        => Assert.Equal("https://example.com", Urls.Normalize("  example.com  "));
+
+    [Fact]
+    public void Protocol_relative_url_defaults_to_https_without_doubling_slashes()
+        => Assert.Equal("https://example.com", Urls.Normalize("//example.com"));
+
+    [Fact]
+    public void Empty_is_left_for_downstream_validation()
+        => Assert.Equal("", Urls.Normalize("   "));
+}


### PR DESCRIPTION
## Problem
```
$ webreaper scrape alexpavlov.dev
InvalidOperationException: An invalid request URI was provided. Either the
request URI must be an absolute URI or BaseAddress must be set.
```
The bare host was passed straight through to `Crawl(url)` / `MapAsync(url)`, so the HTTP loader received a **relative** URI and threw.

## Fix
`Urls.Normalize(raw)` at the CLI arg boundary defaults a missing scheme to `https://` (applied in both `scrape` and `map`):
- `alexpavlov.dev` → `https://alexpavlov.dev`
- explicit `http://` / `https://` → untouched
- `//host` → `https://host`; whitespace trimmed

Deliberately **not** pushed into the library: `Crawl(string)` / `MapAsync(string)` keep their absolute-URI contract.

## Verified
- `WebReaper.Cli.Tests`: 76 pass, 0 warnings (new `UrlsTests` + 2 `ScrapeContextTests` cases).
- Live: `webreaper scrape alexpavlov.dev` → `{"title":"Hi, I am Alex","markdown":"…"}`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)