### PR TITLE
feat(loaders)!: per-page escalating page loader with host-sticky climbing (ADR-0083 slice 4)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -221,7 +221,7 @@ The `BlockVerdict` a **block detector** returns: a `BlockConfidence` tier (None,
 _Avoid_: block result, detection result, score.
 
 **Blocked page**:
-A **page load result** the **block detector** classifies as a challenge (`IsBlocked`, i.e. confidence above None). Load-stage and reliable: it is read straight off the response, before extraction. The **Crawl driver** suppresses it per the **block drop policy** and tallies the drop into the **run report**'s `BlockedPageCount`; climbing a blocked page to a stronger transport is a later slice. Distinct from an **Empty result**, which is a weaker extraction-stage hint.
+A **page load result** the **block detector** classifies as a challenge (`IsBlocked`, i.e. confidence above None). Load-stage and reliable: it is read straight off the response, before extraction. It is the signal that drives the **escalating page loader** to climb to a stronger transport tier; if the page is still blocked at the top tier the **Crawl driver** suppresses it per the **block drop policy** and tallies the drop into the **run report**'s `BlockedPageCount`. Distinct from an **Empty result**, which is a weaker extraction-stage hint.
 _Avoid_: blocked response, challenge page, captcha page.
 
 **Block drop policy**:
@@ -231,6 +231,20 @@ _Avoid_: suppression filter, block filter, drop rule (unqualified).
 **Empty result**:
 A page that loaded fine but whose extraction yielded zero records: possibly genuinely empty, possibly a block the **block detector** missed. A weak, extraction-stage hint, not a verdict; it stays a CLI stderr suggestion ("retry with `--browser` / `--stealth`", the `EmptyResultAdvisor` from PR #166) and is never on its own a **block drop policy** drop. Distinct from a **blocked page**, which is a reliable load-stage classification the driver does suppress. ADR-0056 fused the two; the fusion was the bug.
 _Avoid_: empty page, no-results, blocked (an empty result is not necessarily blocked).
+
+### Escalation
+
+**Escalating page loader**:
+The one `IPageLoader` (ADR-0004), now block-aware and climbing (ADR-0083). It composes an ordered ladder of **load tier**s, the **block detector**, a **host tier floor**, and the **page cache**. For one page it starts at the host floor, loads at the current tier, and if the result is a **blocked page** with a higher real tier above it, climbs and reloads; it returns the best **page load result** it reached. The whole climb lives inside one `LoadAsync`, so the **Crawl driver**, scheduler, and **visited-link tracker** are untouched (ADR-0022 holds) and both `scrape` and `crawl` get climbing for free. It does not return the verdict — the Spider re-runs the same pure **block detector** on the returned result. Quarantine-clean: the browser / stealth tiers are injected **load transport**s from the Cdp / Playwright satellites; the only tier type core names is the BrowserNotConfigured sentinel, treated as "no real tier" so auto-escalation never launches a browser the consumer did not configure. The cache only ever holds clean loads (a blocked result is never written) and a climb bypasses it for the higher tier. `map` is not covered (the **Site mapper** uses its own HttpClient). The simpler non-climbing `PageLoader` remains for the **Agent driver** and custom `WithPageLoader` wirings.
+_Avoid_: retrying loader, fallback loader, escalator.
+
+**Load tier**:
+One rung of the **escalating page loader**'s ladder (`PageLoadTier`): a **load transport** paired with the **PageType** it serves. Ordered lowest to highest — HTTP (Static), then headless browser (Dynamic), then stealth (Dynamic, added by the CLI flag wiring in a later slice). The PageType tag is how the loader picks a page's starting rung — a Static page may start on any tier, a Dynamic page must skip the HTTP tier because an HTTP fetch returns un-rendered HTML — but it does not change what a transport does (a transport is its own mechanism and ignores the request's PageType).
+_Avoid_: rung (informal), transport (that is the mechanism, one per tier), level, step.
+
+**Host tier floor**:
+The **escalating page loader**'s per-run, per-host memory of the lowest **load tier** a host's pages should start at (`HostTierFloor`). It lifts only on a high-confidence **block verdict** (a challenge-class status or header), never on a weak body-marker block, so one false-positive page cannot promote a whole legitimate host; it never lowers. Because bot protection is near-always site-wide, a status-signalling host settles at its working tier after the first confirmed block, so later same-host pages skip the doomed lower tiers (a bounded one-time climb cost per host). Resets with a fresh engine (precedent: the ADR-0050 semantic-act cache).
+_Avoid_: host cache, tier map, escalation state, per-host policy.
 
 ### Wiring
 

--- a/WebReaper.Tests/WebReaper.UnitTests/EscalatingPageLoaderTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/EscalatingPageLoaderTests.cs
@@ -1,0 +1,234 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using WebReaper.Core.Blocking.Abstract;
+using WebReaper.Core.Loaders.Abstract;
+using WebReaper.Core.Loaders.Concrete;
+using WebReaper.Domain.Selectors;
+using Xunit;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0083 slice 4: the per-page climb. Fake transports + a stub detector — no
+// HTTP, no browser. Each transport returns a result tagged by Html so the stub
+// detector can decide "this rung is blocked" and the assertions can tell which
+// rung produced the returned result.
+public class EscalatingPageLoaderTests
+{
+    private sealed class CountingTransport(string html, int? status = 200) : IPageLoadTransport
+    {
+        private readonly PageLoadResult _result = new() { Html = html, HttpStatus = status };
+        public int Calls { get; private set; }
+        public PageRequest? LastRequest { get; private set; }
+
+        public Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
+        {
+            Calls++;
+            LastRequest = request;
+            return Task.FromResult(_result);
+        }
+    }
+
+    private sealed class ThrowingTransport : IPageLoadTransport
+    {
+        public Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("This transport must not be called.");
+    }
+
+    private sealed class StubDetector(Func<PageLoadResult, BlockVerdict> verdict) : IBlockDetector
+    {
+        public BlockVerdict Detect(PageLoadResult result) => verdict(result);
+    }
+
+    private static readonly IBlockDetector NeverBlocked = new StubDetector(_ => BlockVerdict.None);
+
+    // Blocks any result whose Html matches one of the given tags, at High
+    // confidence; everything else is clean.
+    private static IBlockDetector BlockHigh(params string[] blockedTags) =>
+        new StubDetector(r => blockedTags.Contains(r.Html)
+            ? new BlockVerdict(BlockConfidence.High, $"blocked: {r.Html}")
+            : BlockVerdict.None);
+
+    private static EscalatingPageLoader Loader(
+        IBlockDetector detector, HostTierFloor floor, IPageCache? cache, params PageLoadTier[] tiers)
+        => new(tiers, detector, floor, NullLogger.Instance, cache);
+
+    private static PageLoadTier Http(IPageLoadTransport t) => new(PageType.Static, t);
+    private static PageLoadTier Browser(IPageLoadTransport t) => new(PageType.Dynamic, t);
+
+    [Fact]
+    public async Task A_clean_first_load_returns_without_climbing()
+    {
+        var http = new CountingTransport("http");
+        var browser = new CountingTransport("browser");
+        var loader = Loader(NeverBlocked, new HostTierFloor(), cache: null, Http(http), Browser(browser));
+
+        var result = await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        Assert.Equal("http", result.Html);
+        Assert.Equal(1, http.Calls);
+        Assert.Equal(0, browser.Calls);                       // no over-climbing
+        Assert.Equal("https://x.test/", http.LastRequest!.Url); // request forwarded
+    }
+
+    [Fact]
+    public async Task A_blocked_load_climbs_to_the_next_tier_and_returns_the_clean_result()
+    {
+        var http = new CountingTransport("http");
+        var browser = new CountingTransport("browser");
+        var loader = Loader(BlockHigh("http"), new HostTierFloor(), cache: null, Http(http), Browser(browser));
+
+        var result = await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        Assert.Equal("browser", result.Html); // climbed past the blocked HTTP rung
+        Assert.Equal(1, http.Calls);
+        Assert.Equal(1, browser.Calls);
+    }
+
+    [Fact]
+    public async Task Still_blocked_at_the_top_tier_returns_the_residual_blocked_result()
+    {
+        var http = new CountingTransport("http");
+        var browser = new CountingTransport("browser");
+        var loader = Loader(BlockHigh("http", "browser"), new HostTierFloor(), cache: null,
+            Http(http), Browser(browser));
+
+        var result = await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        Assert.Equal("browser", result.Html); // the top rung's result, still blocked
+        Assert.Equal(1, http.Calls);
+        Assert.Equal(1, browser.Calls);
+    }
+
+    [Fact]
+    public async Task A_dynamic_request_starts_at_the_browser_tier_skipping_http()
+    {
+        var http = new CountingTransport("http");
+        var browser = new CountingTransport("browser");
+        var loader = Loader(NeverBlocked, new HostTierFloor(), cache: null, Http(http), Browser(browser));
+
+        var result = await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Dynamic));
+
+        Assert.Equal("browser", result.Html);
+        Assert.Equal(0, http.Calls); // a Dynamic page never touches the HTTP rung
+        Assert.Equal(1, browser.Calls);
+    }
+
+    [Fact]
+    public async Task A_high_block_lifts_the_host_floor_so_the_next_same_host_page_skips_the_blocked_tier()
+    {
+        var http = new CountingTransport("http");
+        var browser = new CountingTransport("browser");
+        var floor = new HostTierFloor();
+        var loader = Loader(BlockHigh("http"), floor, cache: null, Http(http), Browser(browser));
+
+        await loader.LoadAsync(new PageRequest("https://h.test/a", PageType.Static)); // climbs http->browser
+        await loader.LoadAsync(new PageRequest("https://h.test/b", PageType.Static)); // starts at browser
+
+        Assert.Equal(1, http.Calls);    // only the first page paid the blocked HTTP rung
+        Assert.Equal(2, browser.Calls); // both pages served by the browser rung
+        Assert.Equal(1, floor.FloorFor("h.test"));
+    }
+
+    [Fact]
+    public async Task A_weak_block_does_not_lift_the_floor_so_each_page_re_climbs()
+    {
+        var http = new CountingTransport("http");
+        var browser = new CountingTransport("browser");
+        var floor = new HostTierFloor();
+        // Weak (body-marker) block on the HTTP rung: climb, but never promote the host.
+        var detector = new StubDetector(r => r.Html == "http"
+            ? new BlockVerdict(BlockConfidence.Weak, "weak marker")
+            : BlockVerdict.None);
+        var loader = Loader(detector, floor, cache: null, Http(http), Browser(browser));
+
+        await loader.LoadAsync(new PageRequest("https://h.test/a", PageType.Static));
+        await loader.LoadAsync(new PageRequest("https://h.test/b", PageType.Static));
+
+        Assert.Equal(2, http.Calls);    // each page re-tries the HTTP rung (floor unlifted)
+        Assert.Equal(2, browser.Calls);
+        Assert.Equal(0, floor.FloorFor("h.test"));
+    }
+
+    [Fact]
+    public async Task An_auto_climb_never_launches_the_browser_not_configured_sentinel()
+    {
+        // A blocked Static page with no browser configured stops at HTTP and
+        // returns the residual-blocked result — it does not climb into (and
+        // throw from) the sentinel.
+        var http = new CountingTransport("http");
+        var loader = Loader(BlockHigh("http"), new HostTierFloor(), cache: null,
+            Http(http), Browser(new BrowserNotConfiguredPageLoadTransport()));
+
+        var result = await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        Assert.Equal("http", result.Html);            // residual-blocked, no throw
+        Assert.Equal(0, new HostTierFloor().FloorFor("x.test")); // (sanity) fresh floors start at 0
+    }
+
+    [Fact]
+    public async Task An_explicit_dynamic_request_with_no_browser_throws_the_actionable_message()
+    {
+        var loader = Loader(NeverBlocked, new HostTierFloor(), cache: null,
+            Http(new CountingTransport("http")), Browser(new BrowserNotConfiguredPageLoadTransport()));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => loader.LoadAsync(new PageRequest("https://x.test/", PageType.Dynamic)));
+    }
+
+    [Fact]
+    public async Task A_blocked_result_is_never_written_to_the_cache()
+    {
+        var http = new CountingTransport("http");
+        var cache = new InMemoryPageCache(TimeSpan.FromMinutes(10));
+        var loader = Loader(BlockHigh("http"), new HostTierFloor(), cache, Http(http)); // single rung => residual
+
+        await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        Assert.Null(await cache.TryReadAsync("https://x.test/", PageType.Static, default));
+    }
+
+    [Fact]
+    public async Task A_clean_result_is_written_to_the_cache()
+    {
+        var cache = new InMemoryPageCache(TimeSpan.FromMinutes(10));
+        var loader = Loader(NeverBlocked, new HostTierFloor(), cache, Http(new CountingTransport("http")));
+
+        await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        var cached = await cache.TryReadAsync("https://x.test/", PageType.Static, default);
+        Assert.Equal("http", cached!.Html);
+    }
+
+    [Fact]
+    public async Task A_cache_hit_short_circuits_the_climb_without_touching_a_transport()
+    {
+        var cache = new InMemoryPageCache(TimeSpan.FromMinutes(10));
+        await cache.WriteAsync("https://x.test/", PageType.Static,
+            new PageLoadResult { Html = "cached" }, default);
+        // Both rungs throw — the test passes only because the cache short-circuits.
+        var loader = Loader(NeverBlocked, new HostTierFloor(), cache,
+            Http(new ThrowingTransport()), Browser(new ThrowingTransport()));
+
+        var result = await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        Assert.Equal("cached", result.Html);
+    }
+
+    [Fact]
+    public async Task A_cache_write_failure_does_not_fail_the_load()
+    {
+        var loader = Loader(NeverBlocked, new HostTierFloor(), new ThrowingWriteCache(),
+            Http(new CountingTransport("http")));
+
+        var result = await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        Assert.Equal("http", result.Html); // the successful load is still returned
+    }
+
+    private sealed class ThrowingWriteCache : IPageCache
+    {
+        public Task<PageLoadResult?> TryReadAsync(string url, PageType pageType, CancellationToken cancellationToken)
+            => Task.FromResult<PageLoadResult?>(null);
+        public Task WriteAsync(string url, PageType pageType, PageLoadResult document, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("Cache backend down.");
+    }
+}

--- a/WebReaper.Tests/WebReaper.UnitTests/HostTierFloorTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/HostTierFloorTests.cs
@@ -1,0 +1,61 @@
+using WebReaper.Core.Blocking.Abstract;
+using WebReaper.Core.Loaders.Concrete;
+using Xunit;
+
+namespace WebReaper.UnitTests;
+
+// ADR-0083 slice 4: the per-host starting-tier memory. Only a high-confidence
+// block lifts the floor; it never lowers; hosts are independent.
+public class HostTierFloorTests
+{
+    [Fact]
+    public void An_unseen_host_starts_at_tier_zero()
+    {
+        var floor = new HostTierFloor();
+        Assert.Equal(0, floor.FloorFor("example.com"));
+    }
+
+    [Fact]
+    public void A_high_confidence_block_lifts_the_floor()
+    {
+        var floor = new HostTierFloor();
+        floor.Lift("example.com", 1, BlockConfidence.High);
+        Assert.Equal(1, floor.FloorFor("example.com"));
+    }
+
+    [Theory]
+    [InlineData(BlockConfidence.Weak)]
+    [InlineData(BlockConfidence.None)]
+    public void A_non_high_block_never_lifts_the_floor(BlockConfidence confidence)
+    {
+        var floor = new HostTierFloor();
+        floor.Lift("example.com", 2, confidence);
+        Assert.Equal(0, floor.FloorFor("example.com"));
+    }
+
+    [Fact]
+    public void The_floor_never_lowers()
+    {
+        var floor = new HostTierFloor();
+        floor.Lift("example.com", 2, BlockConfidence.High);
+        floor.Lift("example.com", 1, BlockConfidence.High); // a lower lift is a no-op
+        Assert.Equal(2, floor.FloorFor("example.com"));
+    }
+
+    [Fact]
+    public void Hosts_are_independent()
+    {
+        var floor = new HostTierFloor();
+        floor.Lift("blocked.com", 1, BlockConfidence.High);
+        Assert.Equal(1, floor.FloorFor("blocked.com"));
+        Assert.Equal(0, floor.FloorFor("clean.com"));
+    }
+
+    [Fact]
+    public void Host_matching_is_case_insensitive()
+    {
+        var floor = new HostTierFloor();
+        floor.Lift("Example.COM", 1, BlockConfidence.High);
+        Assert.Equal(1, floor.FloorFor("example.com"));
+    }
+}

--- a/WebReaper/Builders/SpiderBuilder.cs
+++ b/WebReaper/Builders/SpiderBuilder.cs
@@ -17,6 +17,7 @@ using WebReaper.Core.Crawling.Concrete;
 using WebReaper.Core.Spider.Abstract;
 using WebReaper.Core.Spider.Concrete;
 using WebReaper.Domain;
+using WebReaper.Domain.Selectors;
 using WebReaper.Infra.Abstract;
 using WebReaper.Infra.Concrete;
 using WebReaper.Processing.Abstract;
@@ -310,22 +311,40 @@ internal class SpiderBuilder
         ContentExtractor ??= new SchemaFold<AngleSharp.Dom.IParentNode>(
             new AngleSharpSchemaBackend(), Logger);
 
-        // One loader (ADR 0004). The HTTP transport is the core default; the
-        // Dynamic slot is the registered transport factory (e.g.
-        // WebReaper.Puppeteer's .WithPuppeteerPageLoader()) or, with none, an
-        // actionable throw — core is HTTP-only by default (ADR-0009). The
-        // proxy/no-proxy choice is still a (possibly null) provider handed in
-        // to whichever transports exist, not a branch.
-        // ADR-0041: PageCache is woven in as a cache-aside collaborator —
-        // NullPageCache by default (no behaviour change), real cache when
-        // WithPageCache / WithMaxAge wired one.
-        PageLoader ??= new PageLoader(
-            new HttpPageLoadTransport(CookieStorage, ProxyProvider, Logger),
-            DynamicPageLoadTransportFactory is null
+        // One loader (ADR 0004), now the block-aware climbing loader (ADR-0083).
+        // The HTTP transport is the core default Static rung; the Dynamic rung is
+        // the registered transport factory (e.g. WebReaper.Cdp's
+        // .WithCdpPageLoader()) or, with none, the actionable
+        // BrowserNotConfigured sentinel — core is HTTP-only by default (ADR-0009).
+        // The proxy/no-proxy choice is still a (possibly null) provider handed in
+        // to whichever transports exist, not a branch. Tiers run lowest→highest:
+        // HTTP (Static) then browser (Dynamic); a Static page climbs to the
+        // browser rung on a block, a Dynamic page starts at it. The stealth rung
+        // is added by the CLI flag wiring (ADR-0083 slice 5).
+        // ADR-0041: PageCache is the cache-aside collaborator (NullPageCache by
+        // default); the loader never caches a blocked result, and a climb
+        // bypasses the cache for the higher rung.
+        // The transports are built only when no custom loader was supplied (a
+        // WithPageLoader wiring must not invoke the dynamic transport factory —
+        // it may launch a browser), preserving the old `??=` laziness.
+        if (PageLoader is null)
+        {
+            var httpTransport = new HttpPageLoadTransport(CookieStorage, ProxyProvider, Logger);
+            IPageLoadTransport dynamicTransport = DynamicPageLoadTransportFactory is null
                 ? new BrowserNotConfiguredPageLoadTransport()
-                : DynamicPageLoadTransportFactory(CookieStorage, ProxyProvider, Logger, ActionResolver),
-            Logger,
-            PageCache);
+                : DynamicPageLoadTransportFactory(CookieStorage, ProxyProvider, Logger, ActionResolver);
+
+            PageLoader = new EscalatingPageLoader(
+                new[]
+                {
+                    new PageLoadTier(PageType.Static, httpTransport),
+                    new PageLoadTier(PageType.Dynamic, dynamicTransport),
+                },
+                BlockDetector,
+                new HostTierFloor(),
+                Logger,
+                PageCache);
+        }
 
         CookieStorage.AddAsync(Cookies);
 

--- a/WebReaper/Core/Loaders/Abstract/PageLoadTier.cs
+++ b/WebReaper/Core/Loaders/Abstract/PageLoadTier.cs
@@ -1,0 +1,22 @@
+using WebReaper.Domain.Selectors;
+
+namespace WebReaper.Core.Loaders.Abstract;
+
+/// <summary>
+/// One rung of the <c>EscalatingPageLoader</c>'s ladder (ADR-0083): a
+/// <see cref="IPageLoadTransport"/> paired with the <see cref="PageType"/> it
+/// serves. The ladder is ordered lowest to highest — HTTP (Static) then the
+/// headless-browser transports (Dynamic) — and the loader climbs it on a block.
+/// <para>
+/// The <see cref="PageType"/> tag is how the loader picks a page's starting rung:
+/// a Static page may start on any tier (an HTTP tier serves it, and a browser
+/// tier renders it too), but a Dynamic page must skip the HTTP tier because an
+/// HTTP fetch returns un-rendered HTML. It does not change what a transport does
+/// — a transport is its own mechanism and ignores <c>PageRequest.PageType</c>.
+/// </para>
+/// </summary>
+/// <param name="PageType">The load mode this rung serves: <see cref="PageType.Static"/>
+/// for the HTTP transport, <see cref="PageType.Dynamic"/> for a headless-browser
+/// transport.</param>
+/// <param name="Transport">The mechanism for this rung.</param>
+internal sealed record PageLoadTier(PageType PageType, IPageLoadTransport Transport);

--- a/WebReaper/Core/Loaders/Concrete/EscalatingPageLoader.cs
+++ b/WebReaper/Core/Loaders/Concrete/EscalatingPageLoader.cs
@@ -1,0 +1,179 @@
+using Microsoft.Extensions.Logging;
+using WebReaper.Core.Blocking.Abstract;
+using WebReaper.Core.Loaders.Abstract;
+using WebReaper.Domain.Selectors;
+
+namespace WebReaper.Core.Loaders.Concrete;
+
+/// <summary>
+/// The one <see cref="IPageLoader"/> (ADR-0004), now block-aware and climbing
+/// (ADR-0083 part 4). It composes an ordered ladder of <see cref="PageLoadTier"/>
+/// rungs (HTTP then headless browser then, with the CLI flag wiring, stealth),
+/// the <see cref="IBlockDetector"/>, a per-run <see cref="HostTierFloor"/>, and
+/// the <see cref="IPageCache"/>. For one page it starts at the host floor, loads
+/// at the current rung, runs the detector, and if the result looks blocked and a
+/// higher real rung exists it climbs and reloads; it returns the best
+/// <see cref="PageLoadResult"/> it reached.
+/// <para>
+/// Because the whole climb lives inside one <see cref="LoadAsync"/> call, the
+/// Crawl driver, scheduler, and visited-link tracker are untouched (ADR-0022's
+/// transport-blind driver holds) — so <c>scrape</c> and <c>crawl</c> both get
+/// climbing for free. The loader does not return the verdict: the Spider
+/// re-runs the same pure <see cref="IBlockDetector"/> on the returned result for
+/// the Job report, which yields the final rung's verdict by construction.
+/// </para>
+/// <para>
+/// Quarantine-clean (ADR-0009): the browser / stealth rungs are injected
+/// <see cref="IPageLoadTransport"/>s supplied by the Cdp / Playwright satellites;
+/// core never references them. The only rung type core knows by name is the
+/// <see cref="BrowserNotConfiguredPageLoadTransport"/> sentinel, which is treated
+/// as "no real rung" so auto-escalation never launches a browser the consumer
+/// did not configure.
+/// </para>
+/// </summary>
+internal sealed class EscalatingPageLoader : IPageLoader
+{
+    private readonly IReadOnlyList<PageLoadTier> _tiers;
+    private readonly IBlockDetector _blockDetector;
+    private readonly HostTierFloor _hostTierFloor;
+    private readonly IPageCache _cache;
+    private readonly ILogger _logger;
+
+    public EscalatingPageLoader(
+        IReadOnlyList<PageLoadTier> tiers,
+        IBlockDetector blockDetector,
+        HostTierFloor hostTierFloor,
+        ILogger logger,
+        IPageCache? cache = null)
+    {
+        ArgumentNullException.ThrowIfNull(tiers);
+        if (tiers.Count == 0)
+            throw new ArgumentException("The escalating loader needs at least one tier.", nameof(tiers));
+        ArgumentNullException.ThrowIfNull(blockDetector);
+        ArgumentNullException.ThrowIfNull(hostTierFloor);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _tiers = tiers;
+        _blockDetector = blockDetector;
+        _hostTierFloor = hostTierFloor;
+        _logger = logger;
+        // ADR-0041: NullPageCache preserves the no-cache behaviour exactly.
+        _cache = cache ?? new NullPageCache();
+    }
+
+    public async Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
+    {
+        var host = HostOf(request.Url);
+
+        // ADR-0041 + ADR-0083: the cache-aside read happens once, before the
+        // climb. A hit is always a clean (non-blocked) result — a blocked result
+        // is never written — so it is safe to serve without re-detecting.
+        var cached = await _cache.TryReadAsync(request.Url, request.PageType, cancellationToken);
+        if (cached is not null)
+        {
+            _logger.LogInformation("Page cache hit for {Url}", request.Url);
+            return cached;
+        }
+
+        var start = StartTier(request.PageType, _hostTierFloor.FloorFor(host));
+
+        PageLoadResult result = null!;
+        for (var tier = start; tier < _tiers.Count; tier++)
+        {
+            _logger.LogInformation(
+                "Loading {PageType} page {Url} at tier {Tier}",
+                _tiers[tier].PageType, request.Url, tier);
+
+            // ADR-0083: a climb bypasses the cache for the higher rung (no read
+            // here), so a stale cached lower-tier result can never silently
+            // defeat a climb. A transport fault (no response) throws a
+            // PageLoadException and propagates to the retry policy — only a
+            // completed, detector-flagged response climbs.
+            result = await _tiers[tier].Transport.LoadAsync(request, cancellationToken);
+
+            var verdict = _blockDetector.Detect(result);
+            if (!verdict.IsBlocked)
+            {
+                // Only clean results are cached (so the read above is always
+                // safe to serve). A cache-write failure must not fail the load.
+                await TryWriteCacheAsync(request, result, cancellationToken);
+                return result;
+            }
+
+            // Blocked. A real higher rung is one that is configured — the
+            // BrowserNotConfigured sentinel does not count, so auto-escalation
+            // never launches a browser the consumer did not wire (an explicit
+            // Dynamic-start load still hits the sentinel's actionable throw).
+            var hasHigherTier =
+                tier + 1 < _tiers.Count && IsRealTier(_tiers[tier + 1]);
+
+            // ADR-0083 part 5: only a high-confidence block lifts the host floor
+            // (a weak body-marker is too unreliable to promote a whole host),
+            // and only to a real rung — never strand the host on the sentinel.
+            if (hasHigherTier)
+                _hostTierFloor.Lift(host, tier + 1, verdict.Confidence);
+
+            if (!hasHigherTier)
+            {
+                // Ceiling: the top reachable rung is still blocked. Return the
+                // residual-blocked result UNCACHED; the driver's block drop
+                // policy (slice 3) suppresses and tallies it.
+                _logger.LogInformation(
+                    "Page {Url} still blocked at the top tier: {Reason}",
+                    request.Url, verdict.Reason);
+                return result;
+            }
+
+            _logger.LogInformation(
+                "Page {Url} blocked at tier {Tier} ({Reason}); climbing to tier {Next}",
+                request.Url, tier, verdict.Reason, tier + 1);
+        }
+
+        // Unreachable: the loop returns on the first clean load or at the
+        // ceiling, and StartTier keeps the start index in range.
+        return result;
+    }
+
+    // The starting rung for a request: a Dynamic page cannot be served by an
+    // HTTP (Static) rung, so it starts at the first Dynamic-capable rung; a
+    // Static page can start anywhere and so starts at the host floor. Never
+    // below the floor, never past the top rung.
+    private int StartTier(PageType pageType, int floor)
+    {
+        var min = pageType == PageType.Dynamic ? FirstDynamicTier() : 0;
+        var start = Math.Max(floor, min);
+        return Math.Min(start, _tiers.Count - 1);
+    }
+
+    private int FirstDynamicTier()
+    {
+        for (var i = 0; i < _tiers.Count; i++)
+            if (_tiers[i].PageType == PageType.Dynamic) return i;
+
+        // No Dynamic rung in the ladder (an HTTP-only wiring). Clamp to the top
+        // rung; in practice the Dynamic slot is always present (a real browser
+        // transport or the actionable sentinel), so this fallback never trips.
+        return _tiers.Count - 1;
+    }
+
+    // The BrowserNotConfigured sentinel is the absence of a configured browser,
+    // not a real rung to auto-escalate into.
+    private static bool IsRealTier(PageLoadTier tier) =>
+        tier.Transport is not BrowserNotConfiguredPageLoadTransport;
+
+    private async Task TryWriteCacheAsync(
+        PageRequest request, PageLoadResult result, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _cache.WriteAsync(request.Url, request.PageType, result, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Page cache write failed for {Url}", request.Url);
+        }
+    }
+
+    private static string HostOf(string url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri.Host : url;
+}

--- a/WebReaper/Core/Loaders/Concrete/HostTierFloor.cs
+++ b/WebReaper/Core/Loaders/Concrete/HostTierFloor.cs
@@ -1,0 +1,49 @@
+using System.Collections.Concurrent;
+using WebReaper.Core.Blocking.Abstract;
+
+namespace WebReaper.Core.Loaders.Concrete;
+
+/// <summary>
+/// The <c>EscalatingPageLoader</c>'s per-run, per-host starting-tier memory
+/// (ADR-0083 part 5). Bot protection is near-always site-wide, so once one page
+/// on a host is confirmed blocked at a tier, every later same-host page should
+/// start higher rather than re-pay the failed lower tier. This holds that floor.
+/// <para>
+/// The floor lifts <b>only on a high-confidence block</b> (a challenge-class
+/// status or header), never on a weak body-marker block — so one false-positive
+/// page (a post that merely names a vendor) cannot promote a whole legitimate
+/// host. The floor never lowers. State lives for the loader's (engine's)
+/// lifetime and resets with a fresh engine; the precedent is the ADR-0050
+/// <c>SemanticActCoordinator</c> per-crawl cache.
+/// </para>
+/// <para>Thread-safe: a parallel crawl loads many same-host pages at once.</para>
+/// </summary>
+internal sealed class HostTierFloor
+{
+    // Host comparison is case-insensitive (hosts are). The value is the lowest
+    // tier index a page on that host should start at.
+    private readonly ConcurrentDictionary<string, int> _floors =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>The starting tier index for <paramref name="host"/>; 0 (the
+    /// lowest rung) until a high-confidence block lifts it.</summary>
+    public int FloorFor(string host) => _floors.TryGetValue(host, out var tier) ? tier : 0;
+
+    /// <summary>
+    /// Raise <paramref name="host"/>'s floor to <paramref name="tier"/>, but
+    /// only when <paramref name="confidence"/> is
+    /// <see cref="BlockConfidence.High"/> — a weak body-marker block is too
+    /// unreliable to promote a whole host. The floor never lowers: a lift to a
+    /// tier at or below the current floor is a no-op.
+    /// </summary>
+    /// <param name="host">The host whose floor to raise.</param>
+    /// <param name="tier">The tier index to raise the floor to (typically the
+    /// rung above the one that blocked).</param>
+    /// <param name="confidence">The blocking verdict's confidence; only
+    /// <see cref="BlockConfidence.High"/> lifts.</param>
+    public void Lift(string host, int tier, BlockConfidence confidence)
+    {
+        if (confidence != BlockConfidence.High) return;
+        _floors.AddOrUpdate(host, tier, (_, current) => Math.Max(current, tier));
+    }
+}


### PR DESCRIPTION
## What

Slice 4 of [ADR-0083](docs/adr/0083-escalating-page-loader.md) — the per-page climb. The one `IPageLoader` becomes the block-aware **escalating loader**: for each page it starts at the host's floor tier, loads, and if the result is a **blocked page** with a higher real tier above it, climbs and reloads, returning the best `PageLoadResult` it reached. Because the whole climb lives inside one `LoadAsync`, the Crawl driver, scheduler, and visited-link tracker are untouched (ADR-0022 holds), so **`scrape` and `crawl` both get HTTP→browser climbing for free**.

Closes #174. Builds on #176/#178/#179 (slices 1–3).

## New core types

- **`EscalatingPageLoader`** (`IPageLoader`): ordered `PageLoadTier`s + `IBlockDetector` + `HostTierFloor` + block-aware cache-aside. A Static page starts at HTTP and climbs to the browser tier on a block; a Dynamic page starts at the browser tier (an HTTP fetch can't render it). It does **not** return the verdict — the Spider re-runs the pure detector on the result, yielding the final tier's verdict by construction, so `IPageLoader.LoadAsync` keeps its shape.
- **`HostTierFloor`**: per-run, per-host starting-tier memory. Lifts **only on a high-confidence block** (a weak body-marker never promotes a host), never lowers. A status-signalling host settles at its working tier after the first confirmed block, so later same-host pages skip the doomed lower tiers (a bounded one-time climb cost per host).
- **`PageLoadTier(PageType, IPageLoadTransport)`**: one rung of the ladder.

## Quarantine + edge behavior

- **Quarantine-clean** (ADR-0009): browser/stealth tiers are injected transports from the Cdp/Playwright satellites. The only tier type core names is the `BrowserNotConfigured` sentinel, treated as a **non-real climb target** so auto-escalation never launches a browser the consumer didn't configure — an explicit Dynamic load still throws the actionable message.
- **Cache** (ADR-0041 part 9): a blocked result is never written; a climb bypasses the cache for the higher rung.
- **Faults vs blocks**: a no-response `PageLoadException` still propagates to the retry policy; only a completed, detector-flagged response climbs.

## Breaking (behavioral)

The default loader now climbs HTTP→browser on a block when a browser transport is registered; a previously blocked Static page is re-loaded via the browser tier instead of returned blocked. No public API shape changed.

## Scope

`scrape` + `crawl` (the shared `SpiderBuilder` loader path, used by the in-process and distributed Crawl drivers). `map` is out of scope (its own HttpClient, ADR-0083 part 7); the Agent driver keeps the simpler non-climbing `PageLoader`. The stealth tier and the CLI starting-tier flags (`--browser`/`--stealth`) are slice 5 (#175).

> Review note: the wiring keeps the old `??=` laziness via an `if (PageLoader is null)` guard, so a custom `WithPageLoader` never invokes the dynamic transport factory (which may launch a browser).

## Tests / verification

- `EscalatingPageLoaderTests` (13): climb on block, stop at ceiling (residual), return first clean, Dynamic skips HTTP, host floor settles after a High block, Weak never lifts, sentinel is not an auto-climb target, explicit Dynamic-no-browser throws, blocked never cached, clean cached, cache hit short-circuits, write failure swallowed.
- `HostTierFloorTests` (7): High lifts, Weak/None don't, never lowers, hosts independent, case-insensitive.
- All gates green locally: solution build (0 errors), UnitTests (551), AI.Tests (274), Cli.Tests (125), IntegrationTests `Category=LocalServer` (15), Redis distributed adapters via Testcontainers (6), and the AOT smoke test.

`CONTEXT.md` gains **Escalating page loader**, **Load tier**, and **Host tier floor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)