### PR TITLE
feat(cli): hint at --browser/--stealth when a scrape returns zero records

### DIFF
--- a/WebReaper.Cli/Commands/ScrapeCommand.cs
+++ b/WebReaper.Cli/Commands/ScrapeCommand.cs
@@ -32,6 +32,7 @@ internal static class ScrapeCommand
         // No escalation path on pure-HTTP scrapes.
         if (!ctx.Browser)
         {
+            WriteEmptyHint(ctx, first.Records.Count);
             await RecordOutput.WriteAsync(first.Records, ctx.Output);
             return 0;
         }
@@ -46,6 +47,7 @@ internal static class ScrapeCommand
 
         if (!verdict.LikelyBlocked)
         {
+            WriteEmptyHint(ctx, first.Records.Count);
             await RecordOutput.WriteAsync(first.Records, ctx.Output);
             return 0;
         }
@@ -117,6 +119,19 @@ internal static class ScrapeCommand
 
         await RecordOutput.WriteAsync(retry.Records, ctx.Output);
         return 0;
+    }
+
+    // ----- empty-result hint -----
+
+    // Cheap-win companion to the (currently unreachable) bot-check escalation:
+    // when a scrape returns no records, point the user at the next transport to
+    // try instead of silently shipping empty stdout. The decision is the pure
+    // EmptyResultAdvisor; this only writes the line to stderr.
+    private static void WriteEmptyHint(ScrapeContext ctx, int recordCount)
+    {
+        var hint = EmptyResultAdvisor.Advise(ctx.Browser, ctx.Stealth, recordCount);
+        if (hint is not null)
+            Console.Error.WriteLine($"⚠  {hint}");
     }
 
     // ----- single scrape attempt -----

--- a/WebReaper.Cli/Stealth/EmptyResultAdvisor.cs
+++ b/WebReaper.Cli/Stealth/EmptyResultAdvisor.cs
@@ -1,0 +1,56 @@
+namespace WebReaper.Cli.Stealth;
+
+/// <summary>
+/// A best-effort hint emitted when a <c>webreaper scrape</c> attempt returns
+/// no records. Pure function over <c>(browser, stealth, recordCount)</c> with
+/// no IO and no global state, so it is unit-testable without a real scrape.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the cheap-win companion to <see cref="BotCheckDetector"/>. The
+/// detector decides whether to auto-escalate to a stealth backend; this
+/// advisor only points the user at the next thing to try when a scrape comes
+/// back empty. It never escalates and never changes the exit code. It writes a
+/// single stderr line so an empty result is not silently indistinguishable
+/// from "the page genuinely had nothing".
+/// </para>
+/// <para>
+/// Empty-but-fine is a real state (a <c>--schema</c> scrape whose selectors
+/// legitimately match nothing), so the hint is phrased as a possibility, not a
+/// verdict. The cost asymmetry favours the hint: one extra stderr line the
+/// user ignores, versus an unexplained empty stdout.
+/// </para>
+/// <para>
+/// The <paramref name="stealth"/> branch deliberately does not claim a stealth
+/// backend ran. In v10.x the <c>--stealth</c> flag is not yet wired into the
+/// first scrape attempt (the escalation retry that consumes it is currently
+/// unreachable), so the advisor only avoids looping a <c>--stealth</c> user
+/// back to the same flag.
+/// </para>
+/// </remarks>
+internal static class EmptyResultAdvisor
+{
+    /// <summary>Returns a one-line hint for an empty scrape, or <c>null</c>
+    /// when no hint applies (records were produced).</summary>
+    /// <param name="browser">Whether the attempt used a browser transport.</param>
+    /// <param name="stealth">Whether <c>--stealth</c> was requested.</param>
+    /// <param name="recordCount">How many records the scrape emitted.</param>
+    public static string? Advise(bool browser, bool stealth, int recordCount)
+    {
+        if (recordCount > 0)
+            return null;
+
+        if (!browser)
+            return "0 records extracted. The page may be JavaScript-rendered or "
+                 + "blocking plain HTTP requests; retry with --browser "
+                 + "(or --stealth for bot-protected sites).";
+
+        if (stealth)
+            // --stealth already requested; do not loop the user back to it.
+            return "0 records extracted. The site may need a captcha solver, or "
+                 + "the schema selectors may not match the page.";
+
+        return "0 records extracted. If the site uses bot protection "
+             + "(Cloudflare, DataDome, etc.), retry with --stealth.";
+    }
+}

--- a/WebReaper.Tests/WebReaper.Cli.Tests/EmptyResultAdvisorTests.cs
+++ b/WebReaper.Tests/WebReaper.Cli.Tests/EmptyResultAdvisorTests.cs
@@ -1,0 +1,56 @@
+using WebReaper.Cli.Stealth;
+
+namespace WebReaper.Cli.Tests;
+
+/// <summary>
+/// The empty-scrape hint advisor: a pure function over
+/// <c>(browser, stealth, recordCount)</c>. It never escalates; it only
+/// suggests the next transport to try when a scrape returns nothing.
+/// </summary>
+public class EmptyResultAdvisorTests
+{
+    // --- non-empty scrapes get no hint, regardless of transport ---
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void Records_present_produces_no_hint(bool browser, bool stealth)
+    {
+        Assert.Null(EmptyResultAdvisor.Advise(browser, stealth, recordCount: 3));
+    }
+
+    // --- pure-HTTP empty scrape points at --browser (and mentions --stealth) ---
+
+    [Fact]
+    public void Http_empty_suggests_browser()
+    {
+        var hint = EmptyResultAdvisor.Advise(browser: false, stealth: false, recordCount: 0);
+        Assert.NotNull(hint);
+        Assert.Contains("--browser", hint);
+        Assert.Contains("--stealth", hint);
+    }
+
+    // --- browser empty (no --stealth) points at --stealth ---
+
+    [Fact]
+    public void Browser_empty_suggests_stealth()
+    {
+        var hint = EmptyResultAdvisor.Advise(browser: true, stealth: false, recordCount: 0);
+        Assert.NotNull(hint);
+        Assert.Contains("--stealth", hint);
+    }
+
+    // --- --stealth empty does not loop the user back to --stealth ---
+
+    [Fact]
+    public void Stealth_empty_does_not_resuggest_stealth()
+    {
+        var hint = EmptyResultAdvisor.Advise(browser: true, stealth: true, recordCount: 0);
+        Assert.NotNull(hint);
+        Assert.DoesNotContain("--stealth", hint);
+        // It should still say something useful (captcha / selectors), not a
+        // generic blank line.
+        Assert.NotEmpty(hint!);
+    }
+}


### PR DESCRIPTION
## What

When `webreaper scrape <url>` returns no records, the CLI now writes a one-line stderr hint pointing at the next transport to try, instead of silently emitting empty stdout and exiting 0.

- pure HTTP, 0 records: suggest `--browser` (or `--stealth` for bot-protected sites)
- browser, 0 records: suggest `--stealth`
- `--stealth`, 0 records: captcha/selectors note (does not loop the user back to `--stealth`)

The decision lives in a new pure function, `EmptyResultAdvisor.Advise(browser, stealth, recordCount)`, unit-tested in isolation. `ScrapeCommand` calls it at the two reachable success exits.

## Why (and what this does NOT fix)

This is a **symptom-level mitigation**. While verifying the bot-check escalation I found two latent bugs, both deferred to a follow-up ADR because the real fix changes the page-load contract:

1. **The bot-check auto-escalation (ADR-0056) never fires.** Both `BotCheckDetector.Detect()` call sites in `ScrapeCommand` pass `httpStatus: null` (Signal 1 dead), and the `renderedHtml` argument (`LastHtml`) is non-null only when `records.Count > 0`, which can never satisfy Signal 2's `recordCount == 0` precondition. So `Detect()` always returns `NoSignal` in production and the entire escalation block is unreachable. The unit tests pass because they call `Detect()` directly with input combinations the wiring never produces.

2. **`--stealth` is inert.** `ctx.Stealth` is parsed but never consulted in the run flow; the only stealth code path is the unreachable retry. So `--stealth` behaves identically to `--browser` and never reaches the stealth backend. The advisor is deliberately written not to claim a stealth backend ran.

The real fix (surface the loader's HTTP status + raw rendered HTML so the detector sees the actual transport response, not extracted output) needs an `IPageLoader`/transport contract change and is ADR-worthy. That ADR is next.

## Test plan

- New `EmptyResultAdvisorTests` (6 cases): records-present yields no hint across all transports; HTTP-empty suggests `--browser`; browser-empty suggests `--stealth`; `--stealth`-empty does not re-suggest `--stealth`.
- Full-solution build green (0 errors).
- `WebReaper.Cli.Tests`: 90 passed. `WebReaper.UnitTests`: 494 passed.

## Notes

No CHANGELOG entry: `## 10.2.0` is the current unreleased section and a second `## ` heading would stack at release time. This folds into the next release notes at tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)