### PR TITLE
docs(website): refresh bot-check copy for the v11 escalation model

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -41,8 +41,8 @@ const pillars = [
   },
   {
     icon: Shield,
-    title: "Bot-checks handled",
-    body: "Auto-detects Cloudflare, DataDome, and PerimeterX. One flag escalates to a stealth Chromium backend that installs itself.",
+    title: "Bot-checks handled automatically",
+    body: "Detects Cloudflare, DataDome, and PerimeterX and climbs from HTTP to a browser to stealth, per page and host-sticky. Blocked pages are dropped, never returned as data.",
   },
   {
     icon: Network,
@@ -400,8 +400,8 @@ webreaper map https://example.com --search /blog/ --max-urls 50
 # Crawl a whole site to JSON Lines
 webreaper crawl https://example.com > pages.jsonl
 
-# Bot-protected? Auto-detect, install stealth, retry
-webreaper scrape https://example.com --browser --auto-stealth`}
+# Bot-protected? A plain scrape auto-climbs to a browser; --stealth starts at the top tier
+webreaper scrape https://example.com --stealth`}
           />
         </div>
       </section>

--- a/website/content/blog/scraping-cloudflare-dotnet.mdx
+++ b/website/content/blog/scraping-cloudflare-dotnet.mdx
@@ -23,7 +23,8 @@ shows the library equivalent.
 
 If a site fails a plain fetch but is not running aggressive fingerprinting, a
 real headless browser is often enough, because the page just needs JavaScript to
-execute. From the CLI, that is one flag.
+execute. A plain scrape already climbs to a browser on its own when a page looks
+blocked, so the flag below just starts there and skips the HTTP probe.
 
 ```bash
 webreaper scrape https://protected.example.com --browser --output page.md
@@ -34,37 +35,41 @@ delay. After that, the page renders in a real engine, scripts run, and the
 challenge that blocked your HTTP client resolves on its own. For a large share
 of "this site is blocking me" cases, the story ends here.
 
-## Step two: let it escalate to stealth
+## Step two: let it climb to stealth
 
 Some sites look harder at who is knocking. When a real browser still comes back
-with a 403, a 429, a 503, or an empty result on a page carrying a known
-challenge marker, WebReaper can escalate to a stealth Chromium backend that is
-tuned to pass those checks.
+with a 403, a 429, a 503, a challenge response header, or an empty result on a
+page carrying a known challenge marker, WebReaper climbs one more rung to a
+stealth Chromium backend tuned to pass those checks.
 
 ```bash
-webreaper scrape https://protected.example.com --browser --auto-stealth
+webreaper scrape https://protected.example.com --stealth
 ```
 
-With `--auto-stealth`, WebReaper detects the bot-check, escalates, and installs
-the stealth backend on first use if it is not already present. The detection
-covers Cloudflare, DataDome, PerimeterX, Incapsula, and Akamai. It is a single
-retry: if the stealth attempt is also judged blocked, WebReaper stops and points
-you at a captcha solver rather than burning requests in a loop.
+`--stealth` starts the climb at the stealth backend; a plain scrape blocked at a
+vanilla browser climbs there on its own. The climb happens inside a single load,
+per page: WebReaper detects the block (a challenge status, a response header, or
+a body marker, covering Cloudflare, DataDome, PerimeterX, Incapsula, and Akamai),
+escalates to the next rung, reloads, and returns the best result it reached. A
+page still blocked at the top rung is dropped rather than emitted as a challenge
+page, and the run exits non-zero so you know.
 
 ## Unattended runs
 
-The default escalation asks for confirmation before it downloads and launches a
-stealth backend, which is the right behavior at an interactive terminal. In CI,
-a cron job, or an agent loop, there is no one to answer the prompt. Set an
-environment variable and it proceeds on its own.
+Including the stealth rung downloads a few hundred megabytes on first use, so at
+an interactive terminal WebReaper asks once, at startup, before committing to it.
+In CI, a cron job, or an agent loop there is no one to answer, so set an
+environment variable (or pass `--auto-stealth`) and it includes the stealth rung
+without a prompt.
 
 ```bash
 WEBREAPER_AUTO_STEALTH=1 webreaper scrape https://protected.example.com --output page.md
 ```
 
-With that set, a detected bot-check escalates to stealth without a prompt. The
-same single-retry discipline applies, so an unattended run will not spin
-forever: it either gets the page or exits with a clear failure.
+With that set, the climb runs the full ladder unattended. It never spins
+forever: a page still blocked at the top rung is dropped and the run exits with a
+clear, non-zero status. Pass `--no-auto-stealth` to cap the climb at a vanilla
+browser.
 
 ## The library equivalent
 


### PR DESCRIPTION
## What

Website slice of "market v11". The marketing site still described the removed ADR-0056 detect-and-retry stealth model; this refreshes it to the v11 (ADR-0083) per-page **HTTP → browser → stealth** climb. Companion to the README pass in #186.

## Changes (copy only)

- **Homepage** (`app/page.tsx`): the "Bot-checks handled" feature card and the bot-protected code example rewritten — a plain scrape auto-climbs to a browser; `--stealth` starts at the top tier; blocked pages are dropped, not returned as data. (Was "one flag, auto-detect, install, retry".)
- **Blog** (`content/blog/scraping-cloudflare-dotnet.mdx`): "Step two" and "Unattended runs" rewritten from the removed single-retry model to the per-page climb (blocked pages dropped at the top tier, non-zero exit, stealth inclusion decided once at startup), plus a Step-one note that a plain scrape auto-climbs. The library examples (`CrawlWithBrowser` + Playwright/CloakBrowser) and the captcha "honest limit" section were already accurate and are left intact.

No layout or design changes; no em-dashes in the new copy.

## Verification

`pnpm build` (velite + next build) passes locally — all routes prerender, including the edited `/blog/scraping-cloudflare-dotnet`. The Vercel preview on this PR is the live visual check.

## Remaining on "market v11"

The waitlist/billing activation (needs a product decision: email-capture waitlist vs. real Stripe checkout, and the paid-tier promise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)