### PR TITLE
feat(loaders)!: PageLoadResult contract; non-2xx is data (ADR-0083 slice 1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -187,11 +187,11 @@ _Avoid_: durable file / file substrate (the held-handle substrate was rejected �
 ### Page loading
 
 **Page loader**:
-The single seam (`IPageLoader`) that turns a **PageRequest** into a page's HTML, dispatching on the request's **PageType** to one **load transport**; the Spider holds one of these and is loader-blind (no Static/Dynamic loader pair).
+The single seam (`IPageLoader`) that turns a **PageRequest** into a **page load result** (body plus response status and headers, ADR-0083), dispatching on the request's **PageType** to one **load transport**; the Spider holds one of these and is loader-blind (no Static/Dynamic loader pair).
 _Avoid_: page fetcher, downloader, static/dynamic loader.
 
 **Load transport**:
-The per-mechanism adapter behind the **page loader** — HTTP (`HttpPageLoadTransport`, in core), Playwright (browser SDK, `WebReaper.Playwright` satellite), or CDP-direct (raw protocol, `WebReaper.Cdp` satellite — the bedrock for **Browser backend** swaps) — and the only place that mechanism's client/launch quirks and its proxy application live. Browser transports launch and drive a **Browser backend** (the Chromium binary, a separate axis). ADR-0050's `(cookies, proxy, logger, actionResolver)` factory contract applies uniformly across transports.
+The per-mechanism adapter behind the **page loader** — HTTP (`HttpPageLoadTransport`, in core), Playwright (browser SDK, `WebReaper.Playwright` satellite), or CDP-direct (raw protocol, `WebReaper.Cdp` satellite — the bedrock for **Browser backend** swaps) — and the only place that mechanism's client/launch quirks and its proxy application live. Browser transports launch and drive a **Browser backend** (the Chromium binary, a separate axis). ADR-0050's `(cookies, proxy, logger, actionResolver)` factory contract applies uniformly across transports. Returns a **page load result** for any completed response; only a no-response failure is a **page load exception** (ADR-0083).
 _Avoid_: requester, loader, driver, channel.
 
 **Browser backend**:
@@ -201,6 +201,14 @@ _Avoid_: transport (that is how we drive, not what we drive), driver, runtime.
 **PageRequest**:
 What the **page loader** needs to fetch one page — URL, **PageType**, optional page actions, headless flag — projected from a **Job** plus the crawl's headless setting (the loader never sees the selector chain or backlinks).
 _Avoid_: load args, request.
+
+**Page load result**:
+The value a **page loader** / **load transport** returns for one page (ADR-0083): the page `Html` plus the response `HttpStatus` (nullable; null when a transport cannot determine it) and `Headers` (case-insensitive). Replaces the bare HTML string the loader returned before, so a consumer, and in later slices the **block detector**, can read the response metadata; it is the first time the library can report an HTTP status. An init-only record (deliberately not positional, so future fields like `FinalUrl` land additively). A completed response of any status is returned as one of these.
+_Avoid_: response, page, document (that was the old string return).
+
+**Page load exception**:
+What a **load transport** throws when there is no HTTP response at all (ADR-0083): DNS failure, connection refused, TLS error, or timeout. A completed response with any status code, including 4xx and 5xx, is returned as a **page load result**, not thrown; a non-2xx is data, not a fault. This narrows ADR-0004's "a page that cannot be retrieved is an exception" stance to the genuine no-response case, and means the **retry policy** retries only these transport faults, never an HTTP status.
+_Avoid_: load error, HTTP error, fetch failure.
 
 ### Wiring
 

--- a/WebReaper.Cdp/CdpPageLoadTransport.cs
+++ b/WebReaper.Cdp/CdpPageLoadTransport.cs
@@ -71,7 +71,7 @@ public sealed class CdpPageLoadTransport : IPageLoadTransport, IAsyncDisposable
     }
 
     /// <inheritdoc />
-    public async Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
+    public async Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         var browser = await EnsureConnectedAsync(cancellationToken);
@@ -133,7 +133,11 @@ public sealed class CdpPageLoadTransport : IPageLoadTransport, IAsyncDisposable
 
             var html = await CdpPageActionDispatcher.EvaluateAsync(browser, sessionId,
                 "document.documentElement.outerHTML", cancellationToken);
-            return html ?? "";
+            // ADR-0083 slice 1: the CDP transport returns the rendered DOM with a
+            // null HttpStatus and no headers. Capturing the main-document status
+            // via Network.responseReceived is the ADR-named follow-up; browser-
+            // tier block detection works off body markers in this DOM meanwhile.
+            return new PageLoadResult { Html = html ?? "" };
         }
         finally
         {

--- a/WebReaper.Playwright/PlaywrightPageLoadTransport.cs
+++ b/WebReaper.Playwright/PlaywrightPageLoadTransport.cs
@@ -56,7 +56,7 @@ public sealed class PlaywrightPageLoadTransport : IPageLoadTransport, IAsyncDisp
     }
 
     /// <inheritdoc />
-    public async Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
+    public async Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         var browser = await EnsureLaunchedAsync(request.Headless, cancellationToken);
@@ -84,7 +84,7 @@ public sealed class PlaywrightPageLoadTransport : IPageLoadTransport, IAsyncDisp
         await ApplyCookiesAsync(context, request.Url);
 
         var page = await context.NewPageAsync();
-        await page.GotoAsync(request.Url, new PageGotoOptions
+        var response = await page.GotoAsync(request.Url, new PageGotoOptions
         {
             WaitUntil = WaitUntilState.NetworkIdle,
         });
@@ -102,7 +102,18 @@ public sealed class PlaywrightPageLoadTransport : IPageLoadTransport, IAsyncDisp
             }
         }
 
-        return await page.ContentAsync();
+        var html = await page.ContentAsync();
+        // ADR-0083: Playwright surfaces the navigation response, so status and
+        // headers come back cheaply (null when the navigation produced no
+        // main response, e.g. about:blank).
+        return new PageLoadResult
+        {
+            Html = html,
+            HttpStatus = response?.Status,
+            Headers = response?.Headers is { } h
+                ? new Dictionary<string, string>(h, StringComparer.OrdinalIgnoreCase)
+                : PageLoadResult.EmptyHeaders,
+        };
     }
 
     private async Task ApplyCookiesAsync(IBrowserContext context, string url)

--- a/WebReaper.Tests/WebReaper.AI.Tests/LlmAgentBrainTests.cs
+++ b/WebReaper.Tests/WebReaper.AI.Tests/LlmAgentBrainTests.cs
@@ -377,9 +377,9 @@ public class LlmAgentBrainTests
     {
         private readonly string _html;
         public FakePageLoader(string html) => _html = html;
-        public Task<string> LoadAsync(
+        public Task<WebReaper.Core.Loaders.Abstract.PageLoadResult> LoadAsync(
             WebReaper.Core.Loaders.Abstract.PageRequest request,
             CancellationToken ct = default)
-            => Task.FromResult(_html);
+            => Task.FromResult(new WebReaper.Core.Loaders.Abstract.PageLoadResult { Html = _html });
     }
 }

--- a/WebReaper.Tests/WebReaper.AotSmokeTest/Program.cs
+++ b/WebReaper.Tests/WebReaper.AotSmokeTest/Program.cs
@@ -8,6 +8,7 @@
 using System.Collections.Immutable;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging.Abstractions;
+using WebReaper.Core.Loaders.Abstract;
 using WebReaper.Core.Loaders.Concrete;
 using WebReaper.Core.Parser.Abstract;
 using WebReaper.Core.Parser.Concrete;
@@ -200,10 +201,10 @@ Check(md["title"]!.GetValue<string>() == "Hello"
 //    PageLoader. AOT-clean: ConcurrentDictionary<string, struct> with no
 //    reflection paths.
 var pageCache = new InMemoryPageCache(TimeSpan.FromMinutes(1));
-await pageCache.WriteAsync("https://x.test/p", WebReaper.Domain.Selectors.PageType.Static, "<cached/>", default);
+await pageCache.WriteAsync("https://x.test/p", WebReaper.Domain.Selectors.PageType.Static, new PageLoadResult { Html = "<cached/>" }, default);
 var staticHit = await pageCache.TryReadAsync("https://x.test/p", WebReaper.Domain.Selectors.PageType.Static, default);
 var dynamicMiss = await pageCache.TryReadAsync("https://x.test/p", WebReaper.Domain.Selectors.PageType.Dynamic, default);
-Check(staticHit == "<cached/>" && dynamicMiss is null,
+Check(staticHit?.Html == "<cached/>" && dynamicMiss is null,
     "InMemoryPageCache hit/miss with (url, pageType) keying (ADR-0041)");
 
 Console.WriteLine();

--- a/WebReaper.Tests/WebReaper.UnitTests/AgentEngineDriverTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/AgentEngineDriverTests.cs
@@ -715,11 +715,11 @@ public class AgentEngineDriverTests
     // change vs ADR-0051).
     private sealed class FailingFollowLoader(string badUrl) : IPageLoader
     {
-        public Task<string> LoadAsync(PageRequest request, CancellationToken ct = default)
+        public Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken ct = default)
         {
             if (request.Url == badUrl)
                 throw new HttpRequestException($"simulated load failure on {request.Url}");
-            return Task.FromResult("<html/>");
+            return Task.FromResult(new PageLoadResult { Html = "<html/>" });
         }
     }
 
@@ -789,8 +789,8 @@ public class AgentEngineDriverTests
 
     private sealed class FakeLoader(string html) : IPageLoader
     {
-        public Task<string> LoadAsync(PageRequest request, CancellationToken ct = default)
-            => Task.FromResult(html);
+        public Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken ct = default)
+            => Task.FromResult(new PageLoadResult { Html = html });
     }
 
     private sealed class RecordingSink : IScraperSink

--- a/WebReaper.Tests/WebReaper.UnitTests/EngineStopWhenDrainedTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/EngineStopWhenDrainedTests.cs
@@ -4,6 +4,7 @@ using WebReaper.ConfigStorage.Abstract;
 using WebReaper.Core;
 using WebReaper.Core.Crawling;
 using WebReaper.Core.LinkTracker.Concrete;
+using WebReaper.Core.Loaders.Abstract;
 using WebReaper.Core.Scheduler.Concrete;
 using WebReaper.Core.Spider.Abstract;
 using WebReaper.Domain;
@@ -37,7 +38,7 @@ namespace WebReaper.UnitTests
                         new Job("child-2", ImmutableQueue<LinkPathSelector>.Empty, ImmutableQueue<string>.Empty))
                     : ImmutableArray<Job>.Empty;
 
-                return Task.FromResult(new JobReport(CrawlOutcome.Transit(children), string.Empty));
+                return Task.FromResult(new JobReport(CrawlOutcome.Transit(children), new PageLoadResult { Html = string.Empty }));
             }
         }
 

--- a/WebReaper.Tests/WebReaper.UnitTests/HttpPageLoadTransportTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/HttpPageLoadTransportTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using WebReaper.Core.CookieStorage.Concrete;
+using WebReaper.Core.Loaders.Abstract;
+using WebReaper.Core.Loaders.Concrete;
+using WebReaper.Domain.Selectors;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0083 slice 1: the HTTP transport's response-handling contract, exercised
+// through a stubbed HttpMessageHandler (the SiteMapper handler-factory pattern,
+// reused here via HttpPageLoadTransport's internal test-seam constructor). No
+// live server, no network. Pins: a completed non-2xx is returned as data (not
+// thrown), the status and headers are surfaced, and a genuine no-response
+// failure throws PageLoadException.
+public class HttpPageLoadTransportTests
+{
+    // Returns a canned response, or faults the send (the no-response case).
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            try { return Task.FromResult(responder(request)); }
+            catch (Exception ex) { return Task.FromException<HttpResponseMessage>(ex); }
+        }
+    }
+
+    private static HttpPageLoadTransport TransportWith(Func<HttpRequestMessage, HttpResponseMessage> responder) =>
+        new(new InMemoryCookieStorage(), proxyProvider: null, NullLogger.Instance,
+            () => new StubHandler(responder));
+
+    [Theory]
+    [InlineData(403)]
+    [InlineData(429)]
+    [InlineData(503)]
+    public async Task A_completed_non_2xx_is_returned_as_data_not_thrown(int status)
+    {
+        var transport = TransportWith(_ => new HttpResponseMessage((HttpStatusCode)status)
+        {
+            Content = new StringContent("<html>Just a moment...</html>")
+        });
+
+        var result = await transport.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        Assert.Equal(status, result.HttpStatus);
+        Assert.Equal("<html>Just a moment...</html>", result.Html);
+    }
+
+    [Fact]
+    public async Task A_2xx_response_surfaces_status_and_headers()
+    {
+        var transport = TransportWith(_ =>
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("<html>ok</html>")
+            };
+            // A response header and a content header, to prove both are folded in.
+            resp.Headers.TryAddWithoutValidation("CF-RAY", "abc123");
+            return resp;
+        });
+
+        var result = await transport.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        Assert.Equal(200, result.HttpStatus);
+        Assert.Equal("<html>ok</html>", result.Html);
+        // Header lookup is case-insensitive (the detector matches that way).
+        Assert.True(result.Headers.ContainsKey("cf-ray"));
+        Assert.Equal("abc123", result.Headers["cf-ray"]);
+        Assert.True(result.Headers.ContainsKey("Content-Type"));
+    }
+
+    [Fact]
+    public async Task A_no_response_failure_throws_PageLoadException()
+    {
+        var transport = TransportWith(_ =>
+            throw new HttpRequestException("Connection refused"));
+
+        await Assert.ThrowsAsync<PageLoadException>(() =>
+            transport.LoadAsync(new PageRequest("https://x.test/", PageType.Static)));
+    }
+}

--- a/WebReaper.Tests/WebReaper.UnitTests/PageCacheTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/PageCacheTests.cs
@@ -16,7 +16,7 @@ public class PageCacheTests
         // The default: preserves pre-0041 PageLoader behaviour exactly.
         IPageCache cache = new NullPageCache();
 
-        await cache.WriteAsync("https://x.test/", PageType.Static, "<html/>", default);
+        await cache.WriteAsync("https://x.test/", PageType.Static, new PageLoadResult { Html = "<html/>" }, default);
 
         var got = await cache.TryReadAsync("https://x.test/", PageType.Static, default);
 
@@ -28,11 +28,11 @@ public class PageCacheTests
     {
         var cache = new InMemoryPageCache(TimeSpan.FromMinutes(10));
 
-        await cache.WriteAsync("https://x.test/", PageType.Static, "<html>cached</html>", default);
+        await cache.WriteAsync("https://x.test/", PageType.Static, new PageLoadResult { Html = "<html>cached</html>" }, default);
 
         var got = await cache.TryReadAsync("https://x.test/", PageType.Static, default);
 
-        Assert.Equal("<html>cached</html>", got);
+        Assert.Equal("<html>cached</html>", got!.Html);
     }
 
     [Fact]
@@ -54,13 +54,13 @@ public class PageCacheTests
         // a Dynamic request.
         var cache = new InMemoryPageCache(TimeSpan.FromMinutes(10));
 
-        await cache.WriteAsync("https://x.test/", PageType.Static, "<static/>", default);
+        await cache.WriteAsync("https://x.test/", PageType.Static, new PageLoadResult { Html = "<static/>" }, default);
 
         var dynamicRead = await cache.TryReadAsync("https://x.test/", PageType.Dynamic, default);
         Assert.Null(dynamicRead);
 
         var staticRead = await cache.TryReadAsync("https://x.test/", PageType.Static, default);
-        Assert.Equal("<static/>", staticRead);
+        Assert.Equal("<static/>", staticRead!.Html);
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class PageCacheTests
         var now = DateTimeOffset.UtcNow;
         var cache = new InMemoryPageCache(TimeSpan.FromMinutes(10), () => now);
 
-        await cache.WriteAsync("https://x.test/", PageType.Static, "<v1/>", default);
+        await cache.WriteAsync("https://x.test/", PageType.Static, new PageLoadResult { Html = "<v1/>" }, default);
 
         now = now.AddMinutes(11);
 
@@ -89,13 +89,13 @@ public class PageCacheTests
         var now = DateTimeOffset.UtcNow;
         var cache = new InMemoryPageCache(TimeSpan.FromMinutes(10), () => now);
 
-        await cache.WriteAsync("https://x.test/", PageType.Static, "<v1/>", default);
+        await cache.WriteAsync("https://x.test/", PageType.Static, new PageLoadResult { Html = "<v1/>" }, default);
 
         now = now.AddMinutes(10);
 
         var got = await cache.TryReadAsync("https://x.test/", PageType.Static, default);
 
-        Assert.Equal("<v1/>", got);
+        Assert.Equal("<v1/>", got!.Html);
     }
 
     [Fact]
@@ -106,16 +106,16 @@ public class PageCacheTests
         var now = DateTimeOffset.UtcNow;
         var cache = new InMemoryPageCache(TimeSpan.FromMinutes(10), () => now);
 
-        await cache.WriteAsync("https://x.test/", PageType.Static, "<v1/>", default);
+        await cache.WriteAsync("https://x.test/", PageType.Static, new PageLoadResult { Html = "<v1/>" }, default);
 
         now = now.AddMinutes(5);
-        await cache.WriteAsync("https://x.test/", PageType.Static, "<v2/>", default);
+        await cache.WriteAsync("https://x.test/", PageType.Static, new PageLoadResult { Html = "<v2/>" }, default);
 
         // 6 minutes later — within the refreshed TTL.
         now = now.AddMinutes(6);
         var got = await cache.TryReadAsync("https://x.test/", PageType.Static, default);
 
-        Assert.Equal("<v2/>", got);
+        Assert.Equal("<v2/>", got!.Html);
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public class PageCacheTests
         // mode. Writes succeed; reads always miss.
         var cache = new InMemoryPageCache(TimeSpan.Zero);
 
-        await cache.WriteAsync("https://x.test/", PageType.Static, "<html/>", default);
+        await cache.WriteAsync("https://x.test/", PageType.Static, new PageLoadResult { Html = "<html/>" }, default);
 
         var got = await cache.TryReadAsync("https://x.test/", PageType.Static, default);
 
@@ -144,8 +144,8 @@ public class PageCacheTests
     {
         var cache = new InMemoryPageCache(TimeSpan.FromMinutes(10));
 
-        await cache.WriteAsync("https://x.test/a", PageType.Static, "<a/>", default);
-        await cache.WriteAsync("https://x.test/b", PageType.Dynamic, "<b/>", default);
+        await cache.WriteAsync("https://x.test/a", PageType.Static, new PageLoadResult { Html = "<a/>" }, default);
+        await cache.WriteAsync("https://x.test/b", PageType.Dynamic, new PageLoadResult { Html = "<b/>" }, default);
 
         cache.Clear();
 
@@ -161,7 +161,7 @@ public class PageCacheTests
         // if called — the test passes only because the cache short-
         // circuits the dispatch.
         var cache = new InMemoryPageCache(TimeSpan.FromMinutes(10));
-        await cache.WriteAsync("https://x.test/", PageType.Static, "<cached/>", default);
+        await cache.WriteAsync("https://x.test/", PageType.Static, new PageLoadResult { Html = "<cached/>" }, default);
 
         var loader = new PageLoader(
             new ThrowingTransport(),
@@ -171,7 +171,7 @@ public class PageCacheTests
 
         var got = await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static, null, true), default);
 
-        Assert.Equal("<cached/>", got);
+        Assert.Equal("<cached/>", got.Html);
     }
 
     [Fact]
@@ -191,8 +191,8 @@ public class PageCacheTests
         var first = await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static, null, true), default);
         var second = await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static, null, true), default);
 
-        Assert.Equal("<fetched/>", first);
-        Assert.Equal("<fetched/>", second);
+        Assert.Equal("<fetched/>", first.Html);
+        Assert.Equal("<fetched/>", second.Html);
         Assert.Equal(1, http.CallCount);
     }
 
@@ -212,7 +212,7 @@ public class PageCacheTests
 
         var got = await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static, null, true), default);
 
-        Assert.Equal("<fetched/>", got);
+        Assert.Equal("<fetched/>", got.Html);
     }
 
     private sealed class StubTransport : IPageLoadTransport
@@ -220,24 +220,24 @@ public class PageCacheTests
         private readonly string _document;
         public int CallCount { get; private set; }
         public StubTransport(string document) => _document = document;
-        public Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken)
+        public Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken)
         {
             CallCount++;
-            return Task.FromResult(_document);
+            return Task.FromResult(new PageLoadResult { Html = _document });
         }
     }
 
     private sealed class ThrowingTransport : IPageLoadTransport
     {
-        public Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken)
+        public Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken)
             => throw new InvalidOperationException("The cache short-circuit must prevent this call.");
     }
 
     private sealed class ThrowingWriteCache : IPageCache
     {
-        public Task<string?> TryReadAsync(string url, PageType pageType, CancellationToken cancellationToken)
-            => Task.FromResult<string?>(null);
-        public Task WriteAsync(string url, PageType pageType, string document, CancellationToken cancellationToken)
+        public Task<PageLoadResult?> TryReadAsync(string url, PageType pageType, CancellationToken cancellationToken)
+            => Task.FromResult<PageLoadResult?>(null);
+        public Task WriteAsync(string url, PageType pageType, PageLoadResult document, CancellationToken cancellationToken)
             => throw new InvalidOperationException("Cache backend down.");
     }
 }

--- a/WebReaper.Tests/WebReaper.UnitTests/PageLoaderTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/PageLoaderTests.cs
@@ -16,10 +16,10 @@ public class PageLoaderTests
     {
         public PageRequest? Received { get; private set; }
 
-        public Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
+        public Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
         {
             Received = request;
-            return Task.FromResult(html);
+            return Task.FromResult(new PageLoadResult { Html = html });
         }
     }
 
@@ -30,9 +30,9 @@ public class PageLoaderTests
         var browser = new FakeTransport("BROWSER");
         var loader = new PageLoader(http, browser, NullLogger.Instance);
 
-        var html = await loader.LoadAsync(new PageRequest("https://x.test", PageType.Static));
+        var result = await loader.LoadAsync(new PageRequest("https://x.test", PageType.Static));
 
-        Assert.Equal("HTTP", html);
+        Assert.Equal("HTTP", result.Html);
         Assert.Equal("https://x.test", http.Received!.Url);
         Assert.Null(browser.Received);
     }
@@ -44,9 +44,9 @@ public class PageLoaderTests
         var browser = new FakeTransport("BROWSER");
         var loader = new PageLoader(http, browser, NullLogger.Instance);
 
-        var html = await loader.LoadAsync(new PageRequest("https://x.test", PageType.Dynamic));
+        var result = await loader.LoadAsync(new PageRequest("https://x.test", PageType.Dynamic));
 
-        Assert.Equal("BROWSER", html);
+        Assert.Equal("BROWSER", result.Html);
         Assert.Equal("https://x.test", browser.Received!.Url);
         Assert.Null(http.Received);
     }

--- a/WebReaper.Tests/WebReaper.UnitTests/ScraperEngineDriverTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/ScraperEngineDriverTests.cs
@@ -7,6 +7,7 @@ using WebReaper.ConfigStorage.Abstract;
 using WebReaper.Core;
 using WebReaper.Core.Crawling;
 using WebReaper.Core.LinkTracker.Concrete;
+using WebReaper.Core.Loaders.Abstract;
 using WebReaper.Core.Scheduler.Abstract;
 using WebReaper.Core.Scheduler.Concrete;
 using WebReaper.Core.Spider.Abstract;
@@ -137,10 +138,10 @@ public class ScraperEngineDriverTests
         new(CrawlOutcome.Transit(urls
                 .Select(u => new Job(u, ImmutableQueue<LinkPathSelector>.Empty, ImmutableQueue<string>.Empty))
                 .ToImmutableArray()),
-            string.Empty);
+            new PageLoadResult { Html = string.Empty });
 
     private static JobReport Parsed(string url) =>
-        new(CrawlOutcome.Target(new ParsedData(url, new JsonObject())), "<html/>");
+        new(CrawlOutcome.Target(new ParsedData(url, new JsonObject())), new PageLoadResult { Html = "<html/>" });
 
     private static JobReport Swept(string url, params string[] children) =>
         new(CrawlOutcome.Sweep(
@@ -150,7 +151,7 @@ public class ScraperEngineDriverTests
                         ImmutableQueue.CreateRange(new[] { LinkPathSelector.Sweep() }),
                         ImmutableQueue<string>.Empty))
                     .ToImmutableArray()),
-            "<html/>");
+            new PageLoadResult { Html = "<html/>" });
 
     [Fact]
     public async Task Swept_page_both_emits_its_record_and_follows_its_children_until_the_frontier_saturates()

--- a/WebReaper.Tests/WebReaper.UnitTests/SpiderTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/SpiderTests.cs
@@ -28,10 +28,10 @@ public class SpiderTests
     {
         public PageRequest? LastRequest { get; private set; }
 
-        public Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
+        public Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
         {
             LastRequest = request;
-            return Task.FromResult(html);
+            return Task.FromResult(new PageLoadResult { Html = html });
         }
     }
 
@@ -58,7 +58,7 @@ public class SpiderTests
         var parsed = Assert.IsType<CrawlOutcome.Parsed>(report.Outcome);
         Assert.Equal("https://x.test/p/1", parsed.Data.Url);
         Assert.Equal("Hello", parsed.Data.Data["title"]?.ToString());
-        Assert.Equal(html, report.Document);          // the doc the driver needs for PageContext
+        Assert.Equal(html, report.Page.Html);          // the doc the driver needs for PageContext
         Assert.Empty(report.Outcome.NextJobs);
     }
 
@@ -74,7 +74,7 @@ public class SpiderTests
 
         var followed = Assert.IsType<CrawlOutcome.Followed>(report.Outcome);
         Assert.Equal(new[] { "https://x.test/a", "https://x.test/b" }, followed.Next.Select(j => j.Url));
-        Assert.Equal(html, report.Document);
+        Assert.Equal(html, report.Page.Html);
     }
 
     [Fact]

--- a/WebReaper.Tests/WebReaper.UnitTests/SweepPolicyThreadingTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/SweepPolicyThreadingTests.cs
@@ -20,8 +20,8 @@ public class SweepPolicyThreadingTests
 {
     private sealed class FakeLoader(string html) : IPageLoader
     {
-        public Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
-            => Task.FromResult(html);
+        public Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new PageLoadResult { Html = html });
     }
 
     private static ScraperConfig SweepConfig(bool includeSubdomains, int maxDepth = int.MaxValue) => new(

--- a/WebReaper/Core/Agent/Concrete/AgentEngine.cs
+++ b/WebReaper/Core/Agent/Concrete/AgentEngine.cs
@@ -232,14 +232,15 @@ public sealed class AgentEngine : IAsyncDisposable
             try
             {
                 var request = new PageRequest(currentUrl, _pageType, pendingActions, Headless: true);
-                pageHtml = await _pageLoader.LoadAsync(request, cancellationToken);
+                var result = await _pageLoader.LoadAsync(request, cancellationToken);
+                pageHtml = result.Html;
                 pendingActions = null; // one-shot
-                // The HTTP transport doesn't surface a per-page status code
-                // through IPageLoader; we treat a successful load as 200 for
-                // Static and 0 for Dynamic (the brain reads "0 means
-                // dynamic" from the system prompt — Followed StatusCode
-                // semantics, fork 3 verdict).
-                loadStatusCode = _pageType == PageType.Static ? 200 : 0;
+                // ADR-0083: the loader now surfaces the real HTTP status. Fall
+                // back to the pre-0083 synthesis (200 for Static, 0 for Dynamic,
+                // the "0 means dynamic" Followed-StatusCode semantics) when the
+                // transport could not determine it (the CDP transport returns
+                // null today).
+                loadStatusCode = result.HttpStatus ?? (_pageType == PageType.Static ? 200 : 0);
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)

--- a/WebReaper/Core/Crawling/JobReport.cs
+++ b/WebReaper/Core/Crawling/JobReport.cs
@@ -1,3 +1,5 @@
+using WebReaper.Core.Loaders.Abstract;
+
 namespace WebReaper.Core.Crawling;
 
 /// <summary>
@@ -13,6 +15,7 @@ namespace WebReaper.Core.Crawling;
 /// still lives inside the shell). Termination is never a thrown exception.
 /// </summary>
 /// <param name="Outcome">The Crawl step's closed result for this Job.</param>
-/// <param name="Document">The loaded page body, so the driver can build the
-/// page-processor <c>PageContext</c> (ADR-0038, the <c>Html</c>).</param>
-public sealed record JobReport(CrawlOutcome Outcome, string Document);
+/// <param name="Page">The loaded page (ADR-0083 <see cref="PageLoadResult"/>):
+/// its <c>Html</c> builds the page-processor <c>PageContext</c> (ADR-0038), and
+/// its status and headers carry the response metadata later slices read.</param>
+public sealed record JobReport(CrawlOutcome Outcome, PageLoadResult Page);

--- a/WebReaper/Core/Loaders/Abstract/IPageCache.cs
+++ b/WebReaper/Core/Loaders/Abstract/IPageCache.cs
@@ -22,11 +22,11 @@ namespace WebReaper.Core.Loaders.Abstract;
 public interface IPageCache
 {
     /// <summary>
-    /// Return the cached document for <paramref name="url"/> at
-    /// <paramref name="pageType"/>, or <c>null</c> if there is no entry or
+    /// Return the cached <see cref="PageLoadResult"/> for <paramref name="url"/>
+    /// at <paramref name="pageType"/>, or <c>null</c> if there is no entry or
     /// the entry is stale by the implementation's policy.
     /// </summary>
-    Task<string?> TryReadAsync(string url, PageType pageType, CancellationToken cancellationToken);
+    Task<PageLoadResult?> TryReadAsync(string url, PageType pageType, CancellationToken cancellationToken);
 
     /// <summary>
     /// Store <paramref name="document"/> for <paramref name="url"/> at
@@ -35,5 +35,5 @@ public interface IPageCache
     /// <see cref="WebReaper.Core.Loaders.Concrete.PageLoader"/> logs and
     /// swallows so a cache write failure never fails the Crawl.
     /// </summary>
-    Task WriteAsync(string url, PageType pageType, string document, CancellationToken cancellationToken);
+    Task WriteAsync(string url, PageType pageType, PageLoadResult document, CancellationToken cancellationToken);
 }

--- a/WebReaper/Core/Loaders/Abstract/IPageLoadTransport.cs
+++ b/WebReaper/Core/Loaders/Abstract/IPageLoadTransport.cs
@@ -11,10 +11,12 @@ public interface IPageLoadTransport
 {
     /// <summary>
     /// Perform the actual fetch for <paramref name="request"/> via this
-    /// mechanism (HTTP or headless browser) and return the page body. Applies
-    /// the optional proxy and this mechanism's client / launch quirks. A page
-    /// that cannot be retrieved is surfaced as an exception, not an empty
-    /// string.
+    /// mechanism (HTTP or headless browser) and return its
+    /// <see cref="PageLoadResult"/> (body plus response status and headers).
+    /// Applies the optional proxy and this mechanism's client / launch quirks.
+    /// A completed response with any status code is returned as data (ADR-0083);
+    /// only a genuine no-response failure is surfaced as a
+    /// <see cref="PageLoadException"/>.
     /// </summary>
-    Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default);
+    Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default);
 }

--- a/WebReaper/Core/Loaders/Abstract/IPageLoader.cs
+++ b/WebReaper/Core/Loaders/Abstract/IPageLoader.cs
@@ -10,11 +10,12 @@ namespace WebReaper.Core.Loaders.Abstract;
 public interface IPageLoader
 {
     /// <summary>
-    /// Fetch the page for <paramref name="request"/> and return its body,
+    /// Fetch the page for <paramref name="request"/> and return its
+    /// <see cref="PageLoadResult"/> (body plus response status and headers),
     /// dispatching on <see cref="PageRequest.PageType"/> to the matching
-    /// <see cref="IPageLoadTransport"/>. A page that cannot be retrieved is
-    /// surfaced as an exception (the transport decides the type), not an empty
-    /// string.
+    /// <see cref="IPageLoadTransport"/>. A completed response with any status
+    /// code is returned as data (ADR-0083); only a genuine no-response failure
+    /// is surfaced as a <see cref="PageLoadException"/>.
     /// </summary>
-    Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default);
+    Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default);
 }

--- a/WebReaper/Core/Loaders/Abstract/PageLoadException.cs
+++ b/WebReaper/Core/Loaders/Abstract/PageLoadException.cs
@@ -1,0 +1,20 @@
+namespace WebReaper.Core.Loaders.Abstract;
+
+/// <summary>
+/// Thrown by a <see cref="IPageLoadTransport"/> when there is no HTTP response
+/// at all (ADR-0083): DNS failure, connection refused, TLS error, or timeout.
+/// A completed response with any status code, including 4xx and 5xx, is
+/// returned as a <see cref="PageLoadResult"/> rather than thrown — a non-2xx is
+/// data, not a fault. This narrows ADR-0004's "a page that cannot be retrieved
+/// is an exception" stance to the genuine no-response case.
+/// </summary>
+public sealed class PageLoadException : Exception
+{
+    /// <summary>Create a load failure with a message and an optional underlying
+    /// transport exception (the <see cref="System.Net.Http.HttpRequestException"/>
+    /// or timeout that caused it).</summary>
+    public PageLoadException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}

--- a/WebReaper/Core/Loaders/Abstract/PageLoadResult.cs
+++ b/WebReaper/Core/Loaders/Abstract/PageLoadResult.cs
@@ -1,0 +1,36 @@
+namespace WebReaper.Core.Loaders.Abstract;
+
+/// <summary>
+/// What a <see cref="IPageLoader"/> / <see cref="IPageLoadTransport"/> returns
+/// for one page (ADR-0083): the page body plus the response metadata a consumer
+/// (or, in later slices, the block detector) needs. Replaces the bare HTML
+/// string the loader returned before, so the library can report an HTTP status
+/// and response headers for the first time.
+/// <para>
+/// Init-only properties, deliberately not a positional record: this is a
+/// growing bag of response metadata consumed by field access, where
+/// deconstruction buys nothing and a positional arity change would break every
+/// transport on each new field. Future fields (FinalUrl, ContentType) land
+/// additively.
+/// </para>
+/// </summary>
+public sealed record PageLoadResult
+{
+    /// <summary>The page body as loaded: the HTTP response body for the HTTP
+    /// transport, or the rendered DOM for a browser transport.</summary>
+    public required string Html { get; init; }
+
+    /// <summary>The HTTP status of the main-document response, or <c>null</c>
+    /// when the transport cannot determine it (for example the CDP transport,
+    /// which does not yet surface the navigation status).</summary>
+    public int? HttpStatus { get; init; }
+
+    /// <summary>The main-document response headers, compared case-insensitively
+    /// by key. Empty when the transport does not surface them.</summary>
+    public IReadOnlyDictionary<string, string> Headers { get; init; } = EmptyHeaders;
+
+    /// <summary>A shared empty, case-insensitive header map, used as the default
+    /// so the common no-headers case allocates nothing.</summary>
+    public static readonly IReadOnlyDictionary<string, string> EmptyHeaders =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+}

--- a/WebReaper/Core/Loaders/Concrete/BrowserNotConfiguredPageLoadTransport.cs
+++ b/WebReaper/Core/Loaders/Concrete/BrowserNotConfiguredPageLoadTransport.cs
@@ -17,7 +17,7 @@ namespace WebReaper.Core.Loaders.Concrete;
 /// </summary>
 internal sealed class BrowserNotConfiguredPageLoadTransport : IPageLoadTransport
 {
-    public Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default) =>
+    public Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default) =>
         throw new InvalidOperationException(
             "Dynamic (headless-browser) page loading requires a browser transport satellite. " +
             "Wire one of:\n" +

--- a/WebReaper/Core/Loaders/Concrete/HttpPageLoadTransport.cs
+++ b/WebReaper/Core/Loaders/Concrete/HttpPageLoadTransport.cs
@@ -30,62 +30,127 @@ internal class HttpPageLoadTransport : IPageLoadTransport
     private readonly ICookiesStorage _cookiesStorage;
     private readonly IProxyProvider? _proxyProvider;
     private readonly ILogger _logger;
+    private readonly Func<HttpMessageHandler>? _handlerFactory;
 
     public HttpPageLoadTransport(ICookiesStorage cookiesStorage, IProxyProvider? proxyProvider, ILogger logger)
+        : this(cookiesStorage, proxyProvider, logger, handlerFactory: null)
     {
-        // The connection limit and cert-bypass live on the per-request
-        // SocketsHttpHandler in LoadAsync (MaxConnectionsPerServer +
-        // SslOptions.RemoteCertificateValidationCallback). The old
+    }
+
+    // Test seam (ADR-0083): inject a stub HttpMessageHandler so the response-
+    // handling behaviour (non-2xx returned as data, header capture, the
+    // no-response PageLoadException) is unit-testable without a live server.
+    // Mirrors SiteMapper's handler-factory pattern. A null factory (production)
+    // builds the per-request SocketsHttpHandler with cookies and the optional
+    // proxy applied; a supplied factory bypasses that and uses the stub.
+    internal HttpPageLoadTransport(
+        ICookiesStorage cookiesStorage,
+        IProxyProvider? proxyProvider,
+        ILogger logger,
+        Func<HttpMessageHandler>? handlerFactory)
+    {
         // ServicePointManager.DefaultConnectionLimit / .ServerCertificateValidationCallback
-        // calls were obsolete (SYSLIB0014) AND inert — ServicePointManager
-        // does not affect HttpClient/SocketsHttpHandler — so they are removed,
-        // not ported. No behavioural change to the request path.
+        // were obsolete (SYSLIB0014) and inert (they do not affect
+        // SocketsHttpHandler), so the connection limit and cert-bypass live on
+        // the per-request SocketsHttpHandler in LoadAsync instead.
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
         _cookiesStorage = cookiesStorage;
         _proxyProvider = proxyProvider;
         _logger = logger;
+        _handlerFactory = handlerFactory;
     }
 
-    public async Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
+    public async Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
     {
         using var _ = _logger.LogMethodDuration();
 
-        var cookies = await _cookiesStorage.GetAsync();
-
-        var handler = new SocketsHttpHandler
+        HttpMessageHandler handler;
+        if (_handlerFactory is not null)
         {
-            MaxConnectionsPerServer = 10000,
-            SslOptions = new SslClientAuthenticationOptions
+            handler = _handlerFactory();
+        }
+        else
+        {
+            var cookies = await _cookiesStorage.GetAsync();
+
+            var socketsHandler = new SocketsHttpHandler
             {
-                // Leave certs unvalidated — parity with the removed requesters.
-                RemoteCertificateValidationCallback = delegate { return true; }
-            },
-            PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2),
-            PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
-            UseCookies = true,
-            CookieContainer = cookies
-        };
+                MaxConnectionsPerServer = 10000,
+                SslOptions = new SslClientAuthenticationOptions
+                {
+                    // Leave certs unvalidated for parity with the removed requesters.
+                    RemoteCertificateValidationCallback = delegate { return true; }
+                },
+                PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2),
+                PooledConnectionLifetime = Timeout.InfiniteTimeSpan,
+                UseCookies = true,
+                CookieContainer = cookies
+            };
 
-        if (_proxyProvider is not null)
-        {
-            handler.UseProxy = true;
-            handler.Proxy = await _proxyProvider.GetProxyAsync();
+            if (_proxyProvider is not null)
+            {
+                socketsHandler.UseProxy = true;
+                socketsHandler.Proxy = await _proxyProvider.GetProxyAsync();
+            }
+
+            handler = socketsHandler;
         }
 
         using var client = new HttpClient(handler);
         client.DefaultRequestHeaders.Add("User-Agent", UserAgent);
 
-        var response = await client.GetAsync(request.Url, cancellationToken);
-
-        if (response.IsSuccessStatusCode)
-            return await response.Content.ReadAsStringAsync(cancellationToken);
-
-        _logger.LogError("Failed to load page {url}. Error code: {statusCode}", request.Url, response.StatusCode);
-
-        throw new InvalidOperationException($"Failed to load page {request.Url}. Error code: {response.StatusCode}")
+        HttpResponseMessage response;
+        try
         {
-            Data = { ["url"] = request.Url, ["statusCode"] = response.StatusCode }
-        };
+            response = await client.GetAsync(request.Url, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            // No response at all (DNS failure, connection refused, TLS error).
+            // ADR-0083: a transport fault, not a status to report.
+            _logger.LogError(ex, "No response loading page {url}", request.Url);
+            throw new PageLoadException($"No response from {request.Url}: {ex.Message}", ex);
+        }
+        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            // A timeout (the caller did not cancel) is also a transport fault.
+            // Genuine caller cancellation propagates as the original
+            // OperationCanceledException so the retry policy does not retry it.
+            throw new PageLoadException($"Timed out loading {request.Url}.", ex);
+        }
+
+        using (response)
+        {
+            // ADR-0083: a completed response is data, whatever its status. The
+            // body, status, and headers all flow back; a non-2xx no longer
+            // throws (the pre-0083 InvalidOperationException, which discarded the
+            // status into Exception.Data, is gone). The block detector and the
+            // CLI escalation read the status/headers in later slices.
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            if (!response.IsSuccessStatusCode)
+                _logger.LogWarning(
+                    "Page {url} returned status {statusCode}", request.Url, (int)response.StatusCode);
+
+            return new PageLoadResult
+            {
+                Html = body,
+                HttpStatus = (int)response.StatusCode,
+                Headers = CollectHeaders(response),
+            };
+        }
+    }
+
+    // Flatten response + content headers into one case-insensitive map. A
+    // multi-value header is joined with ", " (the block detector substring-
+    // matches, so the exact join is immaterial).
+    private static IReadOnlyDictionary<string, string> CollectHeaders(HttpResponseMessage response)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var h in response.Headers)
+            headers[h.Key] = string.Join(", ", h.Value);
+        foreach (var h in response.Content.Headers)
+            headers[h.Key] = string.Join(", ", h.Value);
+        return headers;
     }
 }

--- a/WebReaper/Core/Loaders/Concrete/InMemoryPageCache.cs
+++ b/WebReaper/Core/Loaders/Concrete/InMemoryPageCache.cs
@@ -54,21 +54,21 @@ public sealed class InMemoryPageCache : IPageCache
     }
 
     /// <inheritdoc/>
-    public Task<string?> TryReadAsync(string url, PageType pageType, CancellationToken cancellationToken)
+    public Task<PageLoadResult?> TryReadAsync(string url, PageType pageType, CancellationToken cancellationToken)
     {
-        if (_maxAge == TimeSpan.Zero) return Task.FromResult<string?>(null);
+        if (_maxAge == TimeSpan.Zero) return Task.FromResult<PageLoadResult?>(null);
 
         if (!_entries.TryGetValue(Key(url, pageType), out var entry))
-            return Task.FromResult<string?>(null);
+            return Task.FromResult<PageLoadResult?>(null);
 
         if (_clock() - entry.StoredAt > _maxAge)
-            return Task.FromResult<string?>(null);
+            return Task.FromResult<PageLoadResult?>(null);
 
-        return Task.FromResult<string?>(entry.Document);
+        return Task.FromResult<PageLoadResult?>(entry.Document);
     }
 
     /// <inheritdoc/>
-    public Task WriteAsync(string url, PageType pageType, string document, CancellationToken cancellationToken)
+    public Task WriteAsync(string url, PageType pageType, PageLoadResult document, CancellationToken cancellationToken)
     {
         _entries[Key(url, pageType)] = new Entry(document, _clock());
         return Task.CompletedTask;
@@ -81,5 +81,5 @@ public sealed class InMemoryPageCache : IPageCache
     // Dynamic load of the same URL can return different HTML.
     private static string Key(string url, PageType pageType) => $"{pageType}:{url}";
 
-    private readonly record struct Entry(string Document, DateTimeOffset StoredAt);
+    private readonly record struct Entry(PageLoadResult Document, DateTimeOffset StoredAt);
 }

--- a/WebReaper/Core/Loaders/Concrete/NullPageCache.cs
+++ b/WebReaper/Core/Loaders/Concrete/NullPageCache.cs
@@ -11,9 +11,9 @@ namespace WebReaper.Core.Loaders.Concrete;
 /// </summary>
 internal sealed class NullPageCache : IPageCache
 {
-    public Task<string?> TryReadAsync(string url, PageType pageType, CancellationToken cancellationToken)
-        => Task.FromResult<string?>(null);
+    public Task<PageLoadResult?> TryReadAsync(string url, PageType pageType, CancellationToken cancellationToken)
+        => Task.FromResult<PageLoadResult?>(null);
 
-    public Task WriteAsync(string url, PageType pageType, string document, CancellationToken cancellationToken)
+    public Task WriteAsync(string url, PageType pageType, PageLoadResult document, CancellationToken cancellationToken)
         => Task.CompletedTask;
 }

--- a/WebReaper/Core/Loaders/Concrete/PageLoader.cs
+++ b/WebReaper/Core/Loaders/Concrete/PageLoader.cs
@@ -34,7 +34,7 @@ internal class PageLoader : IPageLoader
         _cache = cache ?? new NullPageCache();
     }
 
-    public async Task<string> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
+    public async Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Loading {PageType} page {Url}", request.PageType, request.Url);
 

--- a/WebReaper/Core/ScraperEngine.cs
+++ b/WebReaper/Core/ScraperEngine.cs
@@ -240,7 +240,7 @@ public class ScraperEngine : IAsyncDisposable
                         // the surviving-record return — the crawl path fires and
                         // forgets).
                         Logger.LogInvocationCount();
-                        await _pipeline.ProcessAndEmitAsync(parsed.Data, report.Document,
+                        await _pipeline.ProcessAndEmitAsync(parsed.Data, report.Page.Html,
                             job.ParentBacklinks.ToList(), config.ParsingScheme, token);
                         newJobs = new List<Job>();
                     }
@@ -254,7 +254,7 @@ public class ScraperEngine : IAsyncDisposable
                         // is also what terminates the sweep when the on-domain
                         // frontier saturates.
                         Logger.LogInvocationCount();
-                        await _pipeline.ProcessAndEmitAsync(swept.Data, report.Document,
+                        await _pipeline.ProcessAndEmitAsync(swept.Data, report.Page.Html,
                             job.ParentBacklinks.ToList(), config.ParsingScheme, token);
                         newJobs = swept.Next.ToList();
                     }

--- a/WebReaper/Core/Spider/Concrete/Spider.cs
+++ b/WebReaper/Core/Spider/Concrete/Spider.cs
@@ -48,12 +48,12 @@ internal class Spider : ISpider
 
     public async Task<JobReport> CrawlAsync(Job job, CancellationToken cancellationToken = default)
     {
-        var doc = await PageLoader.LoadAsync(
+        var page = await PageLoader.LoadAsync(
             new PageRequest(job.Url, job.PageType, job.PageActions, Headless),
             cancellationToken);
 
-        var outcome = await CrawlStep.StepAsync(job, doc, ParsingScheme);
+        var outcome = await CrawlStep.StepAsync(job, page.Html, ParsingScheme);
 
-        return new JobReport(outcome, doc);
+        return new JobReport(outcome, page);
     }
 }


### PR DESCRIPTION
Implements **slice 1 of ADR-0083** (closes #171; parent #170). The foundational spine of the escalating-loader work: no detection or climbing yet, just the richer return value flowing end to end.

## What changed

- **Contract widened**: `IPageLoader.LoadAsync` and `IPageLoadTransport.LoadAsync` return `Task<PageLoadResult>` (init-only record: `Html`, `HttpStatus`, `Headers`) instead of `Task<string>`. **v11 major break.**
- **Failure contract narrowed**: a completed HTTP response of any status (200/403/503) is returned as data; only a genuine no-response failure (DNS, connection refused, TLS, timeout) throws, now as a typed `PageLoadException`. This reverses ADR-0004's "non-2xx is an exception" stance, so `webreaper scrape <403-url>` no longer stack-traces, and the library can report an HTTP status for the first time.
- **Transports**: `HttpPageLoadTransport` returns non-2xx as data + captures status/headers (with an internal handler-factory test seam, the `SiteMapper` pattern); `PlaywrightPageLoadTransport` captures status + headers from the navigation response; `CdpPageLoadTransport` returns the DOM with a null status (main-document status capture is the ADR-named follow-up).
- **Cache**: `IPageCache` / `InMemoryPageCache` / `NullPageCache` now cache `PageLoadResult`.
- **Threading**: `JobReport` carries the `PageLoadResult`; the Crawl driver and Spider read `Page.Html`. `AgentEngine` now uses the real HTTP status instead of synthesizing it.
- **Retry**: with non-2xx no longer throwing, the retry policy (ADR-0026) now retries only genuine transport faults. No policy code change.
- **`CONTEXT.md`**: adds the `PageLoadResult` and `PageLoadException` glossary terms; updates the page-loader / load-transport defs.

## Tests

- New `HttpPageLoadTransportTests`: non-2xx returned as data (403/429/503), 2xx surfaces status + headers (case-insensitive), no-response throws `PageLoadException`.
- Existing loader / cache / spider / driver test stubs adapted to the new contract.
- Full solution build clean (Examples/ and Misc/ included). Offline tests: **UnitTests 499**, **AI.Tests 274**, **Cli.Tests 125**, all green.

Next: slice 2 (#172) adds the core `IBlockDetector` over this result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)