### PR TITLE
feat: ADR-0081 site sweep, whole-site recursive crawl (10.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## 10.2.0: whole-site crawl (Site sweep)
+
+One command now crawls an entire site:
+
+```bash
+webreaper crawl https://example.com > pages.jsonl
+```
+
+and the library equivalent:
+
+```csharp
+await ScraperEngineBuilder
+    .Crawl("https://example.com")
+    .AsMarkdown()            // or .Extract(schema)
+    .Sweep()
+    .StopWhenAllLinksProcessed()
+    .WriteToConsole()
+    .BuildAsync();
+```
+
+Before this, covering a whole site meant `map` piped into a shell loop of `scrape` calls, which silently missed deep pages on sitemap-less sites (the Site mapper is one HTTP pass, not a crawl). [ADR-0081](docs/adr/0081-site-sweep-whole-site-crawl.md) closes that gap with the **Site sweep**: a recursive, on-domain crawl that extracts every page as it follows every link, terminating when the frontier saturates. It is Firecrawl `crawl` parity, built as the small local extension [ADR-0001](docs/adr/0001-crawl-outcome-closed-sum.md) and [ADR-0030](docs/adr/0030-link-path-selector-construction-guards.md) anticipated, not a new engine.
+
+The model: a **Sweep page** is the first **Page category** that BOTH extracts and follows. A recursive `LinkPathSelector.Sweep(...)` selector marks it; the **Crawl step** returns a new fourth **Crawl outcome** arm, `Swept` (this page's `ParsedData` plus its on-domain child Jobs); children **retain** the sweep selector so the traversal perpetuates; the existing **Visited-link tracker** dedups and terminates it, and the **Stop rule** page-limit cutoff bounds it. The whole termination, latch, and Sink fan-out machinery is reused unchanged.
+
+- **On-domain by default, dependency-free.** The sweep follows only links whose host equals the start host, treating a leading `www.` as the apex. `--include-subdomains` widens to a suffix match on the apex host (a documented heuristic, not public-suffix-list-correct; the eTLD+1 dependency was rejected to keep core dependency-light).
+- **Sitemap seeding, default-on.** The frontier is seeded from the Site mapper's discovered URLs too, so a site with a sitemap but sparse internal linking is still covered; the two discovery modes union through the same Visited-link tracker. `--no-sitemap` opts out.
+- **Bounds.** `--max-pages` (default 1000) maps onto the existing Stop-rule cutoff; `--max-depth` (default unlimited) reads the Job's parent-backlink-chain length.
+- **Output is JSON Lines, streamed** to the Sinks as each page is extracted. Markdown `{ title, markdown }` per page by default; `--schema` applies the deterministic Schema fold instead.
+
+The recursive marker round-trips through the selector-chain JSON codec, so durable and distributed crawls resume a Sweep page as a sweep. The distributed-driver example (`Examples/WebReaper.AzureFuncs`) gains the `Swept` case (emit AND follow), and a `CrawlOutcome` arm census test guards every consumer against a future fifth arm.
+
+| File | Change |
+|---|---|
+| `WebReaper/Domain/Selectors/LinkPathSelector.cs` | New init-only `Recursive` marker and a `Sweep(selector = "a[href]", …)` named factory (the third intent-shape beside `Follow` / `Paginate`). |
+| `WebReaper/Core/Crawling/CrawlOutcome.cs` | New `Swept(ParsedData Data, ImmutableArray<Job> Next)` arm + `Sweep(...)` factory; `NextJobs` surfaces the swept children. |
+| `WebReaper/Core/Crawling/Concrete/CrawlStep.cs` | The Sweep branch: a recursive head selector extracts the page AND produces on-domain children retaining the selector, with a depth gate. |
+| `WebReaper/Core/Crawling/Concrete/SweepDomainFilter.cs` | NEW. The on-domain boundary (host + `www`, apex-suffix with `--include-subdomains`); the leading-dot guard rejects `notexample.com` / `example.com.evil.com`. |
+| `WebReaper/Core/Crawling/Concrete/SweepPolicy.cs` | NEW. The crawl-global anchor-host + subdomains + depth policy threaded into the step. |
+| `WebReaper/Core/ScraperEngine.cs` | The driver's `Swept` case: run the record through the Post-extraction pipeline (emit) AND enqueue the children (follow). The only arm that does both. |
+| `WebReaper/Serialization/Converters/ImmutableQueueJsonConverters.cs` | Round-trip the `recursive` marker (written only when set, so pre-10.2 JSON is unchanged). |
+| `WebReaper/Domain/ScraperConfig.cs` | New `IncludeSubdomains` + `MaxDepth` knobs. |
+| `WebReaper/Builders/SweepOptions.cs` | NEW. The `.Sweep(options?)` options record. |
+| `WebReaper/Builders/{ConfigBuilder,ScraperEngineBuilder,SpiderBuilder}.cs` | `.Sweep(options?)`; `SpiderBuilder` derives the `SweepPolicy` from the config (covers both Crawl drivers); `BuildAsync` seeds the frontier from the Site mapper when sitemap is on. |
+| `WebReaper.Cli/Commands/CrawlCommand.cs` | NEW `crawl` verb. Flags `--schema` / `--output` / `--max-pages` / `--max-depth` / `--include-subdomains` / `--no-sitemap`. HTTP-only, AOT-clean. |
+| `WebReaper.Cli/{SchemaFile,RecordOutput}.cs` | NEW. Schema-loading + JSON-lines emission extracted from `ScrapeCommand` and shared with `crawl`. |
+| `WebReaper.Cli/{Program,Help}.cs`, `WebReaper.Cli/skill/SKILL.md` | Dispatch, help text, and the bundled Agent Skill document the `crawl` verb. |
+
+Semver: additive (a new CLI verb, a new library method, a new selector factory, a new closed-sum arm). No existing arm or method changes shape.
+
+This release also folds in two fixes merged since 10.1.0:
+
+- **CLI accepts bare-host URLs** ([#162](https://github.com/pavlovtech/WebReaper/pull/162)): `webreaper scrape example.com` now defaults a missing scheme to `https://` at the argument boundary, instead of failing with "An invalid request URI was provided".
+- **Build-warnings cleanup** ([#161](https://github.com/pavlovtech/WebReaper/pull/161)): the xUnit1031, Node20-artifact, retention-days, and NU5128 warnings are cleared.
+
 ## 10.1.0: form-interaction page actions, MCP browser mode, and post-launch refactors
 
 ### Three new `PageAction` arms: `Fill`, `Press`, `ScrollIntoView` (ADR-0074)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,7 @@
   -->
 
   <PropertyGroup>
-    <Version>10.1.0</Version>
+    <Version>10.2.0</Version>
 
     <Authors>Alex Pavlov</Authors>
     <Company>Alex Pavlov</Company>

--- a/Examples/WebReaper.AzureFuncs/WebReaperSpider.cs
+++ b/Examples/WebReaper.AzureFuncs/WebReaperSpider.cs
@@ -96,6 +96,14 @@ namespace WebReaper.AzureFuncs
 
                 if (report.Outcome is CrawlOutcome.Parsed parsed)
                     await CosmosSink.EmitAsync(parsed.Data);   // the driver fans out
+                else if (report.Outcome is CrawlOutcome.Swept swept)
+                {
+                    // ADR-0081: the Sweep page is the one arm that BOTH emits
+                    // AND follows. Emit its record and enqueue its on-domain
+                    // children; the per-message TryAdd gate above dedups them.
+                    await CosmosSink.EmitAsync(swept.Data);
+                    children = swept.Next;
+                }
                 else
                     children = report.Outcome.NextJobs;        // unfiltered; dedup is the per-message gate above
             }

--- a/WebReaper.Cli/Commands/CrawlCommand.cs
+++ b/WebReaper.Cli/Commands/CrawlCommand.cs
@@ -1,0 +1,82 @@
+using WebReaper.Builders;
+using WebReaper.Sinks.Models;
+
+namespace WebReaper.Cli.Commands;
+
+// `webreaper crawl <url>`: the ADR-0081 whole-site recursive Site sweep. From
+// the start URL (seeded by the sitemap too, unless --no-sitemap), follow every
+// on-domain link breadth-first, extract each page, and stream JSON Lines to
+// stdout (or --output). Markdown by default; JSON when --schema is given. The
+// Visited-link tracker dedups and terminates the sweep; --max-pages bounds it.
+//
+// HTTP-only and AOT-clean by design (no browser transport baked into the CLI):
+// for a JS-rendered or bot-protected site, `scrape --browser` is the path.
+internal static class CrawlCommand
+{
+    public static async Task<int> RunAsync(ParsedArgs args)
+    {
+        if (args.Positional.Count < 1)
+            throw new CliException("Missing <url>. Usage: webreaper crawl <url> [flags]");
+
+        var ctx = ParseContext(args);
+
+        // ADR-0081: AsMarkdown is the default sweep extraction (every page
+        // becomes clean content, sidestepping page heterogeneity); --schema
+        // applies the deterministic fold to every page instead.
+        var seed = ScraperEngineBuilder.Crawl(ctx.Url);
+        var builder = ctx.SchemaPath is not null
+            ? seed.Extract(SchemaFile.Load(ctx.SchemaPath))
+            : seed.AsMarkdown();
+
+        builder = builder
+            .Sweep(new SweepOptions
+            {
+                IncludeSubdomains = ctx.IncludeSubdomains,
+                MaxDepth = ctx.MaxDepth,
+                Sitemap = ctx.Sitemap,
+            })
+            .PageCrawlLimit(ctx.MaxPages)        // ADR-0032 cutoff
+            .StopWhenAllLinksProcessed();        // terminate when the frontier saturates
+
+        // The crawl loop is parallel (ADR-0022), so sink emits are concurrent;
+        // guard the collection. The default --max-pages bounds the memory.
+        var records = new List<ParsedData>();
+        builder = builder.Subscribe(r => { lock (records) records.Add(r); });
+
+        // ADR-0058: await using disposes the engine's resources on scope exit.
+        await using (var engine = await builder.BuildAsync())
+        {
+            await engine.RunAsync();
+        }
+
+        await RecordOutput.WriteAsync(records, ctx.Output);
+        return 0;
+    }
+
+    internal sealed record CrawlContext(
+        string Url,
+        string? SchemaPath,
+        string? Output,
+        int MaxPages,
+        int? MaxDepth,
+        bool IncludeSubdomains,
+        bool Sitemap);
+
+    internal static CrawlContext ParseContext(ParsedArgs args)
+    {
+        // --max-depth absent ⇒ unbounded (null); present ⇒ parsed (a
+        // non-integer value throws via GetIntFlag).
+        int? maxDepth = args.HasFlag("max-depth")
+            ? args.GetIntFlag("max-depth", int.MaxValue)
+            : null;
+
+        return new CrawlContext(
+            Url: Urls.Normalize(args.Positional[0]),
+            SchemaPath: args.GetFlag("schema"),
+            Output: args.GetFlag("output"),
+            MaxPages: args.GetIntFlag("max-pages", 1000),
+            MaxDepth: maxDepth,
+            IncludeSubdomains: args.HasFlag("include-subdomains"),
+            Sitemap: !args.HasFlag("no-sitemap"));
+    }
+}

--- a/WebReaper.Cli/Commands/ScrapeCommand.cs
+++ b/WebReaper.Cli/Commands/ScrapeCommand.cs
@@ -1,10 +1,7 @@
 using System.Diagnostics;
-using System.Text.Json;
-using System.Text.Json.Nodes;
 using WebReaper.Builders;
 using WebReaper.Cdp;
 using WebReaper.Cli.Stealth;
-using WebReaper.Domain.Parsing;
 using WebReaper.Sinks.Models;
 
 namespace WebReaper.Cli.Commands;
@@ -35,7 +32,7 @@ internal static class ScrapeCommand
         // No escalation path on pure-HTTP scrapes.
         if (!ctx.Browser)
         {
-            await Emit(first.Records, ctx.Output);
+            await RecordOutput.WriteAsync(first.Records, ctx.Output);
             return 0;
         }
 
@@ -49,7 +46,7 @@ internal static class ScrapeCommand
 
         if (!verdict.LikelyBlocked)
         {
-            await Emit(first.Records, ctx.Output);
+            await RecordOutput.WriteAsync(first.Records, ctx.Output);
             return 0;
         }
 
@@ -62,7 +59,7 @@ internal static class ScrapeCommand
             // result is what we ship.
             Console.Error.WriteLine(
                 "⚠  Auto-stealth disabled (--no-auto-stealth); retry manually with --stealth.");
-            await Emit(first.Records, ctx.Output);
+            await RecordOutput.WriteAsync(first.Records, ctx.Output);
             return 0;
         }
 
@@ -75,7 +72,7 @@ internal static class ScrapeCommand
             if (!string.IsNullOrEmpty(reply) && !reply.Equals("y", StringComparison.OrdinalIgnoreCase))
             {
                 Console.Error.WriteLine("Aborted; shipping first-attempt result.");
-                await Emit(first.Records, ctx.Output);
+                await RecordOutput.WriteAsync(first.Records, ctx.Output);
                 return 0;
             }
         }
@@ -88,7 +85,7 @@ internal static class ScrapeCommand
         if (installCode != 0)
         {
             Console.Error.WriteLine($"✗  Stealth install failed (exit {installCode}); shipping first-attempt result.");
-            await Emit(first.Records, ctx.Output);
+            await RecordOutput.WriteAsync(first.Records, ctx.Output);
             return installCode;
         }
 
@@ -97,7 +94,7 @@ internal static class ScrapeCommand
         if (stealthPath is null)
         {
             Console.Error.WriteLine("✗  Stealth install reported success but path resolution failed.");
-            await Emit(first.Records, ctx.Output);
+            await RecordOutput.WriteAsync(first.Records, ctx.Output);
             return 1;
         }
 
@@ -114,11 +111,11 @@ internal static class ScrapeCommand
                 $"✗  Stealth retry still likely blocked: {retryVerdict.Reason}");
             Console.Error.WriteLine(
                 "   The site may need a captcha-solver (deferred — see ADR-0055 §F5).");
-            await Emit(retry.Records, ctx.Output);
+            await RecordOutput.WriteAsync(retry.Records, ctx.Output);
             return 1;
         }
 
-        await Emit(retry.Records, ctx.Output);
+        await RecordOutput.WriteAsync(retry.Records, ctx.Output);
         return 0;
     }
 
@@ -137,7 +134,7 @@ internal static class ScrapeCommand
             : ScraperEngineBuilder.Crawl(ctx.Url);
 
         var builder = ctx.SchemaPath is not null
-            ? seed.Extract(LoadSchema(ctx.SchemaPath))
+            ? seed.Extract(SchemaFile.Load(ctx.SchemaPath))
             : seed.AsMarkdown();
 
         // ADR-0055 layered auto-spawn (paired with the ADR-0056 retry override):
@@ -290,135 +287,4 @@ internal static class ScrapeCommand
             NoAutoStealth: noAutoStealth);
     }
 
-    // ----- emission + schema parsing -----
-
-    private static async Task Emit(List<ParsedData> records, string? output)
-    {
-        // Default: write to stdout. With --output, write to file.
-        // Single record → output its Data JSON; multiple → JSON Lines.
-        var sb = new System.Text.StringBuilder();
-        foreach (var r in records)
-        {
-            sb.Append(r.Data.ToJsonString());
-            sb.Append('\n');
-        }
-
-        var text = sb.ToString().TrimEnd('\n');
-
-        if (output is not null)
-            await File.WriteAllTextAsync(output, text);
-        else
-            Console.WriteLine(text);
-    }
-
-    private static Schema LoadSchema(string path)
-    {
-        if (!File.Exists(path))
-            throw new CliException($"Schema file not found: {path}");
-
-        string content;
-        try { content = File.ReadAllText(path); }
-        catch (Exception ex)
-        {
-            throw new CliException($"Failed to read schema file '{path}': {ex.Message}");
-        }
-
-        JsonNode? root;
-        try { root = JsonNode.Parse(content); }
-        catch (JsonException ex)
-        {
-            throw new CliException($"Schema file '{path}' is not valid JSON: {ex.Message}");
-        }
-
-        if (root is not JsonObject obj)
-            throw new CliException(
-                $"Schema file '{path}' must contain a JSON object at the root.");
-
-        var schema = BuildSchema(obj);
-        return schema;
-    }
-
-    private static Schema BuildSchema(JsonObject obj)
-    {
-        // Recursive parse of the schema JSON shape into the library's
-        // Schema/SchemaElement records. The shape pinned in ADR-0043:
-        //   { field, selector?, type?, attr?, is_list?, children? }
-        //
-        // An object with children is a Schema (a nested container);
-        // a leaf with no children is a SchemaElement.
-
-        var children = obj["children"] as JsonArray;
-
-        if (children is null || children.Count == 0)
-        {
-            // Leaf.
-            return WrapAsSchema(BuildElement(obj));
-        }
-
-        // Container.
-        var field = obj["field"]?.GetValue<string>();
-        var selector = obj["selector"]?.GetValue<string>();
-        var isList = obj["is_list"]?.GetValue<bool>() ?? false;
-
-        var container = field is not null
-            ? new Schema(field) { Selector = selector ?? string.Empty, IsList = isList }
-            : new Schema();
-
-        foreach (var child in children)
-        {
-            if (child is not JsonObject childObj)
-                throw new CliException("Schema children must be objects.");
-            container.Add(BuildElement(childObj));
-        }
-
-        return container;
-    }
-
-    private static SchemaElement BuildElement(JsonObject obj)
-    {
-        var field = obj["field"]?.GetValue<string>()
-            ?? throw new CliException("Schema element is missing 'field'.");
-
-        var children = obj["children"] as JsonArray;
-        if (children is not null && children.Count > 0)
-        {
-            return BuildSchema(obj);
-        }
-
-        var selector = obj["selector"]?.GetValue<string>() ?? string.Empty;
-        var attr = obj["attr"]?.GetValue<string>();
-        var isList = obj["is_list"]?.GetValue<bool>() ?? false;
-        var type = ParseDataType(obj["type"]?.GetValue<string>());
-
-        var element = new SchemaElement(field, selector)
-        {
-            Type = type,
-            IsList = isList
-        };
-
-        if (attr is not null) element.Attr = attr;
-
-        return element;
-    }
-
-    private static Schema WrapAsSchema(SchemaElement element)
-    {
-        if (element is Schema schema) return schema;
-        return new Schema { element };
-    }
-
-    private static DataType? ParseDataType(string? raw)
-    {
-        if (string.IsNullOrEmpty(raw)) return null;
-        return raw.ToLowerInvariant() switch
-        {
-            "string" => DataType.String,
-            "integer" or "int" => DataType.Integer,
-            "float" or "double" or "decimal" => DataType.Float,
-            "boolean" or "bool" => DataType.Boolean,
-            "datetime" or "date" => DataType.DataTime,
-            _ => throw new CliException(
-                $"Unknown schema type '{raw}'. Valid: string, integer, float, boolean, datetime.")
-        };
-    }
 }

--- a/WebReaper.Cli/Help.cs
+++ b/WebReaper.Cli/Help.cs
@@ -14,6 +14,9 @@ Usage:
 Commands:
   scrape <url>          Fetch a URL; output Markdown by default,
                         or JSON if --schema is given.
+  crawl <url>           Crawl a whole site recursively (every on-domain
+                        page); stream JSON Lines. Markdown by default,
+                        or JSON if --schema is given.
   map <url>             Discover URLs (sitemap.xml + root-page links).
   browser <sub>         Manage the managed Chromium for --browser scrapes
                         (install/path/list).
@@ -47,6 +50,17 @@ Flags (per-command):
     --no-auto-stealth   Warn-only on bot-check detection; never install or
                         retry (ADR-0056 escape hatch).
 
+  crawl:
+    --schema <path>     JSON schema file (switches output to JSON).
+    --output <path>     Write to a file instead of stdout.
+    --max-pages <n>     Cap the pages crawled (default 1000).
+    --max-depth <n>     Cap the hop distance from the start URL
+                        (default: unlimited).
+    --include-subdomains  Follow subdomains of the start host too
+                          (default: same host + www only).
+    --no-sitemap        Don't seed the crawl from the site's sitemap;
+                        recursive link-following only.
+
   browser:
     install [--revision N]   Download managed Chromium to ~/.webreaper/.
     path    [--revision N]   Print cached binary path.
@@ -76,6 +90,8 @@ Flags (per-command):
 Examples:
   webreaper scrape https://example.com
   webreaper scrape https://example.com --schema schema.json
+  webreaper crawl https://example.com > pages.jsonl
+  webreaper crawl https://example.com --schema schema.json --max-pages 200
   webreaper map https://example.com --search /blog/
   webreaper init
 ".TrimStart();

--- a/WebReaper.Cli/Program.cs
+++ b/WebReaper.Cli/Program.cs
@@ -17,6 +17,7 @@ static async Task<int> Run(string[] args)
         return parsed.Command switch
         {
             "scrape" => await ScrapeCommand.RunAsync(parsed),
+            "crawl" => await CrawlCommand.RunAsync(parsed),
             "map" => await MapCommand.RunAsync(parsed),
             "init" => InitCommand.Run(parsed),
             "version" => VersionCommand.Run(),

--- a/WebReaper.Cli/RecordOutput.cs
+++ b/WebReaper.Cli/RecordOutput.cs
@@ -1,0 +1,27 @@
+using System.Text;
+using WebReaper.Sinks.Models;
+
+namespace WebReaper.Cli;
+
+// Shared record emission for `scrape` and `crawl` (ADR-0043 / ADR-0081). One
+// JSON object per line (JSON Lines): a single record is one line, multiple
+// records are one-per-line. Writes to stdout, or to a file with --output.
+internal static class RecordOutput
+{
+    public static async Task WriteAsync(IReadOnlyList<ParsedData> records, string? output)
+    {
+        var sb = new StringBuilder();
+        foreach (var r in records)
+        {
+            sb.Append(r.Data.ToJsonString());
+            sb.Append('\n');
+        }
+
+        var text = sb.ToString().TrimEnd('\n');
+
+        if (output is not null)
+            await File.WriteAllTextAsync(output, text);
+        else
+            Console.WriteLine(text);
+    }
+}

--- a/WebReaper.Cli/SchemaFile.cs
+++ b/WebReaper.Cli/SchemaFile.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using WebReaper.Domain.Parsing;
+
+namespace WebReaper.Cli;
+
+// Shared schema-file loader for `scrape` and `crawl` (ADR-0043 / ADR-0081). The
+// JSON shape is the ADR-0043 contract:
+//   { field, selector?, type?, attr?, is_list?, children? }
+// An object with children is a Schema (a nested container); a leaf with no
+// children is a SchemaElement. AOT-clean: JsonNode parsing, no reflection.
+internal static class SchemaFile
+{
+    public static Schema Load(string path)
+    {
+        if (!File.Exists(path))
+            throw new CliException($"Schema file not found: {path}");
+
+        string content;
+        try { content = File.ReadAllText(path); }
+        catch (Exception ex)
+        {
+            throw new CliException($"Failed to read schema file '{path}': {ex.Message}");
+        }
+
+        JsonNode? root;
+        try { root = JsonNode.Parse(content); }
+        catch (JsonException ex)
+        {
+            throw new CliException($"Schema file '{path}' is not valid JSON: {ex.Message}");
+        }
+
+        if (root is not JsonObject obj)
+            throw new CliException(
+                $"Schema file '{path}' must contain a JSON object at the root.");
+
+        return BuildSchema(obj);
+    }
+
+    private static Schema BuildSchema(JsonObject obj)
+    {
+        var children = obj["children"] as JsonArray;
+
+        if (children is null || children.Count == 0)
+        {
+            // Leaf.
+            return WrapAsSchema(BuildElement(obj));
+        }
+
+        // Container.
+        var field = obj["field"]?.GetValue<string>();
+        var selector = obj["selector"]?.GetValue<string>();
+        var isList = obj["is_list"]?.GetValue<bool>() ?? false;
+
+        var container = field is not null
+            ? new Schema(field) { Selector = selector ?? string.Empty, IsList = isList }
+            : new Schema();
+
+        foreach (var child in children)
+        {
+            if (child is not JsonObject childObj)
+                throw new CliException("Schema children must be objects.");
+            container.Add(BuildElement(childObj));
+        }
+
+        return container;
+    }
+
+    private static SchemaElement BuildElement(JsonObject obj)
+    {
+        var field = obj["field"]?.GetValue<string>()
+            ?? throw new CliException("Schema element is missing 'field'.");
+
+        var children = obj["children"] as JsonArray;
+        if (children is not null && children.Count > 0)
+        {
+            return BuildSchema(obj);
+        }
+
+        var selector = obj["selector"]?.GetValue<string>() ?? string.Empty;
+        var attr = obj["attr"]?.GetValue<string>();
+        var isList = obj["is_list"]?.GetValue<bool>() ?? false;
+        var type = ParseDataType(obj["type"]?.GetValue<string>());
+
+        var element = new SchemaElement(field, selector)
+        {
+            Type = type,
+            IsList = isList
+        };
+
+        if (attr is not null) element.Attr = attr;
+
+        return element;
+    }
+
+    private static Schema WrapAsSchema(SchemaElement element)
+    {
+        if (element is Schema schema) return schema;
+        return new Schema { element };
+    }
+
+    private static DataType? ParseDataType(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw)) return null;
+        return raw.ToLowerInvariant() switch
+        {
+            "string" => DataType.String,
+            "integer" or "int" => DataType.Integer,
+            "float" or "double" or "decimal" => DataType.Float,
+            "boolean" or "bool" => DataType.Boolean,
+            "datetime" or "date" => DataType.DataTime,
+            _ => throw new CliException(
+                $"Unknown schema type '{raw}'. Valid: string, integer, float, boolean, datetime.")
+        };
+    }
+}

--- a/WebReaper.Cli/skill/SKILL.md
+++ b/WebReaper.Cli/skill/SKILL.md
@@ -43,18 +43,43 @@ Three commands. Each is one shell call; output goes to stdout unless `--output`.
 | The readable text of one page | `webreaper scrape <url>` |
 | The readable text saved to a file | `webreaper scrape <url> --output page.md` |
 | Specific fields from one page | `webreaper scrape <url> --schema schema.json` |
+| Every page of a whole site (Markdown) | `webreaper crawl <url> > pages.jsonl` |
+| Every page of a whole site (fields) | `webreaper crawl <url> --schema schema.json` |
 | URLs on a site | `webreaper map <url>` |
 | URLs matching a substring | `webreaper map <url> --search /blog/ --max-urls 50` |
 | A JS-rendered page (SPA) | `webreaper scrape <url> --browser` |
 | A bot-protected site | `webreaper scrape <url> --browser --auto-stealth` |
 | Fields from every linked page | `webreaper scrape <index-url> --follow "<css selector>" --schema schema.json` |
 
-## Common workflow — multi-page extraction
+## Whole-site crawl in one command
 
-The CLI's `scrape` is single-URL. For multi-page work, chain `map` → filter → loop:
+To cover an entire site, use `crawl`: it recursively follows every on-domain
+link from the start URL, extracts each page, and streams JSON Lines (one object
+per page). Markdown by default; `--schema` switches to field extraction.
 
 ```bash
-# 1. Discover URLs.
+# Every page, as Markdown, to a file.
+webreaper crawl https://example.com > pages.jsonl
+
+# Every page, specific fields, bounded.
+webreaper crawl https://example.com --schema schema.json --max-pages 200
+```
+
+Flags: `--max-pages <n>` (default 1000), `--max-depth <n>` (hops from the start
+URL; default unlimited), `--include-subdomains` (default: same host + `www`
+only), `--no-sitemap` (skip sitemap seeding; recursive links only),
+`--schema` / `--output` (as for `scrape`). On-domain only; off-domain links
+are never followed. `crawl` is HTTP-only; for a JS-rendered or bot-protected
+site, scrape the pages with `scrape --browser` instead.
+
+## Common workflow: selective multi-page extraction
+
+`crawl` covers the *whole* site. When the user wants only a *subset* (e.g. just
+blog posts), chain `map` → filter → `scrape` loop instead, so you fetch only the
+matching URLs:
+
+```bash
+# 1. Discover + filter URLs.
 webreaper map https://example.com/blog --search /post/ --max-urls 20 > urls.txt
 
 # 2. Scrape each. Cache so reruns are free.
@@ -63,9 +88,8 @@ while read -r url; do
 done < urls.txt
 ```
 
-When the user asks "scrape the top N articles from <site> and …", this is the
-shape — `map` first, `scrape --schema` per URL, then process the JSON Lines
-output.
+Rule of thumb: "everything on the site" → `crawl`; "the pages matching X" →
+`map --search X` then `scrape` per URL.
 
 ## Browser & stealth — when sites resist
 
@@ -119,6 +143,8 @@ A schema is a tree of fields. Leaves have a CSS `selector` and a `type`
 - `scrape` without `--schema` → Markdown (one document per page).
 - `scrape` with `--schema` → JSON (one record per page; multiple pages = JSON
   Lines, one object per line).
+- `crawl` → JSON Lines, one object per swept page (Markdown record by default,
+  schema fields with `--schema`).
 - `map` → one URL per line.
 - `--output <path>` redirects to a file instead of stdout.
 

--- a/WebReaper.Tests/WebReaper.AotSmokeTest/Program.cs
+++ b/WebReaper.Tests/WebReaper.AotSmokeTest/Program.cs
@@ -108,6 +108,22 @@ Check(gotFillConfig.PageActions![0] is PageAction.Fill { Selector: "input#q", Va
 Check(((Schema)gotConfig.ParsingScheme!.Children[0]).Children[0].Type == DataType.Integer,
     "polymorphic Schema/SchemaElement round-trip");
 
+// 1e. ADR-0081: the recursive Site-sweep marker survives the selector-chain
+//     codec, and the config's IncludeSubdomains + MaxDepth knobs round-trip
+//     through source-gen, all AOT-clean.
+var sweepConfig = new ScraperConfig(
+    ParsingScheme: null,
+    LinkPathSelectors: ImmutableQueue.CreateRange(new[] { LinkPathSelector.Sweep("a[href]") }),
+    StartUrls: new[] { "https://x.test/" },
+    UrlBlackList: Array.Empty<string>(),
+    IncludeSubdomains: true,
+    MaxDepth: 4);
+var sweepGot = WebReaperJson.DeserializeConfig(WebReaperJson.SerializeConfig(sweepConfig));
+Check(sweepGot.LinkPathSelectors.Single().Recursive
+      && sweepGot.IncludeSubdomains
+      && sweepGot.MaxDepth == 4,
+    "Site-sweep recursive marker + config knobs round-trip (ADR-0081, AOT-clean)");
+
 // 2. Production WebReaperJson — Job round-trip (ADR-0005 closure).
 var job = new Job("https://x.test/p",
     ImmutableQueue.CreateRange(new[] { new LinkPathSelector("a.x", null, PageType.Static) }),

--- a/WebReaper.Tests/WebReaper.Cli.Tests/CliEndToEndTests.cs
+++ b/WebReaper.Tests/WebReaper.Cli.Tests/CliEndToEndTests.cs
@@ -139,6 +139,46 @@ public sealed class CliEndToEndTests : IClassFixture<CliSiteFixture>
     }
 
     [Fact]
+    public async Task Crawl_sweeps_the_whole_site_and_streams_multiple_pages()
+    {
+        // ADR-0081: a whole-site sweep from the root. It follows on-domain links
+        // (root → /static, /list, /item/1; pagination → page 2 → /item/4..6) and
+        // is seeded by the sitemap (/item/1..3, /static); the off-domain
+        // example.com links are dropped, so it does NOT hang on the network. The
+        // Visited-link tracker dedups and the frontier saturates, so the
+        // subprocess returns (a non-terminating sweep would hang the test).
+        var r = await RunCli(["crawl", _site.BaseUrl, "--max-pages", "50"]);
+
+        Assert.Equal(0, r.ExitCode);
+        var lines = r.Stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.True(lines.Length >= 5, $"expected several swept pages, got {lines.Length}");
+        Assert.Contains("Widget Pro 3000", r.Stdout);   // /static, extracted as Markdown
+        Assert.Contains("Item 1", r.Stdout);            // a leaf item page, swept + extracted
+    }
+
+    [Fact]
+    public async Task Crawl_with_schema_emits_json_lines_for_swept_pages()
+    {
+        var schemaPath = Path.Combine(Path.GetTempPath(), $"wr-crawl-schema-{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(schemaPath, """
+        { "children": [ { "field": "title", "selector": ".title" } ] }
+        """);
+
+        try
+        {
+            var r = await RunCli(["crawl", _site.BaseUrl, "--schema", schemaPath, "--max-pages", "50"]);
+
+            Assert.Equal(0, r.ExitCode);
+            Assert.Contains("Widget Pro 3000", r.Stdout);   // /static .title
+            Assert.Contains("\"url\"", r.Stdout);           // JSON records, url folded in
+        }
+        finally
+        {
+            File.Delete(schemaPath);
+        }
+    }
+
+    [Fact]
     public async Task Map_discovers_urls_from_sitemap_and_root_page()
     {
         var r = await RunCli(["map", _site.BaseUrl]);

--- a/WebReaper.Tests/WebReaper.Cli.Tests/CrawlContextTests.cs
+++ b/WebReaper.Tests/WebReaper.Cli.Tests/CrawlContextTests.cs
@@ -1,0 +1,64 @@
+using WebReaper.Cli;
+using WebReaper.Cli.Commands;
+
+namespace WebReaper.Cli.Tests;
+
+/// <summary>
+/// ADR-0081. The CrawlCommand's flag-parsing contract:
+/// --schema / --output / --max-pages / --max-depth / --include-subdomains /
+/// --no-sitemap, and the defaults (max-pages 1000, sitemap on, no subdomains,
+/// unbounded depth).
+/// </summary>
+public class CrawlContextTests
+{
+    private static CrawlCommand.CrawlContext Parse(params string[] argv)
+        => CrawlCommand.ParseContext(Args.Parse(argv));
+
+    [Fact]
+    public void Defaults_are_sitemap_on_1000_pages_no_subdomains_unbounded_depth()
+    {
+        var ctx = Parse("crawl", "https://example.com");
+
+        Assert.Equal("https://example.com", ctx.Url);
+        Assert.Null(ctx.SchemaPath);
+        Assert.Null(ctx.Output);
+        Assert.Equal(1000, ctx.MaxPages);
+        Assert.Null(ctx.MaxDepth);             // unbounded
+        Assert.False(ctx.IncludeSubdomains);
+        Assert.True(ctx.Sitemap);
+    }
+
+    [Fact]
+    public void Bare_host_url_defaults_to_https()
+    {
+        Assert.Equal("https://example.com", Parse("crawl", "example.com").Url);
+    }
+
+    [Fact]
+    public void Max_pages_and_max_depth_flags_parse()
+    {
+        var ctx = Parse("crawl", "https://example.com", "--max-pages", "50", "--max-depth", "3");
+        Assert.Equal(50, ctx.MaxPages);
+        Assert.Equal(3, ctx.MaxDepth);
+    }
+
+    [Fact]
+    public void Include_subdomains_flag_sets_the_boundary()
+    {
+        Assert.True(Parse("crawl", "https://example.com", "--include-subdomains").IncludeSubdomains);
+    }
+
+    [Fact]
+    public void No_sitemap_flag_turns_seeding_off()
+    {
+        Assert.False(Parse("crawl", "https://example.com", "--no-sitemap").Sitemap);
+    }
+
+    [Fact]
+    public void Schema_and_output_flags_parse()
+    {
+        var ctx = Parse("crawl", "https://example.com", "--schema", "s.json", "--output", "out.jsonl");
+        Assert.Equal("s.json", ctx.SchemaPath);
+        Assert.Equal("out.jsonl", ctx.Output);
+    }
+}

--- a/WebReaper.Tests/WebReaper.UnitTests/CrawlOutcomeArmCensusTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/CrawlOutcomeArmCensusTests.cs
@@ -1,0 +1,60 @@
+using System.Collections.Immutable;
+using System.Text.Json.Nodes;
+using WebReaper.Core.Crawling;
+using WebReaper.Domain;
+using WebReaper.Sinks.Models;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0081 (sibling to PageActionArmCensusTests): the CrawlOutcome closed sum
+// is interpreted by every Crawl driver, and C# has no closed-hierarchy
+// exhaustiveness to make a forgotten arm a compile error. This census is the
+// cheap tripwire: when an arm is added or removed it fails with a checklist of
+// every consumer to update (the in-process driver, the distributed-driver
+// example, and the NextJobs projection).
+public class CrawlOutcomeArmCensusTests
+{
+    [Fact]
+    public void CrawlOutcome_arm_set_is_pinned_so_a_new_arm_forces_updating_every_consumer()
+    {
+        var arms = typeof(CrawlOutcome).GetNestedTypes()
+            .Where(t => t.IsSealed && t.IsSubclassOf(typeof(CrawlOutcome)))
+            .Select(t => t.Name)
+            .ToHashSet();
+
+        var expected = new HashSet<string>
+        {
+            nameof(CrawlOutcome.Parsed),
+            nameof(CrawlOutcome.Followed),
+            nameof(CrawlOutcome.Paginated),
+            nameof(CrawlOutcome.Swept),
+        };
+
+        Assert.True(arms.SetEquals(expected),
+            "CrawlOutcome's arm set changed. An arm is interpreted by every Crawl " +
+            "driver, so update ALL of them, then this census:\n" +
+            "  - WebReaper.Core.ScraperEngine (the in-process driver's arm switch)\n" +
+            "  - Examples/WebReaper.AzureFuncs/WebReaperSpider.cs (the distributed driver)\n" +
+            "  - CrawlOutcome.NextJobs (the candidate-children projection)\n" +
+            $"Expected: [{string.Join(", ", expected.OrderBy(x => x))}]\n" +
+            $"Actual:   [{string.Join(", ", arms.OrderBy(x => x))}]");
+    }
+
+    [Fact]
+    public void Swept_carries_the_page_record_and_its_on_domain_children()
+    {
+        var data = new ParsedData("https://x.test/", new JsonObject());
+        var child = new Job("https://x.test/a",
+            ImmutableQueue<WebReaper.Domain.Selectors.LinkPathSelector>.Empty,
+            ImmutableQueue<string>.Empty);
+
+        var outcome = CrawlOutcome.Sweep(data, ImmutableArray.Create(child));
+
+        var swept = Assert.IsType<CrawlOutcome.Swept>(outcome);
+        Assert.Same(data, swept.Data);
+        Assert.Equal(new[] { "https://x.test/a" }, swept.Next.Select(j => j.Url));
+        // NextJobs surfaces the swept children too; a generic consumer that
+        // enqueues NextJobs (the distributed else-branch) still follows them.
+        Assert.Equal(new[] { "https://x.test/a" }, outcome.NextJobs.Select(j => j.Url));
+    }
+}

--- a/WebReaper.Tests/WebReaper.UnitTests/CrawlStepTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/CrawlStepTests.cs
@@ -14,11 +14,15 @@ namespace WebReaper.UnitTests;
 // HTML ⇒ assert the outcome arm and its selector-chain handling".
 public class CrawlStepTests
 {
-    private static CrawlStep Step() =>
-        new(new SchemaFold<AngleSharp.Dom.IParentNode>(new AngleSharpSchemaBackend(), NullLogger.Instance));
+    private static CrawlStep Step(SweepPolicy? sweepPolicy = null) =>
+        new(new SchemaFold<AngleSharp.Dom.IParentNode>(new AngleSharpSchemaBackend(), NullLogger.Instance),
+            sweepPolicy);
 
     private static Job Job(string url, params LinkPathSelector[] chain) =>
         new(url, ImmutableQueue.CreateRange(chain), ImmutableQueue.Create<string>());
+
+    private static Job JobWithBacklinks(string url, string[] backlinks, params LinkPathSelector[] chain) =>
+        new(url, ImmutableQueue.CreateRange(chain), ImmutableQueue.CreateRange(backlinks));
 
     [Fact]
     public async Task Empty_chain_yields_one_ParsedData_and_no_jobs()
@@ -103,5 +107,78 @@ public class CrawlStepTests
         // NextJobs projection = items then next-pages, in order.
         Assert.Equal(new[] { "https://x.test/i1", "https://x.test/list?p=2" },
             outcome.NextJobs.Select(j => j.Url));
+    }
+
+    // ---- Sweep page (ADR-0081): the one arm that extracts AND follows ----
+
+    [Fact]
+    public async Task Sweep_page_yields_ParsedData_and_on_domain_children_that_retain_the_sweep_selector()
+    {
+        var sweep = LinkPathSelector.Sweep();                      // recursive a[href]
+        var job = Job("https://x.test/", sweep);
+        var schema = new Schema { new("title", "h1.t") };
+        const string html = "<html><body><h1 class='t'>Home</h1>" +
+                            "<a href='/a'>a</a>" +
+                            "<a href='/b'>b</a>" +
+                            "<a href='https://other.test/x'>off</a></body></html>";
+
+        var outcome = await Step().StepAsync(job, html, schema);
+
+        var swept = Assert.IsType<CrawlOutcome.Swept>(outcome);
+        // Extracts like a target page...
+        Assert.Equal("https://x.test/", swept.Data.Url);
+        Assert.Equal("Home", swept.Data.Data["title"]?.ToString());
+        // ...AND follows its on-domain links (the off-domain one is dropped).
+        Assert.Equal(new[] { "https://x.test/a", "https://x.test/b" },
+            swept.Next.Select(j => j.Url));
+        Assert.All(swept.Next, j =>
+        {
+            // RETAIN: the child carries the same one-element recursive chain.
+            var retained = Assert.Single(j.LinkPathSelectors);
+            Assert.True(retained.Recursive);
+            Assert.Equal(sweep, retained);
+            Assert.Equal("https://x.test/", j.ParentBacklinks.Single()); // provenance
+        });
+    }
+
+    [Fact]
+    public async Task Sweep_excludes_subdomains_by_default_but_includes_them_when_opted_in()
+    {
+        var job = Job("https://example.com/", LinkPathSelector.Sweep());
+        const string html = "<html><body>" +
+                            "<a href='https://blog.example.com/x'>sub</a></body></html>";
+        var schema = new Schema { new("title", "h1") };
+
+        // Default (no policy ⇒ anchor derived from the page host, no subdomains).
+        var byDefault = Assert.IsType<CrawlOutcome.Swept>(
+            await Step().StepAsync(job, html, schema));
+        Assert.Empty(byDefault.Next);
+
+        // --include-subdomains widens to the apex suffix.
+        var opted = Assert.IsType<CrawlOutcome.Swept>(
+            await Step(new SweepPolicy("example.com", IncludeSubdomains: true, MaxDepth: int.MaxValue))
+                .StepAsync(job, html, schema));
+        Assert.Equal(new[] { "https://blog.example.com/x" }, opted.Next.Select(j => j.Url));
+    }
+
+    [Fact]
+    public async Task Sweep_stops_following_at_max_depth_but_still_extracts_the_page()
+    {
+        var sweep = LinkPathSelector.Sweep();
+        var schema = new Schema { new("title", "h1") };
+        const string html = "<html><body><h1>deep</h1><a href='/c'>c</a></body></html>";
+
+        var policy = new SweepPolicy("x.test", IncludeSubdomains: false, MaxDepth: 1);
+
+        // Depth 1 (one backlink) with MaxDepth 1: extract, do NOT follow.
+        var atCap = JobWithBacklinks("https://x.test/b", new[] { "https://x.test/" }, sweep);
+        var capped = Assert.IsType<CrawlOutcome.Swept>(await Step(policy).StepAsync(atCap, html, schema));
+        Assert.Equal("deep", capped.Data.Data["title"]?.ToString());
+        Assert.Empty(capped.Next);
+
+        // Depth 0 (the start page) with MaxDepth 1: still follows.
+        var atStart = Job("https://x.test/", sweep);
+        var followed = Assert.IsType<CrawlOutcome.Swept>(await Step(policy).StepAsync(atStart, html, schema));
+        Assert.Equal(new[] { "https://x.test/c" }, followed.Next.Select(j => j.Url));
     }
 }

--- a/WebReaper.Tests/WebReaper.UnitTests/LinkPathSelectorConstructionTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/LinkPathSelectorConstructionTests.cs
@@ -154,4 +154,57 @@ public class LinkPathSelectorConstructionTests
         Assert.Equal(PageType.Dynamic, s.PageType);
         Assert.Single(s.PageActions!);
     }
+
+    // ---- Sweep factory (ADR-0081, the recursive Site-sweep intent-shape) ----
+
+    [Fact]
+    public void Sweep_builds_a_recursive_step_with_the_default_link_selector()
+    {
+        var s = LinkPathSelector.Sweep();
+
+        Assert.True(s.Recursive);
+        Assert.Equal("a[href]", s.Selector);   // default: follow every anchor
+        Assert.Null(s.PaginationSelector);
+        Assert.False(s.HasPagination);
+        Assert.Equal(PageType.Static, s.PageType);
+    }
+
+    [Fact]
+    public void Sweep_accepts_a_restricting_link_selector()
+    {
+        var s = LinkPathSelector.Sweep("a[href^='/blog/']");
+
+        Assert.True(s.Recursive);
+        Assert.Equal("a[href^='/blog/']", s.Selector);
+    }
+
+    [Fact]
+    public void Sweep_rejects_an_empty_selector()
+    {
+        // The non-empty-Selector grammar rule (ADR-0030) still applies to the
+        // third intent-shape; an explicitly-blank link selector is malformed.
+        Assert.Throws<ArgumentException>(() => LinkPathSelector.Sweep(""));
+    }
+
+    [Fact]
+    public void Sweep_with_browser_actions_uses_a_dynamic_transport()
+    {
+        var actions = new List<PageAction> { new PageAction.Click(".accept") };
+
+        var s = LinkPathSelector.Sweep("a[href]", PageType.Dynamic, actions);
+
+        Assert.Equal(PageType.Dynamic, s.PageType);
+        Assert.Single(s.PageActions!);
+        Assert.True(s.Recursive);
+    }
+
+    [Fact]
+    public void Follow_and_Paginate_and_the_constructor_are_not_recursive()
+    {
+        // Recursive is the Sweep-only marker; every other construction path
+        // leaves it false so the Crawl step keeps its advance/retain behaviour.
+        Assert.False(new LinkPathSelector("a.item").Recursive);
+        Assert.False(LinkPathSelector.Follow("a.item").Recursive);
+        Assert.False(LinkPathSelector.Paginate("a.item", "a.next").Recursive);
+    }
 }

--- a/WebReaper.Tests/WebReaper.UnitTests/ScraperEngineDriverTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/ScraperEngineDriverTests.cs
@@ -142,6 +142,51 @@ public class ScraperEngineDriverTests
     private static JobReport Parsed(string url) =>
         new(CrawlOutcome.Target(new ParsedData(url, new JsonObject())), "<html/>");
 
+    private static JobReport Swept(string url, params string[] children) =>
+        new(CrawlOutcome.Sweep(
+                new ParsedData(url, new JsonObject()),
+                children
+                    .Select(u => new Job(u,
+                        ImmutableQueue.CreateRange(new[] { LinkPathSelector.Sweep() }),
+                        ImmutableQueue<string>.Empty))
+                    .ToImmutableArray()),
+            "<html/>");
+
+    [Fact]
+    public async Task Swept_page_both_emits_its_record_and_follows_its_children_until_the_frontier_saturates()
+    {
+        // ADR-0081: the Sweep page is the one arm that BOTH emits AND follows.
+        // A cyclic 3-page graph; the Visited-link tracker dedups so each page is
+        // crawled and emitted exactly once, and the recursive frontier
+        // saturates so the crawl terminates (a hang would fail WaitAsync).
+        var sink = new RecordingSink();
+
+        var spider = new ScriptedSpider(job => job.Url switch
+        {
+            "root" => Swept("root", "a", "b"),
+            "a" => Swept("a", "b", "root"),   // cycles back to seen pages
+            "b" => Swept("b", "a"),           // cycles
+            _ => Swept(job.Url),
+        });
+
+        var engine = new ScraperEngine(
+            parallelismDegree: 1,
+            new FakeConfigStorage(Config()),
+            new InMemoryScheduler(),
+            spider,
+            new InMemoryVisitedLinkTracker(),
+            new List<IScraperSink> { sink },
+            NullLogger.Instance);
+
+        await engine.RunAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Each page crawled once (dedup) AND emitted once (Swept emits like a
+        // target page), proof the driver runs the Post-extraction pipeline for
+        // the Swept arm, not only for Parsed.
+        Assert.Equal(new[] { "a", "b", "root" }, sink.Emitted.Select(p => p.Url).OrderBy(u => u));
+        Assert.Equal(3, spider.Crawled.Count);
+    }
+
     [Fact]
     public async Task Crawl_limit_stops_the_run_as_a_value_never_an_exception()
     {

--- a/WebReaper.Tests/WebReaper.UnitTests/StjSerializationTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/StjSerializationTests.cs
@@ -116,6 +116,40 @@ public class StjSerializationTests
     }
 
     [Fact]
+    public void Sweep_selector_round_trips_with_the_recursive_marker()
+    {
+        // ADR-0081: the recursive marker must survive the selector-chain codec
+        // so a durable / distributed scheduler resumes a Sweep page as a sweep,
+        // not a plain follow.
+        var job = new Job(
+            "https://x.test/",
+            ImmutableQueue.CreateRange(new[] { LinkPathSelector.Sweep("a[href]") }),
+            ImmutableQueue<string>.Empty);
+
+        var json = WebReaperJson.SerializeJob(job);
+        var got = WebReaperJson.DeserializeJob(json);
+
+        var selector = Assert.Single(got.LinkPathSelectors);
+        Assert.True(selector.Recursive);
+        Assert.Equal("a[href]", selector.Selector);
+    }
+
+    [Fact]
+    public void Non_recursive_selectors_round_trip_with_recursive_false()
+    {
+        // The marker is written only when set, so an ordinary follow step
+        // deserialises with Recursive = false (the default).
+        var job = new Job(
+            "https://x.test/",
+            ImmutableQueue.CreateRange(new[] { LinkPathSelector.Follow("a.item") }),
+            ImmutableQueue<string>.Empty);
+
+        var got = WebReaperJson.DeserializeJob(WebReaperJson.SerializeJob(job));
+
+        Assert.False(Assert.Single(got.LinkPathSelectors).Recursive);
+    }
+
+    [Fact]
     public void DeserializeJob_throws_on_a_chain_entry_with_a_blank_selector()
     {
         // ADR-0030: a corrupt persisted Job — a selector-chain entry whose

--- a/WebReaper.Tests/WebReaper.UnitTests/SweepBuilderTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/SweepBuilderTests.cs
@@ -1,0 +1,100 @@
+using WebReaper.Builders;
+using WebReaper.ConfigStorage.Abstract;
+using WebReaper.Core.Mapping;
+using WebReaper.Domain;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0081: the .Sweep(options?) builder surface: it appends the recursive
+// selector and maps the options onto the ScraperConfig, and BuildAsync seeds
+// the frontier from the Site mapper when SweepOptions.Sitemap is on.
+public class SweepBuilderTests
+{
+    private sealed class CapturingConfigStorage : IScraperConfigStorage
+    {
+        public ScraperConfig? Created;
+        public Task CreateConfigAsync(ScraperConfig config) { Created = config; return Task.CompletedTask; }
+        public Task<ScraperConfig> GetConfigAsync() => Task.FromResult(Created!);
+    }
+
+    private sealed class FakeSiteMapper(params string[] urls) : ISiteMapper
+    {
+        public Task<IReadOnlyList<string>> MapAsync(
+            string url, MapOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(urls);
+    }
+
+    private sealed class ThrowingSiteMapper : ISiteMapper
+    {
+        public Task<IReadOnlyList<string>> MapAsync(
+            string url, MapOptions? options = null, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("the site mapper must not be called when Sitemap is off");
+    }
+
+    [Fact]
+    public void Sweep_appends_a_recursive_selector_and_maps_options_onto_the_config()
+    {
+        var config = ScraperEngineBuilder
+            .Crawl("https://example.com/")
+            .AsMarkdown()
+            .Sweep(new SweepOptions { LinkSelector = "a.x", IncludeSubdomains = true, MaxDepth = 5 })
+            .Build();
+
+        var selector = Assert.Single(config.LinkPathSelectors);
+        Assert.True(selector.Recursive);
+        Assert.Equal("a.x", selector.Selector);
+        Assert.True(config.IncludeSubdomains);
+        Assert.Equal(5, config.MaxDepth);
+    }
+
+    [Fact]
+    public void Sweep_defaults_to_a_href_no_subdomains_unbounded_depth()
+    {
+        var config = ScraperEngineBuilder
+            .Crawl("https://example.com/")
+            .AsMarkdown()
+            .Sweep()
+            .Build();
+
+        var selector = Assert.Single(config.LinkPathSelectors);
+        Assert.Equal("a[href]", selector.Selector);
+        Assert.True(selector.Recursive);
+        Assert.False(config.IncludeSubdomains);
+        Assert.Equal(int.MaxValue, config.MaxDepth);
+    }
+
+    [Fact]
+    public async Task Sweep_with_sitemap_on_seeds_the_frontier_from_discovered_urls()
+    {
+        var capture = new CapturingConfigStorage();
+
+        await using var engine = await ScraperEngineBuilder
+            .Crawl("https://example.com/")
+            .AsMarkdown()
+            .Sweep(new SweepOptions { Sitemap = true })
+            .WithConfigStorage(capture)
+            .WithSiteMapper(new FakeSiteMapper("https://example.com/a", "https://example.com/b"))
+            .BuildAsync();
+
+        var starts = capture.Created!.StartUrls.ToList();
+        Assert.Equal(
+            new[] { "https://example.com/", "https://example.com/a", "https://example.com/b" },
+            starts);
+    }
+
+    [Fact]
+    public async Task Sweep_with_sitemap_off_does_not_call_the_site_mapper()
+    {
+        var capture = new CapturingConfigStorage();
+
+        await using var engine = await ScraperEngineBuilder
+            .Crawl("https://example.com/")
+            .AsMarkdown()
+            .Sweep(new SweepOptions { Sitemap = false })
+            .WithConfigStorage(capture)
+            .WithSiteMapper(new ThrowingSiteMapper())   // throws if seeding runs
+            .BuildAsync();
+
+        Assert.Equal(new[] { "https://example.com/" }, capture.Created!.StartUrls);
+    }
+}

--- a/WebReaper.Tests/WebReaper.UnitTests/SweepDomainFilterTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/SweepDomainFilterTests.cs
@@ -1,0 +1,72 @@
+using WebReaper.Core.Crawling.Concrete;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0081: the on-domain boundary a Site sweep follows. Default is
+// same-host-plus-www (anchored on the start host); --include-subdomains widens
+// to a suffix match on the apex (a documented heuristic, not PSL-correct). The
+// dot boundary on the suffix match is load-bearing: "notexample.com" must not
+// count as on-domain for "example.com".
+public class SweepDomainFilterTests
+{
+    // ---- default mode: same host, www treated as the apex ----
+
+    [Theory]
+    [InlineData("https://example.com/a")]
+    [InlineData("https://example.com/deep/path?q=1")]
+    [InlineData("http://example.com/a")]            // scheme-agnostic
+    [InlineData("https://EXAMPLE.com/a")]           // host case-insensitive
+    public void Same_host_is_on_domain(string url)
+    {
+        Assert.True(SweepDomainFilter.IsOnDomain(url, "example.com", includeSubdomains: false));
+    }
+
+    [Fact]
+    public void Leading_www_is_equal_to_the_apex_both_directions()
+    {
+        Assert.True(SweepDomainFilter.IsOnDomain("https://www.example.com/a", "example.com", false));
+        Assert.True(SweepDomainFilter.IsOnDomain("https://example.com/a", "www.example.com", false));
+    }
+
+    [Theory]
+    [InlineData("https://other.com/a")]
+    [InlineData("https://blog.example.com/a")]      // a subdomain is OFF by default
+    [InlineData("https://notexample.com/a")]        // dot-boundary guard
+    public void Other_hosts_are_off_domain_by_default(string url)
+    {
+        Assert.False(SweepDomainFilter.IsOnDomain(url, "example.com", includeSubdomains: false));
+    }
+
+    // ---- include-subdomains: suffix match on the apex ----
+
+    [Theory]
+    [InlineData("https://blog.example.com/a")]
+    [InlineData("https://deep.nested.example.com/a")]
+    [InlineData("https://example.com/a")]           // the apex itself
+    [InlineData("https://www.example.com/a")]
+    public void Subdomains_are_on_domain_when_opted_in(string url)
+    {
+        Assert.True(SweepDomainFilter.IsOnDomain(url, "example.com", includeSubdomains: true));
+    }
+
+    [Theory]
+    [InlineData("https://notexample.com/a")]        // shares no dot boundary
+    [InlineData("https://example.com.evil.com/a")]  // suffix attack: not a real subdomain
+    [InlineData("https://other.com/a")]
+    public void Subdomain_mode_still_rejects_unrelated_hosts(string url)
+    {
+        Assert.False(SweepDomainFilter.IsOnDomain(url, "example.com", includeSubdomains: true));
+    }
+
+    // ---- malformed input is skipped, never thrown ----
+
+    [Theory]
+    [InlineData("/relative/path")]
+    [InlineData("not a url")]
+    [InlineData("")]
+    public void A_non_absolute_url_is_not_on_domain(string url)
+    {
+        Assert.False(SweepDomainFilter.IsOnDomain(url, "example.com", includeSubdomains: false));
+        Assert.False(SweepDomainFilter.IsOnDomain(url, "example.com", includeSubdomains: true));
+    }
+}

--- a/WebReaper.Tests/WebReaper.UnitTests/SweepPolicyThreadingTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/SweepPolicyThreadingTests.cs
@@ -1,0 +1,78 @@
+using System.Collections.Immutable;
+using WebReaper.Builders;
+using WebReaper.Core.Crawling;
+using WebReaper.Core.Loaders.Abstract;
+using WebReaper.Core.Spider.Abstract;
+using WebReaper.Domain;
+using WebReaper.Domain.Parsing;
+using WebReaper.Domain.Selectors;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0081: SpiderBuilder derives the SweepPolicy from the ScraperConfig (the
+// anchor host from the start URL, IncludeSubdomains + MaxDepth verbatim) and
+// threads it into the CrawlStep. This pins the config → CrawlStep seam end to
+// end through a real Spider (a fake loader, no network), so a Sweep built
+// through the config path (the engine driver OR a distributed worker, both of
+// which go through SpiderBuilder.Build) filters children by the configured
+// boundary.
+public class SweepPolicyThreadingTests
+{
+    private sealed class FakeLoader(string html) : IPageLoader
+    {
+        public Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(html);
+    }
+
+    private static ScraperConfig SweepConfig(bool includeSubdomains, int maxDepth = int.MaxValue) => new(
+        ParsingScheme: new Schema { new("title", "h1") },
+        LinkPathSelectors: ImmutableQueue.CreateRange(new[] { LinkPathSelector.Sweep() }),
+        StartUrls: new[] { "https://example.com/" },
+        UrlBlackList: Array.Empty<string>(),
+        IncludeSubdomains: includeSubdomains,
+        MaxDepth: maxDepth);
+
+    private static ISpider BuildSweepSpider(ScraperConfig config, string html) =>
+        new SpiderBuilder().WithPageLoader(new FakeLoader(html)).WithConfig(config).Build();
+
+    private static Job StartJob() => new(
+        "https://example.com/",
+        ImmutableQueue.CreateRange(new[] { LinkPathSelector.Sweep() }),
+        ImmutableQueue<string>.Empty);
+
+    [Fact]
+    public async Task SpiderBuilder_threads_IncludeSubdomains_from_config_into_the_sweep()
+    {
+        const string html = "<html><body><h1>h</h1>" +
+                            "<a href='https://blog.example.com/x'>sub</a>" +
+                            "<a href='https://example.com/a'>same</a></body></html>";
+
+        var off = await BuildSweepSpider(SweepConfig(includeSubdomains: false), html).CrawlAsync(StartJob());
+        var sweptOff = Assert.IsType<CrawlOutcome.Swept>(off.Outcome);
+        Assert.Equal(new[] { "https://example.com/a" }, sweptOff.Next.Select(j => j.Url));
+
+        var on = await BuildSweepSpider(SweepConfig(includeSubdomains: true), html).CrawlAsync(StartJob());
+        var sweptOn = Assert.IsType<CrawlOutcome.Swept>(on.Outcome);
+        Assert.Equal(new[] { "https://blog.example.com/x", "https://example.com/a" },
+            sweptOn.Next.Select(j => j.Url));
+    }
+
+    [Fact]
+    public async Task SpiderBuilder_threads_MaxDepth_from_config()
+    {
+        const string html = "<html><body><h1>h</h1><a href='https://example.com/a'>x</a></body></html>";
+        var spider = BuildSweepSpider(SweepConfig(includeSubdomains: false, maxDepth: 1), html);
+
+        // Depth 0 (the start page) follows.
+        var d0 = Assert.IsType<CrawlOutcome.Swept>((await spider.CrawlAsync(StartJob())).Outcome);
+        Assert.NotEmpty(d0.Next);
+
+        // Depth 1 (one backlink) is at the cap: extract only.
+        var atCap = new Job(
+            "https://example.com/b",
+            ImmutableQueue.CreateRange(new[] { LinkPathSelector.Sweep() }),
+            ImmutableQueue.CreateRange(new[] { "https://example.com/" }));
+        var d1 = Assert.IsType<CrawlOutcome.Swept>((await spider.CrawlAsync(atCap)).Outcome);
+        Assert.Empty(d1.Next);
+    }
+}

--- a/WebReaper/Builders/ConfigBuilder.cs
+++ b/WebReaper/Builders/ConfigBuilder.cs
@@ -31,6 +31,10 @@ internal class ConfigBuilder
 
     private bool _stopWhenDrained;
 
+    // ADR-0081: Site-sweep on-domain + depth policy, set by Sweep(options).
+    private bool _includeSubdomains;
+    private int _maxDepth = int.MaxValue;
+
     private Schema? _schema;
 
     private PageType _startPageType;
@@ -192,6 +196,51 @@ internal class ConfigBuilder
     }
 
     /// <summary>
+    /// Append a Site-sweep step (ADR-0081): a recursive on-domain
+    /// <see cref="LinkPathSelector"/> that makes the Crawl step return the
+    /// <c>Swept</c> arm: extract each page AND follow its on-domain links,
+    /// child Jobs retaining this selector so the whole site is swept. The
+    /// chain-level sibling to <see cref="Follow"/> / <see cref="Paginate"/>.
+    /// The on-domain boundary (<see cref="SweepOptions.IncludeSubdomains"/>)
+    /// and depth cap (<see cref="SweepOptions.MaxDepth"/>) land on the
+    /// <see cref="ScraperConfig"/>; sitemap seeding
+    /// (<see cref="SweepOptions.Sitemap"/>) is handled by
+    /// <see cref="ScraperEngineBuilder.BuildAsync"/>.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// <see cref="SweepOptions.LinkSelector"/> is empty/whitespace, enforced
+    /// at <see cref="LinkPathSelector"/> construction (ADR-0030).</exception>
+    public ConfigBuilder Sweep(SweepOptions options)
+    {
+        _linkPathSelectors.Add(LinkPathSelector.Sweep(options.LinkSelector));
+        _includeSubdomains = options.IncludeSubdomains;
+        _maxDepth = options.MaxDepth ?? int.MaxValue;
+        return this;
+    }
+
+    /// <summary>
+    /// The first start URL, or null if none was set; the seed
+    /// <see cref="ScraperEngineBuilder.BuildAsync"/> hands the Site mapper for
+    /// ADR-0081 sitemap seeding.
+    /// </summary>
+    internal string? FirstStartUrl => _startUrls.FirstOrDefault();
+
+    /// <summary>
+    /// Union additional seed URLs into the start set (ADR-0081 sitemap
+    /// seeding), preserving the existing seeds first and dropping duplicates.
+    /// The start <see cref="PageType"/> is unchanged.
+    /// </summary>
+    internal ConfigBuilder AddStartUrls(IEnumerable<string> urls)
+    {
+        var seen = new HashSet<string>(_startUrls, StringComparer.Ordinal);
+        var unioned = new List<string>(_startUrls);
+        foreach (var u in urls)
+            if (seen.Add(u)) unioned.Add(u);
+        _startUrls = unioned;
+        return this;
+    }
+
+    /// <summary>
     /// The extraction <see cref="Schema"/> applied to target pages (the
     /// shared fold grammar, ADR-0002). Supplied through the staged entry,
     /// <see cref="ICrawlSeed.Extract"/>.
@@ -224,6 +273,8 @@ internal class ConfigBuilder
             _startPageType,
             _pageActions,
             _headless,
-            _stopWhenDrained);
+            _stopWhenDrained,
+            _includeSubdomains,
+            _maxDepth);
     }
 }

--- a/WebReaper/Builders/ScraperEngineBuilder.cs
+++ b/WebReaper/Builders/ScraperEngineBuilder.cs
@@ -56,6 +56,13 @@ public class ScraperEngineBuilder
     private ConfigBuilder ConfigBuilder { get; } = new();
     private SpiderBuilder SpiderBuilder { get; } = new();
 
+    // ADR-0081: Site-sweep sitemap seeding. _sweepSitemap is set true by
+    // .Sweep(options) when SweepOptions.Sitemap is on; BuildAsync then unions
+    // the Site mapper's discovered URLs into the start set. The mapper is
+    // injectable for offline tests (WithSiteMapper).
+    private bool _sweepSitemap;
+    private ISiteMapper _siteMapper = new SiteMapper();
+
     // ADR-0072: the shared extractor + validator + wrapping-logic module
     // both this builder and AgentEngineBuilder embed. Logger is read via
     // a getter lambda so WithLogger updates after the field-initializer
@@ -755,6 +762,51 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    /// <summary>
+    /// Append a Site-sweep step (ADR-0081): a recursive on-domain crawl that
+    /// extracts every page AND follows its on-domain links until the frontier
+    /// saturates, the whole-site sibling of <see cref="Follow"/> /
+    /// <see cref="Paginate"/>, surfaced on the CLI as <c>webreaper crawl</c>.
+    /// Compose it with a seed terminal:
+    /// <code>
+    /// var engine = await ScraperEngineBuilder
+    ///     .Crawl("https://example.com")
+    ///     .AsMarkdown()          // or .Extract(schema)
+    ///     .Sweep()
+    ///     .StopWhenAllLinksProcessed()
+    ///     .WriteToConsole()
+    ///     .BuildAsync();
+    /// </code>
+    /// <paramref name="options"/> tune the link selector, the on-domain
+    /// boundary, the depth cap, and sitemap seeding (all default to the
+    /// "crawl this site" behaviour). The page cap is the existing
+    /// <see cref="PageCrawlLimit"/>. With <see cref="SweepOptions.Sitemap"/>
+    /// on (the default), <see cref="BuildAsync"/> seeds the frontier from the
+    /// Site mapper's discovered URLs too.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// <see cref="SweepOptions.LinkSelector"/> is empty/whitespace
+    /// (ADR-0030).</exception>
+    public ScraperEngineBuilder Sweep(SweepOptions? options = null)
+    {
+        options ??= new SweepOptions();
+        ConfigBuilder.Sweep(options);
+        _sweepSitemap = options.Sitemap;
+        return this;
+    }
+
+    /// <summary>
+    /// Replace the <see cref="ISiteMapper"/> used for ADR-0081 sweep sitemap
+    /// seeding (default <see cref="SiteMapper"/>). Internal; a test seam so
+    /// the seeding path can run offline; consumers tune discovery through
+    /// <see cref="SweepOptions.Sitemap"/>.
+    /// </summary>
+    internal ScraperEngineBuilder WithSiteMapper(ISiteMapper siteMapper)
+    {
+        _siteMapper = siteMapper;
+        return this;
+    }
+
     /// <summary>Use a custom <see cref="IScheduler"/> (e.g. a distributed
     /// queue) instead of the in-memory default.</summary>
     public ScraperEngineBuilder WithScheduler(IScheduler scheduler)
@@ -948,6 +1000,18 @@ public class ScraperEngineBuilder
     /// </summary>
     public async Task<ScraperEngine> BuildAsync()
     {
+        // ADR-0081: sweep sitemap seeding (default-on). Union the Site mapper's
+        // discovered URLs into the start set before the config is built, so a
+        // site with a sitemap but sparse internal linking is still covered. The
+        // union dedups against followed links at runtime through the shared
+        // Visited-link tracker. Best-effort: the mapper is itself best-effort
+        // (a 404 / malformed XML yields a partial or empty list, ADR-0042).
+        if (_sweepSitemap && ConfigBuilder.FirstStartUrl is { } seedUrl)
+        {
+            var discovered = await _siteMapper.MapAsync(seedUrl);
+            ConfigBuilder.AddStartUrls(discovered);
+        }
+
         // ADR-0034: build the immutable config, hand it to the SpiderBuilder
         // (the shell takes its Headless + ParsingScheme from it), then persist
         // it. The engine still reads ConfigStorage itself in RunAsync.

--- a/WebReaper/Builders/SpiderBuilder.cs
+++ b/WebReaper/Builders/SpiderBuilder.cs
@@ -311,7 +311,12 @@ internal class SpiderBuilder
 
         CookieStorage.AddAsync(Cookies);
 
-        var crawlStep = new CrawlStep(ContentExtractor);
+        // ADR-0081: derive the Sweep on-domain + depth policy from the config
+        // (anchor host from the start URL) and thread it into the step. Covers
+        // both Crawl drivers: the engine path and the distributed worker both
+        // build through here. Null on a non-sweep crawl, so the recursive
+        // branch never fires.
+        var crawlStep = new CrawlStep(ContentExtractor, BuildSweepPolicy(Config!));
 
         // Config is null until WithConfig is called; ADR-0034 makes it
         // required by the time Build runs (the outer ScraperEngineBuilder
@@ -324,5 +329,24 @@ internal class SpiderBuilder
             Config.ParsingScheme);
 
         return spider;
+    }
+
+    // ADR-0081: the Sweep policy is built only when the chain carries a
+    // recursive selector. The anchor host is the start URL's host, fixed for
+    // the crawl, so the on-domain boundary stays correct as pages are reached
+    // through www / subdomains (a per-page host would break --include-subdomains).
+    // No parseable start host ⇒ null, and the step falls back to each page's
+    // own host.
+    private static SweepPolicy? BuildSweepPolicy(ScraperConfig config)
+    {
+        if (!config.LinkPathSelectors.Any(s => s.Recursive)) return null;
+
+        var anchorHost = config.StartUrls
+            .Select(u => Uri.TryCreate(u, UriKind.Absolute, out var uri) ? uri.Host : null)
+            .FirstOrDefault(h => !string.IsNullOrEmpty(h));
+
+        return anchorHost is null
+            ? null
+            : new SweepPolicy(anchorHost, config.IncludeSubdomains, config.MaxDepth);
     }
 }

--- a/WebReaper/Builders/SweepOptions.cs
+++ b/WebReaper/Builders/SweepOptions.cs
@@ -1,0 +1,34 @@
+namespace WebReaper.Builders;
+
+/// <summary>
+/// Options for a Site sweep (ADR-0081): the whole-site recursive crawl
+/// appended by <see cref="ScraperEngineBuilder.Sweep"/>. All optional; the
+/// defaults are the firecrawl-shaped "crawl this site" behaviour (every anchor,
+/// same host plus <c>www</c>, unbounded depth, sitemap-seeded). The page cap is
+/// the existing <see cref="ScraperEngineBuilder.PageCrawlLimit"/> (it maps onto
+/// the Stop rule's cutoff, ADR-0032), not a field here.
+/// </summary>
+public sealed record SweepOptions
+{
+    /// <summary>The links to sweep; defaults to <c>a[href]</c> (every anchor).
+    /// Restrict it (for example <c>a[href^='/blog/']</c>) to sweep one
+    /// section.</summary>
+    public string LinkSelector { get; init; } = "a[href]";
+
+    /// <summary>Widen the on-domain boundary from same-host-plus-<c>www</c> to a
+    /// suffix match on the apex host, a documented heuristic, not
+    /// public-suffix-list-correct (ADR-0081). Default <c>false</c>.</summary>
+    public bool IncludeSubdomains { get; init; }
+
+    /// <summary>The maximum hop distance from a start URL the sweep follows
+    /// links from (a page's parent-backlink-chain length). <c>null</c> is
+    /// unbounded (the default).</summary>
+    public int? MaxDepth { get; init; }
+
+    /// <summary>Also seed the sweep frontier from the Site mapper's discovered
+    /// sitemap URLs (ADR-0042), so a site with a sitemap but sparse internal
+    /// linking is still covered. Default <c>true</c>; the two discovery modes
+    /// union through the same Visited-link tracker, so seeds and followed links
+    /// dedup against each other.</summary>
+    public bool Sitemap { get; init; } = true;
+}

--- a/WebReaper/Core/Crawling/Concrete/CrawlStep.cs
+++ b/WebReaper/Core/Crawling/Concrete/CrawlStep.cs
@@ -13,7 +13,10 @@ namespace WebReaper.Core.Crawling.Concrete;
 /// The crawl-step decision extracted from the old Spider.CrawlAsync. Holds the
 /// page-category dispatch, the selector-chain advance/retain rule, link
 /// extraction, content extraction, and child-Job provenance threading behind
-/// one pure method. Content extraction is the injected
+/// one pure method. ADR-0081 adds the Sweep page: a recursive head selector
+/// returns the <c>Swept</c> arm: extract this page AND enqueue its on-domain
+/// child Jobs (the <see cref="SweepDomainFilter"/> boundary + depth cap from
+/// the injected <see cref="SweepPolicy"/>), each retaining the sweep selector. Content extraction is the injected
 /// <see cref="IContentExtractor"/> seam (ADR-0039) — never surfaced on
 /// <see cref="ICrawlStep"/>; link extraction is the concrete
 /// <see cref="LinkExtractor"/> function, called directly (ADR-0036 — one
@@ -24,10 +27,14 @@ namespace WebReaper.Core.Crawling.Concrete;
 internal sealed class CrawlStep : ICrawlStep
 {
     private readonly IContentExtractor _extractor;
+    // ADR-0081: the crawl-global on-domain + depth policy for the Sweep page
+    // branch. Null on a non-sweep crawl (the recursive branch never fires).
+    private readonly SweepPolicy? _sweepPolicy;
 
-    public CrawlStep(IContentExtractor extractor)
+    public CrawlStep(IContentExtractor extractor, SweepPolicy? sweepPolicy = null)
     {
         _extractor = extractor;
+        _sweepPolicy = sweepPolicy;
     }
 
     public async ValueTask<CrawlOutcome> StepAsync(Job job, string document, Schema? schema)
@@ -42,6 +49,41 @@ internal sealed class CrawlStep : ICrawlStep
         }
 
         var baseUrl = new Uri(job.Url);
+
+        // Sweep page (ADR-0081): a recursive head selector ⇒ the one arm that
+        // both extracts AND follows. Parse this page like a target page, then
+        // enqueue its on-domain child Jobs which RETAIN the sweep selector (the
+        // chain is left unchanged, never advanced), so the traversal
+        // perpetuates until the Visited-link tracker frontier saturates or the
+        // page-cap cutoff trips. The on-domain boundary and depth cap come from
+        // the crawl-global SweepPolicy; with none, the boundary anchors on this
+        // page's own host (transitively the start host on a single-host sweep)
+        // and depth is unbounded.
+        var head = chain.Peek();
+        if (head.Recursive)
+        {
+            var record = await _extractor.ExtractAsync(document, schema);
+            var sweptData = new ParsedData(job.Url, record);
+
+            // Depth gate: the Job's parent-backlink-chain length IS its hop
+            // distance from a start URL. At the cap, extract but follow nothing.
+            var depth = job.ParentBacklinks.Count();
+            var maxDepth = _sweepPolicy?.MaxDepth ?? int.MaxValue;
+            if (depth >= maxDepth)
+                return CrawlOutcome.Sweep(sweptData, ImmutableArray<Job>.Empty);
+
+            var anchorHost = _sweepPolicy?.AnchorHost ?? baseUrl.Host;
+            var includeSubdomains = _sweepPolicy?.IncludeSubdomains ?? false;
+
+            var sweptLinks = await LinkExtractor.GetLinksAsync(baseUrl, document, head.Selector);
+            var onDomain = sweptLinks.Where(
+                link => SweepDomainFilter.IsOnDomain(link, anchorHost, includeSubdomains));
+            // childChain = chain (unchanged) ⇒ RETAIN the recursive selector.
+            var children = CreateJobs(job, head, chain, onDomain);
+
+            return CrawlOutcome.Sweep(sweptData, children);
+        }
+
         var advanced = chain.Dequeue(out var currentSelector);
 
         var itemLinks = await LinkExtractor.GetLinksAsync(baseUrl, document, currentSelector.Selector);

--- a/WebReaper/Core/Crawling/Concrete/SweepDomainFilter.cs
+++ b/WebReaper/Core/Crawling/Concrete/SweepDomainFilter.cs
@@ -1,0 +1,41 @@
+namespace WebReaper.Core.Crawling.Concrete;
+
+/// <summary>
+/// The on-domain boundary a Site sweep (ADR-0081) follows when producing a
+/// Sweep page's child Jobs. Default mode keeps links whose host equals the
+/// anchor (start) host, treating a leading <c>www.</c> as the apex;
+/// <c>includeSubdomains</c> widens to a suffix match on the apex host, a
+/// documented heuristic, not public-suffix-list-correct (ADR-0081 rejected the
+/// eTLD+1 dependency, against the ADR-0009 dependency-light-core bias). The
+/// same-host check is the recursive sibling of the Site mapper's
+/// <c>SameHost</c> (ADR-0042); the leading dot on the suffix match makes the
+/// boundary a real DNS-label boundary, so <c>notexample.com</c> and
+/// <c>example.com.evil.com</c> never count as on-domain for <c>example.com</c>.
+/// </summary>
+internal static class SweepDomainFilter
+{
+    /// <summary>
+    /// True when <paramref name="url"/>'s host is on-domain for
+    /// <paramref name="anchorHost"/>. A non-absolute or unparseable
+    /// <paramref name="url"/> is off-domain (skipped, never thrown), mirroring
+    /// the link-extractor's skip-the-unusable-href posture.
+    /// </summary>
+    public static bool IsOnDomain(string url, string anchorHost, bool includeSubdomains)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+
+        var linkHost = uri.Host;
+        var apex = StripWww(anchorHost);
+
+        if (includeSubdomains)
+        {
+            return string.Equals(linkHost, apex, StringComparison.OrdinalIgnoreCase)
+                || linkHost.EndsWith("." + apex, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return string.Equals(StripWww(linkHost), apex, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string StripWww(string host) =>
+        host.StartsWith("www.", StringComparison.OrdinalIgnoreCase) ? host[4..] : host;
+}

--- a/WebReaper/Core/Crawling/Concrete/SweepPolicy.cs
+++ b/WebReaper/Core/Crawling/Concrete/SweepPolicy.cs
@@ -1,0 +1,24 @@
+namespace WebReaper.Core.Crawling.Concrete;
+
+/// <summary>
+/// The crawl-global on-domain + depth policy a Site sweep (ADR-0081) applies
+/// when a <see cref="CrawlStep"/> produces a Sweep page's child Jobs. Threaded
+/// into the step at construction from the
+/// <see cref="WebReaper.Domain.ScraperConfig"/>. The
+/// <see cref="AnchorHost"/> is derived from the start URL, so it is fixed for
+/// the whole crawl (the start host, not the per-page host, which is what makes
+/// <see cref="IncludeSubdomains"/> correct as pages are reached through
+/// <c>www</c> and subdomains). Null on a non-sweep crawl, in which case the
+/// step's recursive branch never fires; when null but a recursive selector is
+/// somehow present the step falls back to the page's own host, no subdomains,
+/// and unbounded depth.
+/// </summary>
+/// <param name="AnchorHost">The start host the on-domain filter anchors on
+/// (same-host-plus-<c>www</c> by default, apex suffix with subdomains).</param>
+/// <param name="IncludeSubdomains">Widen the on-domain match to a suffix match
+/// on the apex host (a documented heuristic, not public-suffix-list-correct;
+/// ADR-0081 rejected the eTLD+1 dependency).</param>
+/// <param name="MaxDepth">The maximum hop distance from a start URL a Sweep
+/// page may follow links from (the Job's parent-backlink-chain length);
+/// <see cref="int.MaxValue"/> is unbounded.</param>
+internal sealed record SweepPolicy(string AnchorHost, bool IncludeSubdomains, int MaxDepth);

--- a/WebReaper/Core/Crawling/CrawlOutcome.cs
+++ b/WebReaper/Core/Crawling/CrawlOutcome.cs
@@ -6,12 +6,16 @@ namespace WebReaper.Core.Crawling;
 
 /// <summary>
 /// The result of a <see cref="Abstract.ICrawlStep"/>: exactly one of a target
-/// page's <see cref="ParsedData"/>, a transit page's followed Jobs, or a
-/// paginated page's item + next-page Jobs. Never more than one arm; the arm is
-/// a total function of the Job's selector chain.
+/// page's <see cref="ParsedData"/>, a transit page's followed Jobs, a
+/// paginated page's item + next-page Jobs, or a <b>Sweep page</b>'s
+/// <see cref="ParsedData"/> together with its on-domain child Jobs (ADR-0081).
+/// Never more than one arm; the arm is a total function of the Job's selector
+/// chain.
 ///
 /// Closed hierarchy — construct only via the factory members; the union is not
-/// extensible. See docs/adr/0001-crawl-outcome-closed-sum.md.
+/// extensible without adding a genuinely new Page category. See
+/// docs/adr/0001-crawl-outcome-closed-sum.md and
+/// docs/adr/0081-site-sweep-whole-site-crawl.md.
 /// </summary>
 public abstract record CrawlOutcome
 {
@@ -41,6 +45,20 @@ public abstract record CrawlOutcome
         ImmutableArray<Job> Items,
         ImmutableArray<Job> NextPages) : CrawlOutcome;
 
+    /// <summary>Sweep page (ADR-0081): the one arm that both extracts
+    /// <em>and</em> follows. <see cref="Data"/> is this page's parsed record
+    /// (emitted like a <see cref="Parsed"/> target), and <see cref="Next"/>
+    /// are its on-domain child Jobs that <b>retain</b> the recursive sweep
+    /// selector, so the traversal perpetuates until the Visited-link tracker
+    /// frontier saturates or the page-cap cutoff trips. Empty <see cref="Next"/>
+    /// when no on-domain link matched or the depth cap was reached.</summary>
+    /// <param name="Data">The scraped record for this Sweep page.</param>
+    /// <param name="Next">The on-domain child Jobs, each retaining the
+    /// recursive sweep selector.</param>
+    public sealed record Swept(
+        ParsedData Data,
+        ImmutableArray<Job> Next) : CrawlOutcome;
+
     /// <summary>The target-page arm: the page was parsed into
     /// <paramref name="data"/>.</summary>
     public static CrawlOutcome Target(ParsedData data) => new Parsed(data);
@@ -55,14 +73,23 @@ public abstract record CrawlOutcome
         ImmutableArray<Job> items,
         ImmutableArray<Job> nextPages) => new Paginated(items, nextPages);
 
+    /// <summary>The Sweep-page arm (ADR-0081): <paramref name="data"/> is this
+    /// page's parsed record and <paramref name="next"/> its on-domain child
+    /// Jobs (which retain the recursive sweep selector).</summary>
+    public static CrawlOutcome Sweep(
+        ParsedData data,
+        ImmutableArray<Job> next) => new Swept(data, next);
+
     /// <summary>All candidate next Jobs in deterministic order:
     /// <see cref="Followed.Next"/>, or <see cref="Paginated.Items"/> then
-    /// <see cref="Paginated.NextPages"/>, or empty for <see cref="Parsed"/>.
-    /// Candidates only — visited-link filtering is the caller's job.</summary>
+    /// <see cref="Paginated.NextPages"/>, or <see cref="Swept.Next"/>, or empty
+    /// for <see cref="Parsed"/>. Candidates only; visited-link filtering is
+    /// the caller's job.</summary>
     public ImmutableArray<Job> NextJobs => this switch
     {
         Followed f => f.Next,
         Paginated p => p.Items.AddRange(p.NextPages),
+        Swept s => s.Next,
         _ => ImmutableArray<Job>.Empty
     };
 }

--- a/WebReaper/Core/ScraperEngine.cs
+++ b/WebReaper/Core/ScraperEngine.cs
@@ -244,6 +244,20 @@ public class ScraperEngine : IAsyncDisposable
                             job.ParentBacklinks.ToList(), config.ParsingScheme, token);
                         newJobs = new List<Job>();
                     }
+                    else if (report.Outcome is CrawlOutcome.Swept swept)
+                    {
+                        // ADR-0081: the Sweep page is the ONLY arm that does
+                        // both: run its record through the Post-extraction
+                        // pipeline (emit) AND enqueue its on-domain children
+                        // (follow). The children retain the recursive sweep
+                        // selector; the Visited-link tracker dedups them, which
+                        // is also what terminates the sweep when the on-domain
+                        // frontier saturates.
+                        Logger.LogInvocationCount();
+                        await _pipeline.ProcessAndEmitAsync(swept.Data, report.Document,
+                            job.ParentBacklinks.ToList(), config.ParsingScheme, token);
+                        newJobs = swept.Next.ToList();
+                    }
                     else
                     {
                         // Children are enqueued UNFILTERED; discovery dedup is

--- a/WebReaper/Domain/ScraperConfig.cs
+++ b/WebReaper/Domain/ScraperConfig.cs
@@ -26,6 +26,14 @@ namespace WebReaper.Domain;
 /// <param name="Headless">Run the browser headless for dynamic pages.</param>
 /// <param name="StopWhenDrained">Stop once every discovered link is crawled
 /// (issue #20 / ADR-0022 in-memory latch) instead of running forever.</param>
+/// <param name="IncludeSubdomains">Site sweep (ADR-0081): widen the on-domain
+/// boundary from same-host-plus-<c>www</c> to a suffix match on the apex host
+/// (a documented heuristic). Only consulted by a recursive Sweep selector;
+/// ignored otherwise.</param>
+/// <param name="MaxDepth">Site sweep (ADR-0081): the maximum hop distance from
+/// a start URL a Sweep page follows links from (the Job's parent-backlink-chain
+/// length). <see cref="int.MaxValue"/> is unbounded. Only consulted by a
+/// recursive Sweep selector.</param>
 public record ScraperConfig(
     Schema? ParsingScheme,
     ImmutableQueue<LinkPathSelector> LinkPathSelectors,
@@ -35,5 +43,7 @@ public record ScraperConfig(
     PageType StartPageType = PageType.Static,
     List<PageAction>? PageActions = null,
     bool Headless = true,
-    bool StopWhenDrained = false
+    bool StopWhenDrained = false,
+    bool IncludeSubdomains = false,
+    int MaxDepth = int.MaxValue
 );

--- a/WebReaper/Domain/Selectors/LinkPathSelector.cs
+++ b/WebReaper/Domain/Selectors/LinkPathSelector.cs
@@ -48,6 +48,20 @@ public record LinkPathSelector(
     public List<PageAction>? PageActions { get; init; } =
         ActionsMatchTransport(PageActions, PageType);
 
+    /// <summary>
+    /// True when this is a recursive Site-sweep step (ADR-0081): the Crawl
+    /// step returns the <c>Swept</c> arm: extract this page <em>and</em>
+    /// follow its on-domain links, the child Jobs <b>retaining</b> this
+    /// selector so the traversal perpetuates until the Visited-link tracker
+    /// frontier saturates. Set only by <see cref="Sweep"/>; false for every
+    /// other construction path, so the advance/retain behaviour of
+    /// <see cref="Follow"/> / <see cref="Paginate"/> is unchanged. The
+    /// on-domain boundary and the page/depth caps are crawl-global
+    /// (<see cref="WebReaper.Domain.ScraperConfig"/>), not part of this
+    /// per-step intent.
+    /// </summary>
+    public bool Recursive { get; init; }
+
     /// <summary>True when a <see cref="PaginationSelector"/> is set — this
     /// step paginates rather than plain-follows.</summary>
     public bool HasPagination => PaginationSelector != null;
@@ -99,6 +113,32 @@ public record LinkPathSelector(
         ArgumentException.ThrowIfNullOrWhiteSpace(paginationSelector);
         return new(itemSelector, paginationSelector, pageType, actions);
     }
+
+    /// <summary>
+    /// Site-sweep step (ADR-0081): from the current page, extract it
+    /// <em>and</em> recursively follow its on-domain links matching
+    /// <paramref name="selector"/>, the child Jobs retaining this selector so
+    /// the whole site is swept. The named factory for the recursive
+    /// intent-shape, the third sibling beside <see cref="Follow"/> and
+    /// <see cref="Paginate"/>. The on-domain boundary (same host plus
+    /// <c>www</c>, widened by <c>--include-subdomains</c>) and the page/depth
+    /// caps are crawl-global (<see cref="WebReaper.Domain.ScraperConfig"/>),
+    /// not part of this per-step intent.
+    /// </summary>
+    /// <param name="selector">The links to sweep; defaults to <c>a[href]</c>
+    /// (every anchor). Restrict it (for example <c>a[href^='/blog/']</c>) to
+    /// sweep one section. Non-empty when supplied.</param>
+    /// <param name="pageType">How the reached pages load.</param>
+    /// <param name="actions">Browser actions for the reached pages; allowed
+    /// only with <see cref="PageType.Dynamic"/>.</param>
+    /// <exception cref="ArgumentException"><paramref name="selector"/> is
+    /// empty/whitespace, or <paramref name="actions"/> is non-empty with
+    /// <see cref="PageType.Static"/>.</exception>
+    public static LinkPathSelector Sweep(
+        string selector = "a[href]",
+        PageType pageType = PageType.Static,
+        List<PageAction>? actions = null) =>
+        new(selector, null, pageType, actions) { Recursive = true };
 
     // ADR-0030: the grammar is enforced at the construction site. A property
     // initializer over a primary-ctor parameter is the idiomatic positional-

--- a/WebReaper/Serialization/Converters/ImmutableQueueJsonConverters.cs
+++ b/WebReaper/Serialization/Converters/ImmutableQueueJsonConverters.cs
@@ -44,6 +44,10 @@ internal sealed class SelectorChainJsonConverter : JsonConverter<ImmutableQueue<
         w.WriteString("selector", s.Selector);
         if (s.PaginationSelector is not null) w.WriteString("paginationSelector", s.PaginationSelector);
         w.WriteString("pageType", s.PageType.ToString());
+        // ADR-0081: the recursive Site-sweep marker. Written only when set, so
+        // an ordinary follow/paginate step's JSON is unchanged and a pre-0081
+        // persisted Job still round-trips (the field reads back false).
+        if (s.Recursive) w.WriteBoolean("recursive", true);
         if (s.PageActions is { } acts)
         {
             w.WritePropertyName("pageActions");
@@ -61,6 +65,7 @@ internal sealed class SelectorChainJsonConverter : JsonConverter<ImmutableQueue<
         string? pag = null;
         PageType pt = PageType.Static;
         List<PageAction>? acts = null;
+        bool recursive = false;
         while (r.Read() && r.TokenType != JsonTokenType.EndObject)
         {
             var prop = r.GetString();
@@ -72,6 +77,7 @@ internal sealed class SelectorChainJsonConverter : JsonConverter<ImmutableQueue<
                 case "pageType":
                     pt = r.GetString() == "Dynamic" ? PageType.Dynamic : PageType.Static;
                     break;
+                case "recursive": recursive = r.GetBoolean(); break;
                 case "pageActions":
                     acts = new List<PageAction>();
                     while (r.Read() && r.TokenType != JsonTokenType.EndArray)
@@ -88,7 +94,7 @@ internal sealed class SelectorChainJsonConverter : JsonConverter<ImmutableQueue<
         if (string.IsNullOrWhiteSpace(sel))
             throw new JsonException("missing or empty 'selector' on a LinkPathSelector entry");
 
-        return new LinkPathSelector(sel, pag, pt, acts);
+        return new LinkPathSelector(sel, pag, pt, acts) { Recursive = recursive };
     }
 }
 


### PR DESCRIPTION
## What

Implements **ADR-0081 (Site sweep)**: a one-command whole-site recursive crawl. The design was locked and merged ([#163](https://github.com/pavlovtech/WebReaper/pull/163)); this is the implementation, shipped as **10.2.0** (additive minor).

```bash
webreaper crawl https://example.com > pages.jsonl
```

```csharp
await ScraperEngineBuilder
    .Crawl("https://example.com")
    .AsMarkdown()            // or .Extract(schema)
    .Sweep()
    .StopWhenAllLinksProcessed()
    .WriteToConsole()
    .BuildAsync();
```

## How

A **Sweep page** is the first Page category that BOTH extracts and follows. A recursive `LinkPathSelector.Sweep(...)` selector marks it; the Crawl step returns a new fourth `CrawlOutcome` arm, `Swept` (the page's `ParsedData` plus its on-domain child Jobs); children **retain** the sweep selector so the traversal perpetuates; the existing **Visited-link tracker** dedups and terminates it, and the **Stop rule** page-limit cutoff bounds it. The driver, latch, Stop rule, and Sink fan-out are reused unchanged. It is the small local extension ADR-0001 and ADR-0030 anticipated, not a new engine.

- **On-domain by default** (host + `www`); `--include-subdomains` widens to an apex suffix match (a documented heuristic, dependency-free).
- **Sitemap seeding default-on** (`--no-sitemap` opts out), unioned through the same Visited-link tracker.
- **Bounds**: `--max-pages` (default 1000) reuses the Stop-rule cutoff; `--max-depth` (default unlimited) reads the Job backlink-chain length.
- The recursive marker **round-trips** through the selector-chain codec, so durable/distributed crawls resume a sweep as a sweep. The distributed-driver example (`WebReaper.AzureFuncs`) gains the `Swept` case, and a `CrawlOutcome` arm census guards every consumer.

## CLI

`webreaper crawl <url>` with `--schema` / `--output` / `--max-pages` / `--max-depth` / `--include-subdomains` / `--no-sitemap`. HTTP-only and AOT-clean (no browser transport baked in; for JS-rendered or bot-protected sites, `scrape --browser` is the path). `Program`, `Help`, and the bundled Agent Skill document it.

## Tests (offline, TDD)

The `Swept` arm + census, the Crawl-step branch, the `Sweep` grammar, on-domain filtering (host / www / subdomains / dot-boundary), **termination on a multi-page cyclic fixture**, the JSON-codec round-trip (plus an AOT-smoke round-trip), config-to-CrawlStep policy threading through a real Spider, a CLI parse test, and a **crawl end-to-end over the local fixture site** (real CLI binary, proves multi-page sweep + termination).

Guardrails (mirroring `release.yml`): `dotnet build -c Release` clean (0 warnings); `UnitTests` 494, `Cli.Tests` 84, `Sqlite` 10, `Generators` 7, `AI` 274 all pass; AOT publish smoke passes.

## Release

This is **10.2.0** (`Directory.Build.props` bumped; single `## 10.2.0` CHANGELOG heading). It also folds in the unreleased 10.1.1 fixes: [#161](https://github.com/pavlovtech/WebReaper/pull/161) (warnings cleanup) and [#162](https://github.com/pavlovtech/WebReaper/pull/162) (bare-host URL). Merge, the `v10.2.0` tag, and the `nuget-release` gate stay manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)