### PR TITLE
fix(website): inline code rendered literal backticks on all prose pages

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -256,7 +256,7 @@
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
-[data-line] {
+[data-rehype-pretty-code-figure] [data-line] {
   display: inline-block;
   width: 100%;
 }

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -307,3 +307,26 @@
     transform: none !important;
   }
 }
+
+/* ----------------------------------------------------------------------------
+   Authoritative inline-code styling. @tailwindcss/typography injects
+   `code::before/::after { content: "`" }` and default code styling that were
+   winning over the earlier reset (the `:where(code)` wrapper zeroed our element
+   specificity). This block is later in source order AND higher specificity
+   (`.prose :not(pre) > code` beats `.prose :where(code)`), with !important on
+   the pseudo-content reset, so it wins deterministically. Shiki blocks live in
+   <pre>, so `:not(pre) >` leaves them untouched.
+---------------------------------------------------------------------------- */
+.prose :not(pre) > code::before,
+.prose :not(pre) > code::after {
+  content: "" !important;
+}
+.prose :not(pre) > code {
+  border-radius: 0.375rem;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  padding: 0.1rem 0.35rem;
+  font-size: 0.85em;
+  font-weight: 500;
+  color: var(--foreground);
+}

--- a/website/velite.config.ts
+++ b/website/velite.config.ts
@@ -11,7 +11,7 @@ import remarkGfm from "remark-gfm";
 const prettyCode: PrettyCodeOptions = {
   theme: "github-dark-default",
   keepBackground: false,
-  defaultLang: { block: "text", inline: "text" },
+  defaultLang: { block: "text" },
 };
 
 const autolink: [typeof rehypeAutolinkHeadings, Record<string, unknown>] = [


### PR DESCRIPTION
## The bug

Every docs / blog / use-case page rendered inline code with **literal backtick characters** around it, and each code token broke onto its own line with no code box. Reported on the CLI reference page; it affected all `.prose` content.

## Root cause

`@tailwindcss/typography` injects `code::before { content: "\`" }` / `::after` plus default code styling. The earlier reset selector wrapped the element as `:where(code)`, which zeroes the element's specificity contribution, so the typography rules won the cascade. The backtick pseudo-content showed and the custom code-box styling never applied.

## Fix

An authoritative override appended to `app/globals.css`:
- `.prose :not(pre) > code` — higher specificity than `.prose :where(code)`, later in source order, unlayered.
- `!important` on the `::before`/`::after` content reset so the backtick can never win.
- Shiki code blocks live in `<pre>`, so `:not(pre) >` leaves them untouched.

## Verification

- In-browser (browser-harness): inline `<code>` computed `::before`/`::after` content is now `none` (was the backtick char); code boxes render; CLI + blog pages read as clean flowing prose.
- `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)