### PR TITLE
feat(blocking)!: suppress residual-blocked pages via BlockDropPolicy (ADR-0083 slice 3)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -221,8 +221,16 @@ The `BlockVerdict` a **block detector** returns: a `BlockConfidence` tier (None,
 _Avoid_: block result, detection result, score.
 
 **Blocked page**:
-A **page load result** the **block detector** classifies as a challenge (`IsBlocked`, i.e. confidence above None). Load-stage and reliable: it is read straight off the response, before extraction. It drives escalation and suppression in later slices; for now the **Crawl driver** only tallies it into the **run report**'s `BlockedPageCount`. Distinct from an Empty result (zero extracted records), which is a weaker extraction-stage hint.
+A **page load result** the **block detector** classifies as a challenge (`IsBlocked`, i.e. confidence above None). Load-stage and reliable: it is read straight off the response, before extraction. The **Crawl driver** suppresses it per the **block drop policy** and tallies the drop into the **run report**'s `BlockedPageCount`; climbing a blocked page to a stronger transport is a later slice. Distinct from an **Empty result**, which is a weaker extraction-stage hint.
 _Avoid_: blocked response, challenge page, captcha page.
+
+**Block drop policy**:
+The pure `BlockDropPolicy` rule (ADR-0083 part 8) the **Crawl driver** consults to decide whether to suppress a **blocked page** rather than emit it: a **block verdict** plus the page's extracted record count in, a keep-or-drop decision out. High confidence drops always; Weak drops only when the page also yielded zero records (a weak body-marker page that still extracted real records was a false positive and is kept); None never drops. A dropped page skips the **Page processor** pipeline and the **Sink** fan-out entirely, so challenge content never reaches a consumer's store. This is the one place record count re-enters the design: an extraction-stage fact the driver folds in one layer above the **block detector**, never back inside the pure load-stage seam.
+_Avoid_: suppression filter, block filter, drop rule (unqualified).
+
+**Empty result**:
+A page that loaded fine but whose extraction yielded zero records: possibly genuinely empty, possibly a block the **block detector** missed. A weak, extraction-stage hint, not a verdict; it stays a CLI stderr suggestion ("retry with `--browser` / `--stealth`", the `EmptyResultAdvisor` from PR #166) and is never on its own a **block drop policy** drop. Distinct from a **blocked page**, which is a reliable load-stage classification the driver does suppress. ADR-0056 fused the two; the fusion was the bug.
+_Avoid_: empty page, no-results, blocked (an empty result is not necessarily blocked).
 
 ### Wiring
 

--- a/WebReaper.Tests/WebReaper.UnitTests/BlockDropPolicyTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/BlockDropPolicyTests.cs
@@ -1,0 +1,40 @@
+using WebReaper.Core.Blocking.Abstract;
+using WebReaper.Core.Blocking.Concrete;
+using Xunit;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0083 slice 3: the pure confidence-split drop rule (part 8). The Crawl
+// driver supplies the post-extraction record count; the policy never sees a
+// page, only the verdict + count, so its behaviour is a closed truth table.
+public class BlockDropPolicyTests
+{
+    [Theory]
+    // High confidence drops regardless of record count — a confirmed challenge
+    // (a challenge-class status or header) is not worth emitting.
+    [InlineData(BlockConfidence.High, 0, true)]
+    [InlineData(BlockConfidence.High, 1, true)]
+    [InlineData(BlockConfidence.High, 25, true)]
+    // Weak drops only when the page yielded nothing; a weak body-marker page
+    // that still extracted real records was a false positive and is kept.
+    [InlineData(BlockConfidence.Weak, 0, true)]
+    [InlineData(BlockConfidence.Weak, 1, false)]
+    [InlineData(BlockConfidence.Weak, 25, false)]
+    // None is not a block, so never a drop, whatever the record count.
+    [InlineData(BlockConfidence.None, 0, false)]
+    [InlineData(BlockConfidence.None, 25, false)]
+    public void ShouldDrop_follows_the_confidence_split(
+        BlockConfidence confidence, int recordCount, bool expectedDrop)
+    {
+        var verdict = new BlockVerdict(
+            confidence, confidence == BlockConfidence.None ? null : "test marker");
+
+        Assert.Equal(expectedDrop, BlockDropPolicy.ShouldDrop(verdict, recordCount));
+    }
+
+    [Fact]
+    public void ShouldDrop_throws_on_a_null_verdict()
+    {
+        Assert.Throws<ArgumentNullException>(() => BlockDropPolicy.ShouldDrop(null!, 0));
+    }
+}

--- a/WebReaper.Tests/WebReaper.UnitTests/ScraperEngineDriverTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/ScraperEngineDriverTests.cs
@@ -160,6 +160,28 @@ public class ScraperEngineDriverTests
             new PageLoadResult { Html = "<html/>" },
             BlockVerdict.None);
 
+    // ADR-0083 slice 3: a Target page carrying a block verdict and a given record
+    // shape (empty JsonObject => the driver counts zero records; a populated one
+    // => one record), so the driver's confidence-split suppression is exercised
+    // offline. The page URL is folded into Data at ParsedData construction and is
+    // not counted as a record (ADR-0031).
+    private static JobReport ParsedBlocked(string url, BlockConfidence confidence, JsonObject data) =>
+        new(CrawlOutcome.Target(new ParsedData(url, data)),
+            new PageLoadResult { Html = "<html/>" },
+            new BlockVerdict(confidence, "test marker"));
+
+    private static JobReport SweptBlocked(
+        string url, BlockConfidence confidence, JsonObject data, params string[] children) =>
+        new(CrawlOutcome.Sweep(
+                new ParsedData(url, data),
+                children
+                    .Select(u => new Job(u,
+                        ImmutableQueue.CreateRange(new[] { LinkPathSelector.Sweep() }),
+                        ImmutableQueue<string>.Empty))
+                    .ToImmutableArray()),
+            new PageLoadResult { Html = "<html/>" },
+            new BlockVerdict(confidence, "test marker"));
+
     [Fact]
     public async Task Swept_page_both_emits_its_record_and_follows_its_children_until_the_frontier_saturates()
     {
@@ -548,5 +570,147 @@ public class ScraperEngineDriverTests
         await engine.RunAsync().WaitAsync(TimeSpan.FromSeconds(10));
 
         Assert.True(spider.Crawled.Count >= 3); // soft limit: at least the cap
+    }
+
+    [Fact]
+    public async Task High_confidence_blocked_target_is_dropped_reaching_no_sink_and_is_tallied()
+    {
+        // ADR-0083 slice 3: a high-confidence block drops the page regardless of
+        // what it extracted — even though this challenge page "yielded" a field,
+        // it never reaches the sink and is counted as a residual block.
+        var sink = new RecordingSink();
+
+        var spider = new ScriptedSpider(job => job.Url == "root"
+            ? Followed("item")
+            : ParsedBlocked(job.Url, BlockConfidence.High, new JsonObject { ["title"] = "challenge" }));
+
+        var engine = new ScraperEngine(
+            parallelismDegree: 1,
+            new FakeConfigStorage(Config()),
+            new InMemoryScheduler(),
+            spider,
+            new InMemoryVisitedLinkTracker(),
+            new List<IScraperSink> { sink },
+            NullLogger.Instance);
+
+        var report = await engine.RunAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Empty(sink.Emitted);               // suppressed before the fan-out
+        Assert.Equal(1, report.BlockedPageCount);  // tallied as a residual block
+    }
+
+    [Fact]
+    public async Task Weak_blocked_target_with_no_records_is_dropped_and_tallied()
+    {
+        // ADR-0083 slice 3: a weak body-marker block with an empty extraction
+        // (zero records) is suppressed.
+        var sink = new RecordingSink();
+
+        var spider = new ScriptedSpider(job => job.Url == "root"
+            ? Followed("item")
+            : ParsedBlocked(job.Url, BlockConfidence.Weak, new JsonObject())); // url-only => 0 records
+
+        var engine = new ScraperEngine(
+            parallelismDegree: 1,
+            new FakeConfigStorage(Config()),
+            new InMemoryScheduler(),
+            spider,
+            new InMemoryVisitedLinkTracker(),
+            new List<IScraperSink> { sink },
+            NullLogger.Instance);
+
+        var report = await engine.RunAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Empty(sink.Emitted);
+        Assert.Equal(1, report.BlockedPageCount);
+    }
+
+    [Fact]
+    public async Task Weak_blocked_target_that_yielded_records_is_kept_and_emitted()
+    {
+        // ADR-0083 slice 3: a weak block that still extracted real records was a
+        // false positive (or a beatable challenge) — it is kept and emitted, and
+        // not counted as a residual block. This is what stops a vendor-name false
+        // positive from destroying a real page.
+        var sink = new RecordingSink();
+
+        var spider = new ScriptedSpider(job => job.Url == "root"
+            ? Followed("item")
+            : ParsedBlocked(job.Url, BlockConfidence.Weak, new JsonObject { ["title"] = "real" }));
+
+        var engine = new ScraperEngine(
+            parallelismDegree: 1,
+            new FakeConfigStorage(Config()),
+            new InMemoryScheduler(),
+            spider,
+            new InMemoryVisitedLinkTracker(),
+            new List<IScraperSink> { sink },
+            NullLogger.Instance);
+
+        var report = await engine.RunAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        var emitted = Assert.Single(sink.Emitted);
+        Assert.Equal("item", emitted.Url);
+        Assert.Equal(0, report.BlockedPageCount); // kept => not a residual block
+    }
+
+    [Fact]
+    public async Task Unblocked_target_with_no_records_is_still_emitted_and_not_tallied()
+    {
+        // ADR-0083 slice 3: an Empty result (zero records) is NOT a blocked page.
+        // With no block verdict, the page is emitted as usual — only a verdict
+        // can trigger a drop. This pins the Empty-result-vs-blocked distinction.
+        var sink = new RecordingSink();
+
+        var spider = new ScriptedSpider(job => job.Url == "root"
+            ? Followed("item")
+            : Parsed(job.Url)); // BlockVerdict.None + empty data
+
+        var engine = new ScraperEngine(
+            parallelismDegree: 1,
+            new FakeConfigStorage(Config()),
+            new InMemoryScheduler(),
+            spider,
+            new InMemoryVisitedLinkTracker(),
+            new List<IScraperSink> { sink },
+            NullLogger.Instance);
+
+        var report = await engine.RunAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(new[] { "item" }, sink.Emitted.Select(p => p.Url));
+        Assert.Equal(0, report.BlockedPageCount);
+    }
+
+    [Fact]
+    public async Task High_blocked_swept_page_drops_its_record_but_still_follows_its_children()
+    {
+        // ADR-0083 slice 3: the Sweep arm both emits and follows. A blocked Sweep
+        // page has its record suppressed, but its on-domain children are still
+        // enqueued — recovering real content from a blocked page is the loader's
+        // climb (a later slice), not this suppression slice.
+        var sink = new RecordingSink();
+
+        var spider = new ScriptedSpider(job => job.Url switch
+        {
+            "root" => SweptBlocked("root", BlockConfidence.High,
+                new JsonObject { ["t"] = "challenge" }, "a"),
+            _ => Swept(job.Url), // "a": clean, no further children => frontier saturates
+        });
+
+        var engine = new ScraperEngine(
+            parallelismDegree: 1,
+            new FakeConfigStorage(Config()),
+            new InMemoryScheduler(),
+            spider,
+            new InMemoryVisitedLinkTracker(),
+            new List<IScraperSink> { sink },
+            NullLogger.Instance);
+
+        var report = await engine.RunAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(new[] { "a" }, sink.Emitted.Select(p => p.Url)); // root dropped, child kept
+        Assert.Equal(1, report.BlockedPageCount);
+        Assert.Contains("root", spider.Crawled);
+        Assert.Contains("a", spider.Crawled); // child still followed
     }
 }

--- a/WebReaper/Core/Blocking/Concrete/BlockDropPolicy.cs
+++ b/WebReaper/Core/Blocking/Concrete/BlockDropPolicy.cs
@@ -1,0 +1,51 @@
+using WebReaper.Core.Blocking.Abstract;
+
+namespace WebReaper.Core.Blocking.Concrete;
+
+/// <summary>
+/// The pure confidence-split drop rule (ADR-0083 part 8): given a
+/// <see cref="BlockVerdict"/> and the number of records the page extracted,
+/// decide whether the Crawl driver should suppress the page (skip the
+/// post-extraction pipeline and Sink fan-out) instead of emitting its content.
+/// <para>
+/// This is where record count re-enters the design. The
+/// <see cref="IBlockDetector"/> is pure over the load stage and cannot see how
+/// many records the page yielded, so a weak body-marker verdict cannot tell a
+/// real page from a challenge on its own. The count is an extraction-stage fact;
+/// the driver folds it in here, one layer up from the detector, never back inside
+/// the seam. Detection reports, the driver acts.
+/// </para>
+/// </summary>
+public static class BlockDropPolicy
+{
+    /// <summary>
+    /// Decide whether to drop a page given its block verdict and extracted
+    /// record count.
+    /// <list type="bullet">
+    ///   <item><see cref="BlockConfidence.High"/>: drop regardless of count. A
+    ///   confirmed challenge (a challenge-class status or header) is not worth
+    ///   emitting.</item>
+    ///   <item><see cref="BlockConfidence.Weak"/>: drop only when
+    ///   <paramref name="recordCount"/> is zero. A weak body-marker page that
+    ///   still yielded real records was a false positive (or a beatable
+    ///   challenge) and is kept, which is what stops a vendor-name false positive
+    ///   from destroying a real page.</item>
+    ///   <item><see cref="BlockConfidence.None"/>: never drop.</item>
+    /// </list>
+    /// </summary>
+    /// <param name="verdict">The block detector's verdict for the page.</param>
+    /// <param name="recordCount">How many records the page's extraction produced
+    /// (0 for an empty extraction).</param>
+    /// <returns><c>true</c> to suppress the page; <c>false</c> to emit it.</returns>
+    public static bool ShouldDrop(BlockVerdict verdict, int recordCount)
+    {
+        ArgumentNullException.ThrowIfNull(verdict);
+
+        return verdict.Confidence switch
+        {
+            BlockConfidence.High => true,
+            BlockConfidence.Weak => recordCount == 0,
+            _ => false,
+        };
+    }
+}

--- a/WebReaper/Core/ScraperEngine.cs
+++ b/WebReaper/Core/ScraperEngine.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using WebReaper.ConfigStorage.Abstract;
+using WebReaper.Core.Blocking.Concrete;
 using WebReaper.Core.Crawling;
 using WebReaper.Core.Crawling.Abstract;
 using WebReaper.Core.Crawling.Concrete;
@@ -134,11 +135,12 @@ public class ScraperEngine : IAsyncDisposable
         _telemetryHooks?.Reset();
         var sw = Stopwatch.StartNew();
 
-        // ADR-0083: tally of pages the block detector flagged as blocked this
-        // run. A single-element array so the parallel-loop closure mutates the
-        // same cell; Interlocked.Increment makes the per-Job bump thread-safe.
-        // Reporting only this slice — climbing / dropping is later slices.
-        var blockedPageCount = new int[1];
+        // ADR-0083: tally of residual-blocked pages suppressed (dropped) this
+        // run — a Target/Sweep page the block drop policy (part 8) kept out of
+        // the sinks. A single-element array so the parallel-loop closure mutates
+        // the same cell; Interlocked.Increment makes the per-Job bump
+        // thread-safe.
+        var droppedBlockedPageCount = new int[1];
 
         await WarmUpAdaptersAsync();
 
@@ -179,7 +181,7 @@ public class ScraperEngine : IAsyncDisposable
             return new RunReport(
                 Llm: _telemetryHooks?.Snapshot(),
                 Duration: sw.Elapsed,
-                BlockedPageCount: blockedPageCount[0]);
+                BlockedPageCount: droppedBlockedPageCount[0]);
         }
 
         // ADR-0037: the driver ends the Crawl by ceasing its OWN consumption,
@@ -236,39 +238,54 @@ public class ScraperEngine : IAsyncDisposable
                     var report = await RetryPolicy.ExecuteAsync(
                         ct => Spider.CrawlAsync(job, ct), token);
 
-                    // ADR-0083: tally a blocked page once per Job, right after
-                    // the Spider reports. Reporting only this slice — the driver
-                    // does not yet climb the host floor or drop the page.
-                    if (report.Block.IsBlocked)
-                        Interlocked.Increment(ref blockedPageCount[0]);
+                    // ADR-0083 slice 3: suppress a residual-blocked Target/Sweep
+                    // page before the Post-extraction pipeline and Sink fan-out,
+                    // so challenge-page content never reaches a consumer's store.
+                    // The block drop policy (part 8) is the confidence split —
+                    // High drops always, Weak drops only when the page yielded no
+                    // records — and every drop is tallied as a residual block.
+                    // Detection reported (in the Spider); the driver acts, exactly
+                    // as it already does for the visited-link and stop-rule
+                    // verdicts (ADR-0022's line holds). A dropped Sweep page still
+                    // follows its children: recovering real links from a blocked
+                    // page is the loader's climb (a later slice), not this slice.
+                    async Task EmitOrDropAsync(ParsedData data)
+                    {
+                        if (BlockDropPolicy.ShouldDrop(report.Block, CountRecords(data)))
+                        {
+                            Interlocked.Increment(ref droppedBlockedPageCount[0]);
+                            Logger.LogInformation(
+                                "Dropping residual-blocked page {Url}: {Reason}",
+                                data.Url, report.Block.Reason);
+                            return;
+                        }
+
+                        // ADR-0076: the page-processor pipeline + Sink fan-out is
+                        // the Post-extraction pipeline's job; the driver only
+                        // routes the record into it (and ignores the
+                        // surviving-record return — the crawl path fires and
+                        // forgets). ADR-0037: it runs on the iteration token, so a
+                        // Crawl concluding mid-flight cancels the in-flight
+                        // pipeline and fan-out too.
+                        Logger.LogInvocationCount();
+                        await _pipeline.ProcessAndEmitAsync(data, report.Page.Html,
+                            job.ParentBacklinks.ToList(), config.ParsingScheme, token);
+                    }
 
                     if (report.Outcome is CrawlOutcome.Parsed parsed)
                     {
-                        // ADR-0037: per-Job work runs on the iteration token,
-                        // so a Crawl concluding mid-flight cancels the in-flight
-                        // page-processor pipeline and Sink fan-out too.
-                        // ADR-0076: the page-processor pipeline + Sink fan-out
-                        // is the Post-extraction pipeline's job; the driver only
-                        // routes the Target page's record into it (and ignores
-                        // the surviving-record return — the crawl path fires and
-                        // forgets).
-                        Logger.LogInvocationCount();
-                        await _pipeline.ProcessAndEmitAsync(parsed.Data, report.Page.Html,
-                            job.ParentBacklinks.ToList(), config.ParsingScheme, token);
+                        await EmitOrDropAsync(parsed.Data);
                         newJobs = new List<Job>();
                     }
                     else if (report.Outcome is CrawlOutcome.Swept swept)
                     {
-                        // ADR-0081: the Sweep page is the ONLY arm that does
-                        // both: run its record through the Post-extraction
-                        // pipeline (emit) AND enqueue its on-domain children
-                        // (follow). The children retain the recursive sweep
-                        // selector; the Visited-link tracker dedups them, which
-                        // is also what terminates the sweep when the on-domain
-                        // frontier saturates.
-                        Logger.LogInvocationCount();
-                        await _pipeline.ProcessAndEmitAsync(swept.Data, report.Page.Html,
-                            job.ParentBacklinks.ToList(), config.ParsingScheme, token);
+                        // ADR-0081: the Sweep page is the ONLY arm that both
+                        // emits its record AND enqueues its on-domain children.
+                        // The children retain the recursive sweep selector; the
+                        // Visited-link tracker dedups them, which is also what
+                        // terminates the sweep when the on-domain frontier
+                        // saturates.
+                        await EmitOrDropAsync(swept.Data);
                         newJobs = swept.Next.ToList();
                     }
                     else
@@ -330,8 +347,39 @@ public class ScraperEngine : IAsyncDisposable
         return new RunReport(
             Llm: _telemetryHooks?.Snapshot(),
             Duration: sw.Elapsed,
-            BlockedPageCount: blockedPageCount[0]);
+            BlockedPageCount: droppedBlockedPageCount[0]);
     }
+
+    // ADR-0083 slice 3: how many records a Target/Sweep page actually extracted,
+    // for the block drop policy's Weak "drop iff zero records" rule. A single
+    // page yields one record, so this is 0 or 1 — it counts only when the
+    // extraction produced real content. The Schema fold writes an empty string
+    // for a selector that matched nothing (ADR-0029) and the page URL is always
+    // folded in under "url" (ADR-0031), so neither an empty field nor the URL
+    // counts: a challenge page parsed with a schema reads as zero records, which
+    // is what lets the Weak rule suppress it.
+    private static int CountRecords(ParsedData record)
+    {
+        foreach (var (key, value) in record.Data)
+        {
+            if (string.Equals(key, "url", StringComparison.Ordinal)) continue;
+            if (IsNonEmpty(value)) return 1;
+        }
+
+        return 0;
+    }
+
+    private static bool IsNonEmpty(JsonNode? node) => node switch
+    {
+        null => false,
+        // The fold writes "" for a non-matching string selector (ADR-0029); a
+        // number / boolean (including 0 / false) is real data, as are non-empty
+        // arrays and objects.
+        JsonValue value => !(value.TryGetValue<string>(out var s) && string.IsNullOrEmpty(s)),
+        JsonArray array => array.Count > 0,
+        JsonObject obj => obj.Count > 0,
+        _ => true,
+    };
 
     // ADR-0033: warm up every adapter the driver holds that declares the
     // IAsyncInitializable capability — once, before the crawl loop. The driver

--- a/WebReaper/Domain/Telemetry/RunReport.cs
+++ b/WebReaper/Domain/Telemetry/RunReport.cs
@@ -19,10 +19,14 @@ namespace WebReaper.Domain.Telemetry;
 /// is in use.</param>
 /// <param name="Duration">Wall-clock time from <c>RunAsync</c> entry to
 /// completion.</param>
-/// <param name="BlockedPageCount">The number of pages the block detector
-/// (ADR-0083) flagged as blocked (<c>IsBlocked</c>) during the run. For a
-/// single-URL scrape this is 0 or 1; for a crawl it counts every page whose
-/// load looked like a bot-check challenge.</param>
+/// <param name="BlockedPageCount">The number of residual-blocked pages the
+/// run suppressed (ADR-0083): a Target/Sweep page the block drop policy dropped
+/// rather than emit, so its challenge content never reached a sink. A
+/// high-confidence block is always counted; a weak body-marker block is counted
+/// only when the page also yielded no records (a weak block that still extracted
+/// real records is kept and not counted). For a single-URL scrape this is 0 or
+/// 1; for a crawl it is the aggregate the CLI surfaces ("N of M pages still
+/// blocked, consider a captcha solver").</param>
 public sealed record RunReport(
     object? Llm,
     TimeSpan Duration,


### PR DESCRIPTION
## What

Slice 3 of [ADR-0083](docs/adr/0083-escalating-page-loader.md). A page the **block detector** (slice 2) flags as a challenge is no longer emitted as data. The **Crawl driver** now consults a pure `BlockDropPolicy` per Target/Sweep page and, when it drops, skips the **Page processor** pipeline and **Sink** fan-out entirely, so challenge-page content never reaches a consumer's store.

Closes #173. Builds on #176 (slice 1, `PageLoadResult`) and #178 (slice 2, `IBlockDetector`).

## The drop rule (ADR-0083 part 8)

`BlockDropPolicy.ShouldDrop` is pure over `(BlockVerdict, recordCount)`:

| Confidence | Record count | Decision |
|---|---|---|
| `High` | any | **drop** (a confirmed challenge is not worth emitting) |
| `Weak` | `0` | **drop** |
| `Weak` | `> 0` | keep (a weak body-marker page that still extracted real records was a false positive; this stops a vendor-name match from destroying a real page) |
| `None` | any | keep |

This is where **record count re-enters** the design: an extraction-stage fact the driver folds in one layer above the detector, never back inside the pure load-stage seam. The driver counts a page's records from its `ParsedData` (the URL fold and empty-string fold fields don't count, so a challenge page parsed with a schema reads as zero records).

A dropped **Sweep** page still follows its on-domain children; recovering real links from a blocked page is the loader's climb (slice 4), not this slice.

## Breaking (behavioral)

`RunReport.BlockedPageCount` now counts residual-blocked pages the run **suppressed (dropped)**, not every page the detector flagged. The record shape is unchanged; this refines the slice-2 placeholder tally so the value the CLI surfaces (slice 5) is "pages we couldn't get data from".

## Docs

`CONTEXT.md` gains **Block drop policy** and **Empty result**, and sharpens **Blocked page** — the drop applies to blocked pages; an empty result is the PR #166 CLI hint, not a drop. ADR-0056 fused the two; the fusion was the bug.

## Tests / verification

- `BlockDropPolicyTests`: the full confidence-split truth table + null guard.
- `ScraperEngineDriverTests`: High dropped reaching no sink + tallied; Weak+0 dropped; Weak+records kept and emitted; an empty result with no verdict still emitted (the empty-vs-blocked distinction); a high-blocked Sweep page drops its record but still follows its children.
- All five tiers green locally: solution build (0 errors), UnitTests (532), AI.Tests (274), Cli.Tests (125), IntegrationTests `Category=LocalServer` (15, incl. the slice-2 block tests). AOT smoke test also green (core change is trim/AOT-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)