### PR TITLE
feat(cli): ADR-0082 self-update notifier (10.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 10.3.0: self-update notifier
+
+`scrape` / `crawl` / `map` now tell you when a newer release exists:
+
+```
+webreaper 10.4.0 is available (you have 10.3.0).
+Upgrade: brew upgrade webreaper
+(disable this check: WEBREAPER_NO_UPDATE_CHECK=1)
+```
+
+[ADR-0082](docs/adr/0082-self-update.md) Part 1. The notifier is deliberately unobtrusive and respects however you installed the CLI:
+
+- **Opt-out, interactive only.** It prints a single line to **stderr** (never stdout, so piped JSON Lines / Markdown stays clean), and only on an interactive terminal: never in a pipe, never under CI, and never when `WEBREAPER_NO_UPDATE_CHECK=1` (or `NO_UPDATE_NOTIFIER`) is set. Agents and scripts see nothing.
+- **Read-only, no telemetry.** A single `GET` to GitHub's public `releases/latest`, once per 24h (cached in `~/.webreaper/update-check.json`); no machine ID, usage, or analytics payload, so there is no first-run consent gate (the `gh` / npm model). It never blocks the command, never changes its exit code, and swallows every failure (offline, rate-limited).
+- **Channel-aware hint.** Homebrew installs are told `brew upgrade webreaper`, winget / Scoop get their equivalents, and a `curl | sh` install is pointed at the install.sh `--upgrade` one-liner.
+
+A self-replacing `webreaper update` command is deferred (ADR-0082 Part 2): Homebrew and winget already own their upgrade path, so it only benefits `curl | sh` users, and it carries package-manager-desync, Windows, and permissions complexity that the notifier does not.
+
+| File | Change |
+|---|---|
+| `WebReaper.Cli/UpdateNotifier.cs` | NEW. The notifier: pure gating / version-compare / throttle / hint helpers plus a thin, best-effort orchestration (24h cache, `releases/latest` fetch with a User-Agent and a ~1.5s timeout). AOT-clean (HttpClient + JsonDocument, no reflection). |
+| `WebReaper.Cli/Program.cs` | Fire the notifier after a successful `scrape` / `crawl` / `map`. |
+| `WebReaper.Cli/Help.cs`, `WebReaper.Cli/skill/SKILL.md`, `README.md` | Document the check and the `WEBREAPER_NO_UPDATE_CHECK` opt-out. |
+
+Semver: additive. The new opt-out stderr line is the only visible behaviour change for interactive users.
+
 ## 10.2.0: whole-site crawl (Site sweep)
 
 One command now crawls an entire site:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,7 @@
   -->
 
   <PropertyGroup>
-    <Version>10.2.0</Version>
+    <Version>10.3.0</Version>
 
     <Authors>Alex Pavlov</Authors>
     <Company>Alex Pavlov</Company>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ dotnet add package WebReaper
 
 Windows binaries are on the [GitHub Releases page](https://github.com/pavlovtech/WebReaper/releases/latest); `winget` and `Scoop` are on the v10.1 roadmap.
 
+**Updating:** `brew upgrade webreaper` (Homebrew), or re-run the install.sh line with `--upgrade` appended (`| sh -s -- --upgrade`), or `dotnet add package WebReaper` (library). When a newer release exists, `scrape` / `crawl` / `map` print a one-line upgrade hint on stderr (interactive terminals only, never in a pipe or CI); disable that check with `WEBREAPER_NO_UPDATE_CHECK=1`.
+
 ## 30-second demo
 
 ```bash

--- a/WebReaper.Cli/Help.cs
+++ b/WebReaper.Cli/Help.cs
@@ -87,6 +87,12 @@ Flags (per-command):
     --force             Overwrite an existing SKILL.md.
     --dir <path>        Target directory (default .claude/skills/webreaper).
 
+Environment:
+  WEBREAPER_NO_UPDATE_CHECK=1   Disable the once-a-day update check. By default
+                                scrape/crawl/map print an upgrade hint to stderr
+                                (interactive terminals only) when a newer
+                                release exists; never in CI or pipes.
+
 Examples:
   webreaper scrape https://example.com
   webreaper scrape https://example.com --schema schema.json

--- a/WebReaper.Cli/Program.cs
+++ b/WebReaper.Cli/Program.cs
@@ -14,7 +14,7 @@ static async Task<int> Run(string[] args)
     {
         var parsed = Args.Parse(args);
 
-        return parsed.Command switch
+        var exitCode = parsed.Command switch
         {
             "scrape" => await ScrapeCommand.RunAsync(parsed),
             "crawl" => await CrawlCommand.RunAsync(parsed),
@@ -26,6 +26,15 @@ static async Task<int> Run(string[] args)
             "help" => HelpAndExit(0),
             _ => HelpAndExit(2, $"Unknown command: '{parsed.Command}'")
         };
+
+        // ADR-0082: after a successful data command, best-effort tell an
+        // interactive user if a newer release exists (one stderr line; opt-out,
+        // TTY/CI-gated, 24h-throttled). MaybeNotifyAsync swallows every failure,
+        // so it never affects the exit code or the stdout payload.
+        if (exitCode == 0 && parsed.Command is "scrape" or "crawl" or "map")
+            await UpdateNotifier.MaybeNotifyAsync();
+
+        return exitCode;
     }
     catch (CliException ex)
     {

--- a/WebReaper.Cli/UpdateNotifier.cs
+++ b/WebReaper.Cli/UpdateNotifier.cs
@@ -1,0 +1,245 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text.Json;
+using WebReaper.Cli.Commands;
+
+namespace WebReaper.Cli;
+
+// ADR-0082 Part 1: the update notifier. After a successful data command, an
+// interactive user is told once (on stderr) that a newer release exists.
+// Opt-out, TTY/CI/env-gated, 24h-throttled, read-only (a plain GitHub
+// releases/latest GET, no telemetry payload). It never blocks the command,
+// never fails it, and never touches stdout (the payload). AOT-clean: HttpClient
+// + JsonDocument, no reflection beyond the assembly version attribute that
+// VersionCommand already reads.
+internal static class UpdateNotifier
+{
+    private const string DisableVar = "WEBREAPER_NO_UPDATE_CHECK";
+    private const string LatestUrl =
+        "https://api.github.com/repos/pavlovtech/WebReaper/releases/latest";
+    private const string InstallHint =
+        "curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh -s -- --upgrade";
+    private static readonly TimeSpan Ttl = TimeSpan.FromHours(24);
+    private static readonly TimeSpan FetchTimeout = TimeSpan.FromMilliseconds(1500);
+
+    // ---- pure logic (unit-tested) ----
+
+    // Opt-out gating: only an interactive (TTY stderr) run, not under CI, with
+    // neither disable var set, checks for updates.
+    internal static bool ShouldCheck(bool stderrIsTty, string? ciEnv, string? disableEnv, string? noNotifierEnv)
+    {
+        if (!stderrIsTty) return false;
+        if (IsTruthy(ciEnv)) return false;
+        if (!string.IsNullOrEmpty(disableEnv)) return false;
+        if (!string.IsNullOrEmpty(noNotifierEnv)) return false;
+        return true;
+    }
+
+    private static bool IsTruthy(string? v) =>
+        !string.IsNullOrEmpty(v)
+        && !v.Equals("0", StringComparison.Ordinal)
+        && !v.Equals("false", StringComparison.OrdinalIgnoreCase);
+
+    internal static bool IsStale(DateTimeOffset lastCheckUtc, DateTimeOffset nowUtc, TimeSpan ttl) =>
+        nowUtc - lastCheckUtc > ttl;
+
+    // True when latestTag is a strictly newer release than the running version.
+    // Numeric (not lexical) compare; false when either side is unparseable (a
+    // "dev" build never nags, garbage never triggers).
+    internal static bool IsNewer(string latestTag, string currentVersion) =>
+        TryParse(latestTag, out var l) && TryParse(currentVersion, out var c) && l.CompareTo(c) > 0;
+
+    // Parse "vMAJOR.MINOR.PATCH(+build)(-pre)" to a comparable tuple: strip a
+    // leading v and any +build metadata, then read the leading digit run of each
+    // of the first three dotted components. False when major has no digits.
+    private static bool TryParse(string raw, out (int Major, int Minor, int Patch) version)
+    {
+        version = default;
+        if (string.IsNullOrWhiteSpace(raw)) return false;
+        var s = raw.Trim();
+        if (s.StartsWith('v') || s.StartsWith('V')) s = s[1..];
+        var plus = s.IndexOf('+');
+        if (plus >= 0) s = s[..plus];
+
+        var parts = s.Split('.');
+        if (!TryLeadingInt(parts.ElementAtOrDefault(0), out var major)) return false;
+        TryLeadingInt(parts.ElementAtOrDefault(1), out var minor);
+        TryLeadingInt(parts.ElementAtOrDefault(2), out var patch);
+        version = (major, minor, patch);
+        return true;
+    }
+
+    private static bool TryLeadingInt(string? part, out int value)
+    {
+        value = 0;
+        if (string.IsNullOrEmpty(part)) return false;
+        var i = 0;
+        while (i < part.Length && char.IsAsciiDigit(part[i])) i++;
+        return i > 0
+            && int.TryParse(part.AsSpan(0, i), NumberStyles.None, CultureInfo.InvariantCulture, out value);
+    }
+
+    // The channel-appropriate upgrade command, from where the binary lives.
+    // Hardcoded prefix match (AOT-clean, no shelling to brew); separators
+    // normalised so Windows paths match too.
+    internal static string UpgradeHint(string? processPath)
+    {
+        var p = (processPath ?? string.Empty).Replace('\\', '/').ToLowerInvariant();
+        if (p.Contains("/cellar/") || p.Contains("/opt/homebrew/") || p.Contains("linuxbrew"))
+            return "brew upgrade webreaper";
+        if (p.Contains("/winget/"))
+            return "winget upgrade webreaper";
+        if (p.Contains("/scoop/"))
+            return "scoop update webreaper";
+        return InstallHint;
+    }
+
+    internal static string FormatMessage(string latestTag, string currentVersion, string hint) =>
+        $"\nwebreaper {Display(latestTag)} is available (you have {Display(currentVersion)}).\n" +
+        $"Upgrade: {hint}\n" +
+        $"(disable this check: {DisableVar}=1)";
+
+    // Normalise a version string for display: drop a leading v and +build.
+    private static string Display(string raw)
+    {
+        var s = raw.Trim();
+        if (s.StartsWith('v') || s.StartsWith('V')) s = s[1..];
+        var plus = s.IndexOf('+');
+        return plus >= 0 ? s[..plus] : s;
+    }
+
+    // ---- orchestration (thin glue, best-effort) ----
+
+    // Fire-and-forget after a successful data command. Any failure (offline,
+    // rate-limited, malformed cache) is swallowed: the notifier must never
+    // affect the command's exit code or output.
+    internal static async Task MaybeNotifyAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (!ShouldCheck(
+                    stderrIsTty: !Console.IsErrorRedirected,
+                    ciEnv: Environment.GetEnvironmentVariable("CI"),
+                    disableEnv: Environment.GetEnvironmentVariable(DisableVar),
+                    noNotifierEnv: Environment.GetEnvironmentVariable("NO_UPDATE_NOTIFIER")))
+                return;
+
+            var cachePath = Path.Combine(BrowserCommand.GetWebReaperHome(), "update-check.json");
+            var message = await EvaluateAsync(
+                CurrentVersion(),
+                Environment.ProcessPath,
+                DateTimeOffset.UtcNow,
+                () => ReadCache(cachePath),
+                entry => WriteCache(cachePath, entry.LastCheck, entry.LatestTag),
+                () => FetchLatestTagAsync(cancellationToken));
+
+            if (message is not null) Console.Error.WriteLine(message);
+        }
+        catch
+        {
+            // Best-effort: a notifier failure is never the command's problem.
+        }
+    }
+
+    // The orchestration decision, with I/O injected so it is unit-testable
+    // without a network, a clock, or the filesystem. Returns the message to
+    // print on stderr, or null when there is nothing to say. Honours the 24h
+    // throttle: a fresh cache short-circuits the fetch; a stale or missing
+    // cache fetches and re-stamps (keeping the prior tag if the fetch fails, so
+    // an offline run does not retry every invocation).
+    internal static async Task<string?> EvaluateAsync(
+        string currentVersion,
+        string? processPath,
+        DateTimeOffset now,
+        Func<(DateTimeOffset LastCheck, string? LatestTag)?> readCache,
+        Action<(DateTimeOffset LastCheck, string? LatestTag)> writeCache,
+        Func<Task<string?>> fetchLatest)
+    {
+        if (string.Equals(currentVersion, "dev", StringComparison.Ordinal)) return null;
+
+        var cached = readCache();
+        var latest = cached?.LatestTag;
+        if (cached is null || IsStale(cached.Value.LastCheck, now, Ttl))
+        {
+            var fetched = await fetchLatest();
+            latest = fetched ?? cached?.LatestTag;
+            writeCache((now, latest));
+        }
+
+        return !string.IsNullOrEmpty(latest) && IsNewer(latest, currentVersion)
+            ? FormatMessage(latest, currentVersion, UpgradeHint(processPath))
+            : null;
+    }
+
+    private static string CurrentVersion() =>
+        typeof(UpdateNotifier).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? "dev";
+
+    private static (DateTimeOffset LastCheck, string? LatestTag)? ReadCache(string path)
+    {
+        try
+        {
+            if (!File.Exists(path)) return null;
+            using var doc = JsonDocument.Parse(File.ReadAllText(path));
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("lastCheckUtc", out var lc)) return null;
+            if (!DateTimeOffset.TryParse(lc.GetString(), CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind, out var last))
+                return null;
+            var tag = root.TryGetProperty("latestTag", out var t) && t.ValueKind == JsonValueKind.String
+                ? t.GetString()
+                : null;
+            return (last, tag);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void WriteCache(string path, DateTimeOffset now, string? latestTag)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            using var fs = File.Create(path);
+            using var w = new Utf8JsonWriter(fs);
+            w.WriteStartObject();
+            w.WriteString("lastCheckUtc", now.ToString("o", CultureInfo.InvariantCulture));
+            if (latestTag is not null) w.WriteString("latestTag", latestTag);
+            else w.WriteNull("latestTag");
+            w.WriteEndObject();
+        }
+        catch
+        {
+            // Best-effort cache write.
+        }
+    }
+
+    private static async Task<string?> FetchLatestTagAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(FetchTimeout);
+            using var http = new HttpClient { Timeout = FetchTimeout };
+            // GitHub's REST API rejects requests without a User-Agent.
+            http.DefaultRequestHeaders.Add("User-Agent", "webreaper-cli");
+            http.DefaultRequestHeaders.Add("Accept", "application/vnd.github+json");
+
+            using var resp = await http.GetAsync(LatestUrl, cts.Token);
+            if (!resp.IsSuccessStatusCode) return null;
+
+            var json = await resp.Content.ReadAsStringAsync(cts.Token);
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.TryGetProperty("tag_name", out var t) && t.ValueKind == JsonValueKind.String
+                ? t.GetString()
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/WebReaper.Cli/skill/SKILL.md
+++ b/WebReaper.Cli/skill/SKILL.md
@@ -148,6 +148,11 @@ A schema is a tree of fields. Leaves have a CSS `selector` and a `type`
 - `map` → one URL per line.
 - `--output <path>` redirects to a file instead of stdout.
 
+All data output is on **stdout**; diagnostics and an occasional update hint go to
+**stderr**, so piping or redirecting stdout always yields clean data. The update
+hint only appears on an interactive terminal (never in a pipe or CI); disable it
+with `WEBREAPER_NO_UPDATE_CHECK=1`.
+
 ## Errors
 
 Exit code `0` on success, non-zero on failure. Errors print one human-readable

--- a/WebReaper.Tests/WebReaper.Cli.Tests/UpdateNotifierTests.cs
+++ b/WebReaper.Tests/WebReaper.Cli.Tests/UpdateNotifierTests.cs
@@ -1,0 +1,223 @@
+using WebReaper.Cli;
+
+namespace WebReaper.Cli.Tests;
+
+// ADR-0082: the update notifier's pure logic: gating (TTY / CI / env),
+// numeric version comparison, the 24h throttle, channel-aware upgrade hints,
+// and message formatting. The network fetch + cache I/O + console write are
+// thin glue tested at the wiring level; these pin the decisions.
+public class UpdateNotifierTests
+{
+    // ---- gating (opt-out, TTY/CI/env) ----
+
+    [Fact]
+    public void Checks_when_interactive_and_unset()
+    {
+        Assert.True(UpdateNotifier.ShouldCheck(stderrIsTty: true, ciEnv: null, disableEnv: null, noNotifierEnv: null));
+    }
+
+    [Fact]
+    public void Does_not_check_when_stderr_is_not_a_tty()
+    {
+        // Piped / redirected stderr (agents, CI logs); never notify.
+        Assert.False(UpdateNotifier.ShouldCheck(stderrIsTty: false, ciEnv: null, disableEnv: null, noNotifierEnv: null));
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("1")]
+    [InlineData("TRUE")]
+    public void Does_not_check_under_ci(string ci)
+    {
+        Assert.False(UpdateNotifier.ShouldCheck(stderrIsTty: true, ciEnv: ci, disableEnv: null, noNotifierEnv: null));
+    }
+
+    [Theory]
+    [InlineData("false")]
+    [InlineData("0")]
+    [InlineData("")]
+    public void A_falsey_CI_value_does_not_count_as_ci(string ci)
+    {
+        Assert.True(UpdateNotifier.ShouldCheck(stderrIsTty: true, ciEnv: ci, disableEnv: null, noNotifierEnv: null));
+    }
+
+    [Fact]
+    public void Does_not_check_when_disabled_by_either_env_var()
+    {
+        Assert.False(UpdateNotifier.ShouldCheck(true, null, disableEnv: "1", noNotifierEnv: null));
+        Assert.False(UpdateNotifier.ShouldCheck(true, null, disableEnv: null, noNotifierEnv: "1"));
+    }
+
+    // ---- numeric semver comparison ----
+
+    [Theory]
+    [InlineData("v10.3.0", "10.2.0", true)]
+    [InlineData("10.3.0", "10.2.0", true)]      // no leading v on the tag
+    [InlineData("v10.2.1", "10.2.0", true)]
+    [InlineData("v10.10.0", "10.9.0", true)]    // numeric, not lexical (10.10 > 10.9)
+    [InlineData("v11.0.0", "10.9.9", true)]
+    [InlineData("v10.2.0", "10.2.0", false)]
+    [InlineData("v10.2.0", "10.2.0+abc123", false)]  // build metadata ignored
+    [InlineData("v9.0.0", "10.0.0", false)]
+    [InlineData("v10.2.0-rc1", "10.2.0", false)]     // a prerelease of the same version is not newer
+    public void IsNewer_compares_numerically(string latest, string current, bool expected)
+    {
+        Assert.Equal(expected, UpdateNotifier.IsNewer(latest, current));
+    }
+
+    [Theory]
+    [InlineData("v10.3.0", "dev")]              // unparseable current (dev build), never nag
+    [InlineData("not-a-version", "10.2.0")]     // unparseable tag, swallow
+    public void IsNewer_is_false_when_either_side_is_unparseable(string latest, string current)
+    {
+        Assert.False(UpdateNotifier.IsNewer(latest, current));
+    }
+
+    // ---- 24h throttle ----
+
+    [Fact]
+    public void Cache_is_stale_after_the_ttl()
+    {
+        var now = new DateTimeOffset(2026, 5, 30, 12, 0, 0, TimeSpan.Zero);
+        Assert.True(UpdateNotifier.IsStale(now.AddHours(-25), now, TimeSpan.FromHours(24)));
+        Assert.False(UpdateNotifier.IsStale(now.AddHours(-1), now, TimeSpan.FromHours(24)));
+    }
+
+    // ---- channel-aware upgrade hint ----
+
+    [Theory]
+    [InlineData("/opt/homebrew/bin/webreaper")]
+    [InlineData("/usr/local/Cellar/webreaper/10.2.0/bin/webreaper")]
+    [InlineData("/home/linuxbrew/.linuxbrew/bin/webreaper")]
+    public void Homebrew_paths_hint_brew_upgrade(string path)
+    {
+        Assert.Contains("brew upgrade", UpdateNotifier.UpgradeHint(path));
+    }
+
+    [Fact]
+    public void Winget_path_hints_winget_upgrade()
+    {
+        var path = @"C:\Users\x\AppData\Local\Microsoft\WinGet\Packages\pavlovtech.webreaper\webreaper.exe";
+        Assert.Contains("winget upgrade", UpdateNotifier.UpgradeHint(path));
+    }
+
+    [Fact]
+    public void Scoop_path_hints_scoop_update()
+    {
+        var path = @"C:\Users\x\scoop\apps\webreaper\current\webreaper.exe";
+        Assert.Contains("scoop update", UpdateNotifier.UpgradeHint(path));
+    }
+
+    [Theory]
+    [InlineData("/usr/local/bin/webreaper")]    // curl | sh install
+    [InlineData(null)]                          // unknown
+    public void Non_package_manager_paths_hint_the_install_script(string? path)
+    {
+        Assert.Contains("install.sh", UpdateNotifier.UpgradeHint(path));
+    }
+
+    // ---- message ----
+
+    [Fact]
+    public void Message_names_both_versions_the_hint_and_the_disable_var()
+    {
+        var msg = UpdateNotifier.FormatMessage("v10.3.0", "10.2.0+abc", "brew upgrade webreaper");
+        Assert.Contains("10.3.0", msg);
+        Assert.Contains("10.2.0", msg);
+        Assert.DoesNotContain("abc", msg);          // build metadata stripped for display
+        Assert.Contains("brew upgrade webreaper", msg);
+        Assert.Contains("WEBREAPER_NO_UPDATE_CHECK", msg);
+    }
+
+    // ---- orchestration flow (EvaluateAsync, I/O injected) ----
+
+    private static readonly DateTimeOffset Now = new(2026, 5, 30, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task Fresh_cache_with_a_newer_tag_notifies_without_fetching()
+    {
+        var fetched = false;
+        var wrote = false;
+        var msg = await UpdateNotifier.EvaluateAsync(
+            currentVersion: "10.2.0",
+            processPath: "/usr/local/bin/webreaper",
+            now: Now,
+            readCache: () => (Now.AddHours(-1), "v10.3.0"),   // fresh (within 24h)
+            writeCache: _ => wrote = true,
+            fetchLatest: () => { fetched = true; return Task.FromResult<string?>(null); });
+
+        Assert.NotNull(msg);
+        Assert.Contains("10.3.0", msg!);
+        Assert.False(fetched);   // throttle short-circuits the network
+        Assert.False(wrote);     // and the re-stamp
+    }
+
+    [Fact]
+    public async Task Fresh_cache_at_the_current_version_says_nothing()
+    {
+        var msg = await UpdateNotifier.EvaluateAsync(
+            "10.3.0", "/usr/local/bin/webreaper", Now,
+            () => (Now.AddHours(-1), "v10.3.0"),
+            _ => { }, () => Task.FromResult<string?>(null));
+
+        Assert.Null(msg);
+    }
+
+    [Fact]
+    public async Task Stale_cache_fetches_notifies_and_restamps()
+    {
+        (DateTimeOffset LastCheck, string? LatestTag)? written = null;
+        var msg = await UpdateNotifier.EvaluateAsync(
+            "10.2.0", "/opt/homebrew/bin/webreaper", Now,
+            () => (Now.AddHours(-25), "v10.2.0"),             // stale, old tag
+            e => written = e,
+            () => Task.FromResult<string?>("v10.3.0"));        // fetch finds newer
+
+        Assert.NotNull(msg);
+        Assert.Contains("brew upgrade", msg!);                 // homebrew path → brew hint
+        Assert.Equal((Now, "v10.3.0"), written);              // re-stamped with the new tag
+    }
+
+    [Fact]
+    public async Task No_cache_fetches_on_first_run()
+    {
+        var fetched = false;
+        var msg = await UpdateNotifier.EvaluateAsync(
+            "10.2.0", null, Now,
+            () => null,                                        // first run, no cache
+            _ => { },
+            () => { fetched = true; return Task.FromResult<string?>("v10.3.0"); });
+
+        Assert.True(fetched);
+        Assert.NotNull(msg);
+    }
+
+    [Fact]
+    public async Task Stale_cache_with_a_failed_fetch_keeps_the_old_tag_and_restamps()
+    {
+        // Offline run: keep notifying from the cached tag, but re-stamp the
+        // check time so we do not hammer the network every invocation.
+        (DateTimeOffset LastCheck, string? LatestTag)? written = null;
+        var msg = await UpdateNotifier.EvaluateAsync(
+            "10.2.0", "/usr/local/bin/webreaper", Now,
+            () => (Now.AddHours(-25), "v10.3.0"),             // stale, cached tag already newer
+            e => written = e,
+            () => Task.FromResult<string?>(null));            // fetch fails
+
+        Assert.NotNull(msg);
+        Assert.Equal((Now, "v10.3.0"), written);
+    }
+
+    [Fact]
+    public async Task Dev_build_never_notifies_or_fetches()
+    {
+        var fetched = false;
+        var msg = await UpdateNotifier.EvaluateAsync(
+            "dev", null, Now,
+            () => null, _ => { },
+            () => { fetched = true; return Task.FromResult<string?>("v10.3.0"); });
+
+        Assert.Null(msg);
+        Assert.False(fetched);
+    }
+}


### PR DESCRIPTION
## What

Implements **ADR-0082 Part 1** (merged design, [#165](https://github.com/pavlovtech/WebReaper/pull/165)): an opt-out update notifier. After a successful `scrape` / `crawl` / `map`, an interactive user is told once on stderr when a newer release exists:

```
webreaper 10.4.0 is available (you have 10.3.0).
Upgrade: brew upgrade webreaper
(disable this check: WEBREAPER_NO_UPDATE_CHECK=1)
```

## How (the grilled decisions)

- **Opt-out, interactive only.** stderr only (never the stdout payload); off in pipes, off under CI, off when `WEBREAPER_NO_UPDATE_CHECK` / `NO_UPDATE_NOTIFIER` is set. Agents and scripts see nothing.
- **Read-only, no telemetry, no consent gate.** A single `GET` to GitHub `releases/latest`, at most once per 24h (cached in `~/.webreaper/update-check.json`). Never blocks or fails the command; swallows every error (offline, rate-limited).
- **Channel-aware hint.** Homebrew → `brew upgrade`, winget/Scoop → theirs, `curl\|sh` → the install.sh `--upgrade` one-liner (hardcoded prefix match on the binary path, AOT-clean).
- **`webreaper update` (self-replace) stays deferred** (ADR-0082 Part 2).

## Tests

`UpdateNotifier` splits pure logic from a thin I/O-injected orchestration, so both are unit-tested without network/clock/filesystem (**35 cases**): gating (TTY/CI/env), numeric version compare (`10.10 > 10.9`, strip `v`/`+meta`, `dev` never nags), the 24h throttle, channel hints, and the fetch/fail-keep/restamp flow.

Guardrails: `dotnet build -c Release` clean (0 new warnings); Cli.Tests **125** + UnitTests pass; **AOT publish of the CLI is clean** (the IL set is promoted to errors, so this proves the HttpClient + JsonDocument + assembly-version path is AOT/trim-safe); the published binary runs and `help` shows the new env var.

## Release ordering (heads-up)

This bumps `Directory.Build.props` to **10.3.0** and adds a single `## 10.3.0` CHANGELOG heading, per ADR-0082 (notifier ships separately from site sweep).

**v10.2.0 is merged to master but not yet tagged/released** (latest release is v10.1.0). To give site sweep its own release, **tag/release v10.2.0 from the #164 merge commit `ec97496` first** (its CHANGELOG top is `## 10.2.0`), then merge this PR and release v10.3.0. If you'd rather not, the alternative is to fold the notifier into 10.2.0, but that reverses ADR-0082's "separate release" decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)