### PR TITLE
feat(blocking): core IBlockDetector seam + BlockVerdict (ADR-0083 slice 2)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -210,6 +210,20 @@ _Avoid_: response, page, document (that was the old string return).
 What a **load transport** throws when there is no HTTP response at all (ADR-0083): DNS failure, connection refused, TLS error, or timeout. A completed response with any status code, including 4xx and 5xx, is returned as a **page load result**, not thrown; a non-2xx is data, not a fault. This narrows ADR-0004's "a page that cannot be retrieved is an exception" stance to the genuine no-response case, and means the **retry policy** retries only these transport faults, never an HTTP status.
 _Avoid_: load error, HTTP error, fetch failure.
 
+### Block detection
+
+**Block detector**:
+The core `IBlockDetector` seam plus its default `BlockDetector`; a pure classifier over a **page load result** (status, headers, body) that answers "am I being blocked?". It reports, it does not act (ADR-0083); the verdict is data the **Crawl driver** reads, never a thrown signal. Ships in core (blocking is a core scraping concern), runs on every loaded page inside the Spider; swap it via `WithBlockDetector`.
+_Avoid_: bot-check detector (that is the ADR-0056 CLI ancestor), challenge classifier, anti-bot guard.
+
+**Block verdict**:
+The `BlockVerdict` a **block detector** returns: a `BlockConfidence` tier (None, Weak, or High) plus a reason string. High = a challenge-class HTTP status (403 / 429 / 503) or a challenge-signalling response header; Weak = a challenge-structural body marker. Record count is not an input (it re-enters the decision at the driver in a later slice, which is what keeps a weak body-marker false positive from destroying a real page).
+_Avoid_: block result, detection result, score.
+
+**Blocked page**:
+A **page load result** the **block detector** classifies as a challenge (`IsBlocked`, i.e. confidence above None). Load-stage and reliable: it is read straight off the response, before extraction. It drives escalation and suppression in later slices; for now the **Crawl driver** only tallies it into the **run report**'s `BlockedPageCount`. Distinct from an Empty result (zero extracted records), which is a weaker extraction-stage hint.
+_Avoid_: blocked response, challenge page, captcha page.
+
 ### Wiring
 
 **Core adapter**:

--- a/WebReaper.Cli/Commands/ScrapeCommand.cs
+++ b/WebReaper.Cli/Commands/ScrapeCommand.cs
@@ -33,8 +33,7 @@ internal static class ScrapeCommand
         if (!ctx.Browser)
         {
             WriteEmptyHint(ctx, first.Records.Count);
-            await RecordOutput.WriteAsync(first.Records, ctx.Output);
-            return 0;
+            return await ShipAsync(ctx, first);
         }
 
         // ADR-0056: conservative bot-check detector. Runs over the last
@@ -48,8 +47,7 @@ internal static class ScrapeCommand
         if (!verdict.LikelyBlocked)
         {
             WriteEmptyHint(ctx, first.Records.Count);
-            await RecordOutput.WriteAsync(first.Records, ctx.Output);
-            return 0;
+            return await ShipAsync(ctx, first);
         }
 
         // Block detected. Choose action per ctx.
@@ -61,8 +59,7 @@ internal static class ScrapeCommand
             // result is what we ship.
             Console.Error.WriteLine(
                 "⚠  Auto-stealth disabled (--no-auto-stealth); retry manually with --stealth.");
-            await RecordOutput.WriteAsync(first.Records, ctx.Output);
-            return 0;
+            return await ShipAsync(ctx, first);
         }
 
         if (!ctx.AutoStealth)
@@ -74,8 +71,7 @@ internal static class ScrapeCommand
             if (!string.IsNullOrEmpty(reply) && !reply.Equals("y", StringComparison.OrdinalIgnoreCase))
             {
                 Console.Error.WriteLine("Aborted; shipping first-attempt result.");
-                await RecordOutput.WriteAsync(first.Records, ctx.Output);
-                return 0;
+                return await ShipAsync(ctx, first);
             }
         }
 
@@ -117,7 +113,26 @@ internal static class ScrapeCommand
             return 1;
         }
 
-        await RecordOutput.WriteAsync(retry.Records, ctx.Output);
+        return await ShipAsync(ctx, retry);
+    }
+
+    // ----- ship the records, block-aware exit code (ADR-0083) -----
+
+    // Write the attempt's records to the configured output, then return the
+    // exit code: non-zero when the core block detector flagged any page this run
+    // (the load looked like a bot-check challenge), zero otherwise. Additive to
+    // the ADR-0056 BotCheckDetector escalation — that heuristic decides whether
+    // to *retry* with stealth; this tally decides the *exit code* of whatever
+    // result we ship, so an unattended caller can detect a blocked scrape.
+    private static async Task<int> ShipAsync(ScrapeContext ctx, AttemptResult attempt)
+    {
+        await RecordOutput.WriteAsync(attempt.Records, ctx.Output);
+        if (attempt.BlockedPageCount > 0)
+        {
+            Console.Error.WriteLine(
+                $"⚠  {attempt.BlockedPageCount} page(s) looked blocked; the site may use bot protection.");
+            return 1;
+        }
         return 0;
     }
 
@@ -136,7 +151,9 @@ internal static class ScrapeCommand
 
     // ----- single scrape attempt -----
 
-    internal sealed record AttemptResult(List<ParsedData> Records, string? LastHtml);
+    // ADR-0083: BlockedPageCount carries the block detector's run-level tally
+    // out of the engine so RunAsync can warn + exit non-zero on a blocked load.
+    internal sealed record AttemptResult(List<ParsedData> Records, string? LastHtml, int BlockedPageCount);
 
     private static async Task<AttemptResult> RunOnceAsync(
         ScrapeContext ctx, string? stealthExecutablePath)
@@ -187,10 +204,14 @@ internal static class ScrapeCommand
         // exit — including any builder-time-spawned subprocess (managed
         // Chromium, stealth binary on retry). Per-attempt cleanup makes
         // the retry path correct (no two-Chromiums-running window).
+        // ADR-0083: capture the RunReport so the block detector's tally
+        // surfaces to the caller (warning + non-zero exit on a blocked load).
         string? lastHtml = null;
+        var blockedPageCount = 0;
         await using (var engine = await builder.BuildAsync())
         {
-            await engine.RunAsync();
+            var report = await engine.RunAsync();
+            blockedPageCount = report.BlockedPageCount;
         }
 
         // ADR-0056 detector input: approximate the rendered HTML from the
@@ -204,7 +225,7 @@ internal static class ScrapeCommand
             lastHtml = records[^1].Data.ToJsonString();
         }
 
-        return new AttemptResult(records, lastHtml);
+        return new AttemptResult(records, lastHtml, blockedPageCount);
     }
 
     // ----- self-invocation helpers -----

--- a/WebReaper.Tests/WebReaper.IntegrationTests/BlockDetectionTests.cs
+++ b/WebReaper.Tests/WebReaper.IntegrationTests/BlockDetectionTests.cs
@@ -1,0 +1,64 @@
+using WebReaper.Builders;
+using WebReaper.IntegrationTests.Fixtures;
+using WebReaper.TestServer;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace WebReaper.IntegrationTests;
+
+/// <summary>
+/// ADR-0083 slice 2: end-to-end detect-and-tally wiring. Drives the in-process
+/// Crawl driver against <c>/fail?status=403</c> — a 403 is data, not a fault,
+/// since slice 1 (the page loads), so the block detector flags it (HTTP 403 =
+/// High) and the driver increments
+/// <see cref="WebReaper.Domain.Telemetry.RunReport.BlockedPageCount"/>. Pins
+/// the Spider → JobReport → driver → RunReport path through the real engine.
+/// </summary>
+[Collection("LocalSite")]
+[Trait("Category", "LocalServer")]
+public sealed class BlockDetectionTests
+{
+    private readonly LocalTestSite _site;
+    private readonly ITestOutputHelper _output;
+
+    public BlockDetectionTests(LocalSiteFixture fixture, ITestOutputHelper output)
+    {
+        _site = fixture.Site;
+        _output = output;
+    }
+
+    [Fact]
+    public async Task A_403_load_is_tallied_as_a_blocked_page_in_the_run_report()
+    {
+        const string key = "block-403";
+
+        await using var engine = await ScraperEngineBuilder
+            .Crawl(_site.Url($"/fail?key={key}&status=403&times=99"))
+            .AsMarkdown()
+            .WithLogger(new TestOutputLogger(_output))
+            .StopWhenAllLinksProcessed()
+            .BuildAsync();
+
+        var report = await engine.RunAsync();
+
+        Assert.Equal(1, report.BlockedPageCount);   // the single 403 load was flagged
+        Assert.Equal(1, _site.FailHits(key));        // requested once (403 is data, not retried)
+    }
+
+    [Fact]
+    public async Task A_clean_200_load_is_not_tallied_as_blocked()
+    {
+        // Control: a normal page must leave BlockedPageCount at 0, so a passing
+        // assertion above is a real signal and not a constant.
+        await using var engine = await ScraperEngineBuilder
+            .Crawl(_site.Url("/static"))
+            .AsMarkdown()
+            .WithLogger(new TestOutputLogger(_output))
+            .StopWhenAllLinksProcessed()
+            .BuildAsync();
+
+        var report = await engine.RunAsync();
+
+        Assert.Equal(0, report.BlockedPageCount);
+    }
+}

--- a/WebReaper.Tests/WebReaper.UnitTests/BlockDetectorTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/BlockDetectorTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using WebReaper.Core.Blocking.Abstract;
+using WebReaper.Core.Blocking.Concrete;
+using WebReaper.Core.Loaders.Abstract;
+
+namespace WebReaper.UnitTests;
+
+/// <summary>
+/// ADR-0083 slice 1 core classifier. The default <see cref="BlockDetector"/> is
+/// a pure function over a <see cref="PageLoadResult"/> (status, headers, body).
+/// High = challenge-class status or a challenge header; Weak = a body marker;
+/// None = a clean page. Record count is deliberately NOT an input. Prior art:
+/// <c>BotCheckDetectorTests</c> (the ADR-0056 CLI ancestor this ports).
+/// </summary>
+public class BlockDetectorTests
+{
+    private static readonly BlockDetector Sut = new();
+
+    private static PageLoadResult Page(
+        string html = "<html><body>ok</body></html>",
+        int? status = 200,
+        params (string Key, string Value)[] headers)
+    {
+        var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (k, v) in headers) dict[k] = v;
+        return new PageLoadResult { Html = html, HttpStatus = status, Headers = dict };
+    }
+
+    // ---- High: challenge-class HTTP status ----
+
+    [Theory]
+    [InlineData(403)]
+    [InlineData(429)]
+    [InlineData(503)]
+    public void Challenge_class_status_is_High(int status)
+    {
+        var v = Sut.Detect(Page(status: status));
+
+        Assert.Equal(BlockConfidence.High, v.Confidence);
+        Assert.True(v.IsBlocked);
+    }
+
+    // ---- High: challenge-signalling response header ----
+
+    [Fact]
+    public void Challenge_header_on_a_clean_200_is_High()
+    {
+        // cf-mitigated is the curated challenge header; 200 status + clean body
+        // would otherwise be None, so the verdict must come from the header.
+        var v = Sut.Detect(Page(status: 200, headers: ("cf-mitigated", "challenge")));
+
+        Assert.Equal(BlockConfidence.High, v.Confidence);
+        Assert.True(v.IsBlocked);
+    }
+
+    // ---- Weak: body marker ----
+
+    public static IEnumerable<object[]> WeakBodyMarkers =>
+        BlockDetector.WeakBodyMarkers.Select(m => new object[] { m });
+
+    [Theory]
+    [MemberData(nameof(WeakBodyMarkers))]
+    public void Body_marker_on_a_clean_200_is_Weak(string marker)
+    {
+        var html = $"<html><body><div>{marker}</div></body></html>";
+        var v = Sut.Detect(Page(html: html, status: 200));
+
+        Assert.Equal(BlockConfidence.Weak, v.Confidence);
+        Assert.True(v.IsBlocked);
+    }
+
+    // ---- None: clean page ----
+
+    [Fact]
+    public void Clean_200_with_no_markers_or_headers_is_None()
+    {
+        var v = Sut.Detect(Page(html: "<html><body><h1>Hello</h1></body></html>", status: 200));
+
+        Assert.Equal(BlockConfidence.None, v.Confidence);
+        Assert.False(v.IsBlocked);
+    }
+
+    // ---- None: bare vendor names were deliberately dropped (ADR-0083) ----
+
+    [Theory]
+    [InlineData("DataDome")]
+    [InlineData("Akamai")]
+    public void Bare_vendor_name_without_a_structural_marker_is_None(string vendor)
+    {
+        // "DataDome" / "Akamai" appear in legitimate content; the marker list
+        // was tightened to drop them. A page that merely mentions the vendor
+        // (no structural marker like dd-rd / ak_bmsc / /akam/) is not a block.
+        var html = $"<html><body><p>Protected by {vendor}.</p></body></html>";
+        var v = Sut.Detect(Page(html: html, status: 200));
+
+        Assert.Equal(BlockConfidence.None, v.Confidence);
+        Assert.False(v.IsBlocked);
+    }
+
+    // ---- None: WAF-presence header is not a block ----
+
+    [Fact]
+    public void WAF_presence_header_on_a_clean_200_is_None()
+    {
+        // cf-ray is on ALL Cloudflare traffic, blocked or not, so it is
+        // deliberately excluded from the challenge-header set; it must not fire.
+        var v = Sut.Detect(Page(status: 200, headers: ("cf-ray", "7a1b2c3d4e5f6789")));
+
+        Assert.Equal(BlockConfidence.None, v.Confidence);
+        Assert.False(v.IsBlocked);
+    }
+}

--- a/WebReaper.Tests/WebReaper.UnitTests/EngineStopWhenDrainedTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/EngineStopWhenDrainedTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using Microsoft.Extensions.Logging.Abstractions;
 using WebReaper.ConfigStorage.Abstract;
 using WebReaper.Core;
+using WebReaper.Core.Blocking.Abstract;
 using WebReaper.Core.Crawling;
 using WebReaper.Core.LinkTracker.Concrete;
 using WebReaper.Core.Loaders.Abstract;
@@ -38,7 +39,10 @@ namespace WebReaper.UnitTests
                         new Job("child-2", ImmutableQueue<LinkPathSelector>.Empty, ImmutableQueue<string>.Empty))
                     : ImmutableArray<Job>.Empty;
 
-                return Task.FromResult(new JobReport(CrawlOutcome.Transit(children), new PageLoadResult { Html = string.Empty }));
+                return Task.FromResult(new JobReport(
+                    CrawlOutcome.Transit(children),
+                    new PageLoadResult { Html = string.Empty },
+                    BlockVerdict.None));
             }
         }
 

--- a/WebReaper.Tests/WebReaper.UnitTests/ScraperEngineDriverTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/ScraperEngineDriverTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging.Abstractions;
 using WebReaper.ConfigStorage.Abstract;
 using WebReaper.Core;
+using WebReaper.Core.Blocking.Abstract;
 using WebReaper.Core.Crawling;
 using WebReaper.Core.LinkTracker.Concrete;
 using WebReaper.Core.Loaders.Abstract;
@@ -134,14 +135,19 @@ public class ScraperEngineDriverTests
         PageCrawlLimit: limit,
         StopWhenDrained: stopWhenDrained);
 
+    // ADR-0083: these driver tests exercise outcome handling, not block
+    // detection, so the JobReport carries the not-blocked verdict.
     private static JobReport Followed(params string[] urls) =>
         new(CrawlOutcome.Transit(urls
                 .Select(u => new Job(u, ImmutableQueue<LinkPathSelector>.Empty, ImmutableQueue<string>.Empty))
                 .ToImmutableArray()),
-            new PageLoadResult { Html = string.Empty });
+            new PageLoadResult { Html = string.Empty },
+            BlockVerdict.None);
 
     private static JobReport Parsed(string url) =>
-        new(CrawlOutcome.Target(new ParsedData(url, new JsonObject())), new PageLoadResult { Html = "<html/>" });
+        new(CrawlOutcome.Target(new ParsedData(url, new JsonObject())),
+            new PageLoadResult { Html = "<html/>" },
+            BlockVerdict.None);
 
     private static JobReport Swept(string url, params string[] children) =>
         new(CrawlOutcome.Sweep(
@@ -151,7 +157,8 @@ public class ScraperEngineDriverTests
                         ImmutableQueue.CreateRange(new[] { LinkPathSelector.Sweep() }),
                         ImmutableQueue<string>.Empty))
                     .ToImmutableArray()),
-            new PageLoadResult { Html = "<html/>" });
+            new PageLoadResult { Html = "<html/>" },
+            BlockVerdict.None);
 
     [Fact]
     public async Task Swept_page_both_emits_its_record_and_follows_its_children_until_the_frontier_saturates()

--- a/WebReaper.Tests/WebReaper.UnitTests/SpiderTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/SpiderTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.Extensions.Logging.Abstractions;
+using WebReaper.Core.Blocking.Abstract;
+using WebReaper.Core.Blocking.Concrete;
 using WebReaper.Core.Crawling;
 using WebReaper.Core.Crawling.Concrete;
 using WebReaper.Core.Loaders.Abstract;
@@ -38,9 +40,13 @@ public class SpiderTests
     private static CrawlStep CrawlStep() =>
         new(new SchemaFold<AngleSharp.Dom.IParentNode>(new AngleSharpSchemaBackend(), NullLogger.Instance));
 
+    // ADR-0083: the shell now also takes an IBlockDetector. The real core
+    // BlockDetector keeps these tests faithful — a clean fake page yields a
+    // None verdict on the JobReport, asserted below.
     private static Core.Spider.Concrete.Spider Spider(
-        IPageLoader loader, Schema? schema, bool headless = true) =>
-        new(CrawlStep(), loader, headless, schema);
+        IPageLoader loader, Schema? schema, bool headless = true,
+        IBlockDetector? blockDetector = null) =>
+        new(CrawlStep(), loader, blockDetector ?? new BlockDetector(), headless, schema);
 
     private static Job Job(string url, params LinkPathSelector[] chain) =>
         new(url, ImmutableQueue.CreateRange(chain), ImmutableQueue.Create<string>());
@@ -60,6 +66,33 @@ public class SpiderTests
         Assert.Equal("Hello", parsed.Data.Data["title"]?.ToString());
         Assert.Equal(html, report.Page.Html);          // the doc the driver needs for PageContext
         Assert.Empty(report.Outcome.NextJobs);
+        // ADR-0083: the shell ran the block detector and carried its verdict —
+        // a clean 200 fake page is not a block.
+        Assert.Equal(BlockConfidence.None, report.Block.Confidence);
+        Assert.False(report.Block.IsBlocked);
+    }
+
+    [Fact]
+    public async Task A_blocked_load_is_reported_on_the_job_report()
+    {
+        // ADR-0083: the verdict is the detector's, threaded through unchanged.
+        // A stub detector returning High proves the shell calls Detect(page) and
+        // carries the result onto the JobReport (independent of the outcome).
+        var report = await Spider(
+                new FakeLoader("<html><body>ok</body></html>"),
+                schema: null,
+                blockDetector: new StubBlockDetector(
+                    new BlockVerdict(BlockConfidence.High, "stub")))
+            .CrawlAsync(Job("https://x.test/", new LinkPathSelector("a.item")));
+
+        Assert.True(report.Block.IsBlocked);
+        Assert.Equal(BlockConfidence.High, report.Block.Confidence);
+        Assert.Equal("stub", report.Block.Reason);
+    }
+
+    private sealed class StubBlockDetector(BlockVerdict verdict) : IBlockDetector
+    {
+        public BlockVerdict Detect(PageLoadResult result) => verdict;
     }
 
     [Fact]

--- a/WebReaper/Builders/DistributedSpiderBuilder.cs
+++ b/WebReaper/Builders/DistributedSpiderBuilder.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
 using WebReaper.Core.Actions.Abstract;
+using WebReaper.Core.Blocking.Abstract;
 using WebReaper.Core.CookieStorage.Abstract;
 using WebReaper.Core.Loaders.Abstract;
 using WebReaper.Core.Parser.Abstract;
@@ -136,6 +137,21 @@ public class DistributedSpiderBuilder
     public DistributedSpiderBuilder WithCookieStorage(ICookiesStorage cookiesStorage)
     {
         _spiderBuilder.WithCookieStorage(cookiesStorage);
+        return this;
+    }
+
+    /// <summary>Register a custom <see cref="IBlockDetector"/> (ADR-0083); the
+    /// default is the core
+    /// <see cref="WebReaper.Core.Blocking.Concrete.BlockDetector"/>. The
+    /// distributed worker's Spider runs it on every loaded page and carries the
+    /// verdict on the <see cref="WebReaper.Core.Crawling.JobReport"/> the worker
+    /// receives from <c>spider.CrawlAsync(job)</c> — reporting only (ADR-0083),
+    /// the worker decides what to do with it.</summary>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="blockDetector"/> is null.</exception>
+    public DistributedSpiderBuilder WithBlockDetector(IBlockDetector blockDetector)
+    {
+        _spiderBuilder.WithBlockDetector(blockDetector);
         return this;
     }
 

--- a/WebReaper/Builders/ScraperEngineBuilder.cs
+++ b/WebReaper/Builders/ScraperEngineBuilder.cs
@@ -7,6 +7,7 @@ using WebReaper.ConfigStorage.Concrete;
 using WebReaper.Core;
 using WebReaper.Core.Actions.Abstract;
 using WebReaper.Core.Actions.Concrete;
+using WebReaper.Core.Blocking.Abstract;
 using WebReaper.Core.CookieStorage.Abstract;
 using WebReaper.Core.LinkTracker.Abstract;
 using WebReaper.Core.LinkTracker.Concrete;
@@ -861,6 +862,26 @@ public class ScraperEngineBuilder
     public ScraperEngineBuilder WithRetryPolicy(IRetryPolicy retryPolicy)
     {
         SpiderBuilder.WithRetryPolicy(retryPolicy);
+        return this;
+    }
+
+    /// <summary>
+    /// Register a custom <see cref="IBlockDetector"/> (ADR-0083) — the
+    /// classifier the Spider runs on every loaded page to decide whether the
+    /// load looked like a bot-check challenge. The default is the core
+    /// <see cref="WebReaper.Core.Blocking.Concrete.BlockDetector"/> (HTTP status
+    /// / challenge-header / body-marker heuristic). Detection is reporting, not
+    /// acting: the verdict is tallied into
+    /// <see cref="WebReaper.Domain.Telemetry.RunReport.BlockedPageCount"/>; the
+    /// escalation / suppression decisions land in later slices. Supply your own
+    /// to tune or replace the heuristic.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="detector"/> is null.</exception>
+    public ScraperEngineBuilder WithBlockDetector(IBlockDetector detector)
+    {
+        ArgumentNullException.ThrowIfNull(detector);
+        SpiderBuilder.WithBlockDetector(detector);
         return this;
     }
 

--- a/WebReaper/Builders/SpiderBuilder.cs
+++ b/WebReaper/Builders/SpiderBuilder.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using System.Text.Json.Nodes;
 using WebReaper.Core.Actions.Abstract;
 using WebReaper.Core.Actions.Concrete;
+using WebReaper.Core.Blocking.Abstract;
 using WebReaper.Core.CookieStorage.Abstract;
 using WebReaper.Core.CookieStorage.Concrete;
 using WebReaper.Core.LinkTracker.Abstract;
@@ -81,6 +82,14 @@ internal class SpiderBuilder
     // + three retries, the pre-0026 behaviour). Replaced via
     // ScraperEngineBuilder.WithRetryPolicy.
     private IRetryPolicy RetryPolicy { get; set; } = new FixedAttemptsRetryPolicy();
+
+    // ADR-0083: the block detector the Spider runs on every loaded page. The
+    // default core BlockDetector ("am I being blocked?" is a core scraping
+    // concern); replaced via ScraperEngineBuilder.WithBlockDetector. Type
+    // fully-qualified so the field initializer is unambiguous against the
+    // same-named property.
+    private IBlockDetector BlockDetector { get; set; } =
+        new Core.Blocking.Concrete.BlockDetector();
 
     public SpiderBuilder WithContentExtractor(IContentExtractor extractor)
     {
@@ -256,6 +265,15 @@ internal class SpiderBuilder
         return this;
     }
 
+    /// <summary>Register a custom <see cref="IBlockDetector"/> (ADR-0083); the
+    /// default is the core <see cref="Core.Blocking.Concrete.BlockDetector"/>.</summary>
+    public SpiderBuilder WithBlockDetector(IBlockDetector blockDetector)
+    {
+        ArgumentNullException.ThrowIfNull(blockDetector);
+        BlockDetector = blockDetector;
+        return this;
+    }
+
     /// <summary>Register a custom <see cref="IPageCache"/> (ADR-0041);
     /// the default is <see cref="NullPageCache"/> (no cache).</summary>
     public SpiderBuilder WithPageCache(IPageCache cache)
@@ -325,6 +343,7 @@ internal class SpiderBuilder
         var spider = new Spider(
             crawlStep,
             PageLoader,
+            BlockDetector,
             Config!.Headless,
             Config.ParsingScheme);
 

--- a/WebReaper/Core/Blocking/Abstract/BlockConfidence.cs
+++ b/WebReaper/Core/Blocking/Abstract/BlockConfidence.cs
@@ -1,0 +1,23 @@
+namespace WebReaper.Core.Blocking.Abstract;
+
+/// <summary>
+/// How strongly a <see cref="IBlockDetector"/> believes a page is a bot-check
+/// challenge (ADR-0083). A tier, not just a bool, because later slices branch on
+/// it: a high-confidence block drops the page outright, a weak one drops only
+/// when extraction also produced nothing, and only a high-confidence block lifts
+/// a host's escalation floor.
+/// </summary>
+public enum BlockConfidence
+{
+    /// <summary>Not a block.</summary>
+    None,
+
+    /// <summary>A body-marker-only signal: a challenge string appeared in the
+    /// page HTML. Weak because such strings can also appear in legitimate
+    /// content.</summary>
+    Weak,
+
+    /// <summary>A challenge-class HTTP status or a challenge-signalling response
+    /// header. High because a normal page does not carry these.</summary>
+    High,
+}

--- a/WebReaper/Core/Blocking/Abstract/BlockVerdict.cs
+++ b/WebReaper/Core/Blocking/Abstract/BlockVerdict.cs
@@ -1,0 +1,20 @@
+namespace WebReaper.Core.Blocking.Abstract;
+
+/// <summary>
+/// The result of a <see cref="IBlockDetector"/> pass over one
+/// <see cref="WebReaper.Core.Loaders.Abstract.PageLoadResult"/> (ADR-0083): the
+/// confidence tier plus a human-readable reason for the firing signal. Carried
+/// on the Job report so the Crawl driver can act on it without reclassifying.
+/// </summary>
+/// <param name="Confidence">How strongly the page looks like a challenge;
+/// <see cref="BlockConfidence.None"/> means not blocked.</param>
+/// <param name="Reason">A one-line description of the firing signal, or
+/// <c>null</c> when not blocked.</param>
+public sealed record BlockVerdict(BlockConfidence Confidence, string? Reason)
+{
+    /// <summary>Whether the page is a bot-check challenge at all.</summary>
+    public bool IsBlocked => Confidence != BlockConfidence.None;
+
+    /// <summary>The not-blocked verdict.</summary>
+    public static readonly BlockVerdict None = new(BlockConfidence.None, null);
+}

--- a/WebReaper/Core/Blocking/Abstract/IBlockDetector.cs
+++ b/WebReaper/Core/Blocking/Abstract/IBlockDetector.cs
@@ -1,0 +1,19 @@
+using WebReaper.Core.Loaders.Abstract;
+
+namespace WebReaper.Core.Blocking.Abstract;
+
+/// <summary>
+/// The core seam that classifies one loaded page as a bot-check challenge or
+/// not (ADR-0083), purely from its <see cref="PageLoadResult"/> (status,
+/// headers, body). "Am I being blocked?" is a core scraping concern, so the
+/// default <c>BlockDetector</c> ships in core; swap it via
+/// <c>ScraperEngineBuilder.WithBlockDetector(...)</c>. Detection is reporting,
+/// not acting: the <see cref="BlockVerdict"/> is data the Crawl driver acts on
+/// (later slices), never a thrown exception.
+/// </summary>
+public interface IBlockDetector
+{
+    /// <summary>Classify <paramref name="result"/>. Pure: the same input always
+    /// produces the same verdict, and it never throws.</summary>
+    BlockVerdict Detect(PageLoadResult result);
+}

--- a/WebReaper/Core/Blocking/Concrete/BlockDetector.cs
+++ b/WebReaper/Core/Blocking/Concrete/BlockDetector.cs
@@ -1,0 +1,89 @@
+using WebReaper.Core.Blocking.Abstract;
+using WebReaper.Core.Loaders.Abstract;
+
+namespace WebReaper.Core.Blocking.Concrete;
+
+/// <summary>
+/// The default <see cref="IBlockDetector"/> (ADR-0083): a pure heuristic over a
+/// <see cref="PageLoadResult"/>'s status, headers, and body. Ports the ADR-0056
+/// CLI bot-check detector and adds the response-header signal the loader
+/// widening unlocked. Record count is deliberately NOT an input (ADR-0083): it
+/// is an extraction-stage fact the Crawl driver folds into its drop decision one
+/// layer up, which is what keeps a weak body-marker false positive from
+/// destroying a real page.
+/// </summary>
+/// <remarks>
+/// Confidence tiers:
+/// <list type="bullet">
+///   <item><b>High</b>: a challenge-class HTTP status (403 / 429 / 503), or a
+///   challenge-signalling response header. A normal page carries neither.</item>
+///   <item><b>Weak</b>: a challenge-structural string in the body HTML. The
+///   marker list is tightened from ADR-0056 to drop bare vendor names
+///   ("DataDome", "Akamai") that appear in legitimate content, because under
+///   page suppression and host-stickiness (later slices) a false positive is
+///   costly.</item>
+/// </list>
+/// </remarks>
+public sealed class BlockDetector : IBlockDetector
+{
+    /// <inheritdoc/>
+    public BlockVerdict Detect(PageLoadResult result)
+    {
+        // High: a challenge-class HTTP status, independent of the body.
+        if (result.HttpStatus is 403 or 429 or 503)
+            return new BlockVerdict(BlockConfidence.High,
+                $"HTTP {result.HttpStatus}: a challenge-class status.");
+
+        // High: a challenge-signalling response header. Kept high-precision: a
+        // mere "behind a WAF" header (e.g. cf-ray, which is present on ALL
+        // Cloudflare traffic, blocked or not) is NOT a block signal and would
+        // false-positive on every Cloudflare-fronted site, so it is excluded.
+        foreach (var key in ChallengeHeaderKeys)
+            if (result.Headers.ContainsKey(key))
+                return new BlockVerdict(BlockConfidence.High,
+                    $"Challenge-signalling response header: '{key}'.");
+
+        // Weak: a challenge-structural marker in the body.
+        if (!string.IsNullOrWhiteSpace(result.Html))
+        {
+            foreach (var marker in WeakBodyMarkers)
+                if (result.Html.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                    return new BlockVerdict(BlockConfidence.Weak,
+                        $"Challenge marker in body: '{marker}'.");
+        }
+
+        return BlockVerdict.None;
+    }
+
+    // High-confidence challenge response-header keys (looked up case-insensitively
+    // via PageLoadResult.Headers). Curated and high-precision: only a header a
+    // normal response does not carry. cf-mitigated is the header Cloudflare sets
+    // when it is actively challenging (the 200-with-Turnstile case the status
+    // signal misses). WAF-presence headers (cf-ray, server names) are excluded.
+    internal static readonly string[] ChallengeHeaderKeys =
+    [
+        "cf-mitigated",
+    ];
+
+    // Weak-confidence body markers. Tightened from ADR-0056: bare vendor names
+    // ("DataDome", "Akamai") are dropped because they appear in legitimate
+    // content. Adding a marker is a one-line change plus a BlockDetectorTests row.
+    internal static readonly string[] WeakBodyMarkers =
+    [
+        // Cloudflare Turnstile / managed challenge
+        "Just a moment...",
+        "Checking your browser",
+        "cf-chl-bypass",
+        // DataDome
+        "dd-rd",
+        // PerimeterX (HUMAN)
+        "px-captcha",
+        "_pxhd",
+        // Imperva Incapsula
+        "_Incapsula_",
+        "Incapsula incident ID",
+        // Akamai Bot Manager
+        "ak_bmsc",
+        "/akam/",
+    ];
+}

--- a/WebReaper/Core/Crawling/JobReport.cs
+++ b/WebReaper/Core/Crawling/JobReport.cs
@@ -1,3 +1,4 @@
+using WebReaper.Core.Blocking.Abstract;
 using WebReaper.Core.Loaders.Abstract;
 
 namespace WebReaper.Core.Crawling;
@@ -18,4 +19,9 @@ namespace WebReaper.Core.Crawling;
 /// <param name="Page">The loaded page (ADR-0083 <see cref="PageLoadResult"/>):
 /// its <c>Html</c> builds the page-processor <c>PageContext</c> (ADR-0038), and
 /// its status and headers carry the response metadata later slices read.</param>
-public sealed record JobReport(CrawlOutcome Outcome, PageLoadResult Page);
+/// <param name="Block">The block detector's verdict over <paramref name="Page"/>
+/// (ADR-0083): whether this load looked like a bot-check challenge, and how
+/// strongly. Computed by the Spider shell from the loaded page; the Crawl driver
+/// reads it (tallies blocked pages now; climbs / drops in later slices). Never a
+/// thrown signal.</param>
+public sealed record JobReport(CrawlOutcome Outcome, PageLoadResult Page, BlockVerdict Block);

--- a/WebReaper/Core/ScraperEngine.cs
+++ b/WebReaper/Core/ScraperEngine.cs
@@ -134,6 +134,12 @@ public class ScraperEngine : IAsyncDisposable
         _telemetryHooks?.Reset();
         var sw = Stopwatch.StartNew();
 
+        // ADR-0083: tally of pages the block detector flagged as blocked this
+        // run. A single-element array so the parallel-loop closure mutates the
+        // same cell; Interlocked.Increment makes the per-Job bump thread-safe.
+        // Reporting only this slice — climbing / dropping is later slices.
+        var blockedPageCount = new int[1];
+
         await WarmUpAdaptersAsync();
 
         Logger.LogInformation("Start {class}.{method}", nameof(ScraperEngine), nameof(RunAsync));
@@ -172,7 +178,8 @@ public class ScraperEngine : IAsyncDisposable
             sw.Stop();
             return new RunReport(
                 Llm: _telemetryHooks?.Snapshot(),
-                Duration: sw.Elapsed);
+                Duration: sw.Elapsed,
+                BlockedPageCount: blockedPageCount[0]);
         }
 
         // ADR-0037: the driver ends the Crawl by ceasing its OWN consumption,
@@ -228,6 +235,12 @@ public class ScraperEngine : IAsyncDisposable
                     // so the abort is not retry-amplified).
                     var report = await RetryPolicy.ExecuteAsync(
                         ct => Spider.CrawlAsync(job, ct), token);
+
+                    // ADR-0083: tally a blocked page once per Job, right after
+                    // the Spider reports. Reporting only this slice — the driver
+                    // does not yet climb the host floor or drop the page.
+                    if (report.Block.IsBlocked)
+                        Interlocked.Increment(ref blockedPageCount[0]);
 
                     if (report.Outcome is CrawlOutcome.Parsed parsed)
                     {
@@ -316,7 +329,8 @@ public class ScraperEngine : IAsyncDisposable
         sw.Stop();
         return new RunReport(
             Llm: _telemetryHooks?.Snapshot(),
-            Duration: sw.Elapsed);
+            Duration: sw.Elapsed,
+            BlockedPageCount: blockedPageCount[0]);
     }
 
     // ADR-0033: warm up every adapter the driver holds that declares the

--- a/WebReaper/Core/Spider/Concrete/Spider.cs
+++ b/WebReaper/Core/Spider/Concrete/Spider.cs
@@ -1,3 +1,4 @@
+using WebReaper.Core.Blocking.Abstract;
 using WebReaper.Core.Crawling;
 using WebReaper.Core.Crawling.Abstract;
 using WebReaper.Core.Loaders.Abstract;
@@ -25,6 +26,10 @@ internal class Spider : ISpider
 {
     /// <param name="crawlStep">The pure crawl-step decision (ADR-0022).</param>
     /// <param name="pageLoader">The one page loader (ADR-0004).</param>
+    /// <param name="blockDetector">The block detector (ADR-0083): classifies the
+    /// loaded page as a bot-check challenge (reporting, not acting). The shell
+    /// runs it on every load and carries the verdict on the
+    /// <see cref="JobReport"/>.</param>
     /// <param name="headless">The crawl's headless setting, folded into every
     /// <see cref="PageRequest"/> the shell builds.</param>
     /// <param name="parsingScheme">The extraction <see cref="Schema"/> for
@@ -32,17 +37,20 @@ internal class Spider : ISpider
     public Spider(
         ICrawlStep crawlStep,
         IPageLoader pageLoader,
+        IBlockDetector blockDetector,
         bool headless,
         Schema? parsingScheme)
     {
         CrawlStep = crawlStep;
         PageLoader = pageLoader;
+        BlockDetector = blockDetector;
         Headless = headless;
         ParsingScheme = parsingScheme;
     }
 
     private IPageLoader PageLoader { get; }
     private ICrawlStep CrawlStep { get; }
+    private IBlockDetector BlockDetector { get; }
     private bool Headless { get; }
     private Schema? ParsingScheme { get; }
 
@@ -52,8 +60,12 @@ internal class Spider : ISpider
             new PageRequest(job.Url, job.PageType, job.PageActions, Headless),
             cancellationToken);
 
+        // ADR-0083: classify the load before the crawl step runs (the verdict is
+        // independent of the outcome). Pure and non-throwing; the driver reads it.
+        var block = BlockDetector.Detect(page);
+
         var outcome = await CrawlStep.StepAsync(job, page.Html, ParsingScheme);
 
-        return new JobReport(outcome, page);
+        return new JobReport(outcome, page, block);
     }
 }

--- a/WebReaper/Domain/Telemetry/RunReport.cs
+++ b/WebReaper/Domain/Telemetry/RunReport.cs
@@ -19,6 +19,11 @@ namespace WebReaper.Domain.Telemetry;
 /// is in use.</param>
 /// <param name="Duration">Wall-clock time from <c>RunAsync</c> entry to
 /// completion.</param>
+/// <param name="BlockedPageCount">The number of pages the block detector
+/// (ADR-0083) flagged as blocked (<c>IsBlocked</c>) during the run. For a
+/// single-URL scrape this is 0 or 1; for a crawl it counts every page whose
+/// load looked like a bot-check challenge.</param>
 public sealed record RunReport(
     object? Llm,
-    TimeSpan Duration);
+    TimeSpan Duration,
+    int BlockedPageCount = 0);


### PR DESCRIPTION
Implements **slice 2 of ADR-0083** (closes #172; parent #170). Builds on the slice-1 `PageLoadResult` contract. No climbing or dropping yet: a blocked page is still loaded and emitted, but the run now **reports** it.

## What changed

- **New core seam**: `IBlockDetector` + default `BlockDetector` (in `WebReaper.Core.Blocking`), a pure classifier over a `PageLoadResult` returning a `BlockVerdict(BlockConfidence, Reason)`.
  - **High** confidence: HTTP `403/429/503`, or the `cf-mitigated` challenge header.
  - **Weak** confidence: a tightened body-marker list. Per the ADR, bare vendor names (`DataDome`, `Akamai`) are dropped because they appear in legitimate content; `cf-ray` is excluded as a high-confidence header because it is present on *all* Cloudflare traffic (WAF presence is not a block).
  - Record count is deliberately **not** an input; it re-enters at the driver's drop decision in slice 3.
- **Spider** runs the detector per load; the verdict rides on `JobReport.Block`.
- **Crawl driver** tallies blocked pages (thread-safe `Interlocked`) into a new `RunReport.BlockedPageCount` (a defaulted positional param, so other `RunReport` constructions keep compiling).
- **Builders**: `.WithBlockDetector(...)` overrides the default on the engine and distributed-spider builders.
- **CLI** `scrape` captures the `RunReport`; on `BlockedPageCount > 0` it warns on stderr and exits non-zero. Additive: the `EmptyResultAdvisor` (PR #166) and the still-dead `BotCheckDetector` escalation are untouched (slice 5 removes the latter).

## Tests

- New `BlockDetectorTests`: each confidence tier, the dropped vendor names asserting `None`, and a `cf-ray`-present control asserting `None`.
- New LocalServer integration test: a `/fail?status=403` scrape asserts `RunReport.BlockedPageCount == 1` (and a clean 200 asserts 0), pinning the detect-and-tally wiring end to end.
- Existing `JobReport` / `Spider` test constructions adapted.
- `CONTEXT.md`: `Block detector` / `Block verdict` / `Blocked page` glossary terms.

## Verification

Independently re-run on top of master: build clean (0 errors); **UnitTests 518**, **Cli.Tests 125**, **LocalServer integration 15**, **AI.Tests 274**, all green. (The LocalServer tier is included this time, the CI gate that caught slice 1.)

Next: slice 3 (#173) adds `BlockDropPolicy` to suppress residual-blocked pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)