### PR TITLE
feat(website): capture Cloud waitlist signups by emailing the owner

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -1,0 +1,22 @@
+# WebReaper website environment variables.
+# Copy to .env.local for local dev, or set in the Vercel project settings.
+# Everything here is optional: with none set, the site builds and runs, and the
+# Cloud waitlist still accepts signups (it just does not notify anyone yet).
+
+# --- Cloud waitlist lead notification (pricing page "Join the Cloud waitlist") ---
+# Set RESEND_API_KEY to be emailed whenever someone joins the waitlist.
+# Get a free key at https://resend.com. Without it, signups succeed silently.
+RESEND_API_KEY=
+
+# Optional overrides (defaults shown commented):
+# Who receives the notification. Defaults to siteConfig.contactEmail.
+# WAITLIST_NOTIFY_TO=business@highcraft.io
+# The sender. The default needs no domain verification but delivers ONLY to your
+# Resend account's own address (fine for owner notifications). Verify a domain in
+# Resend and set this to send from your own address.
+# WAITLIST_NOTIFY_FROM="WebReaper Waitlist <onboarding@resend.dev>"
+
+# --- Stripe (future) ---
+# Set this to switch the subscribe flow from the waitlist to real Stripe
+# Checkout (see lib/billing.ts). Leave empty until the Cloud product exists.
+# STRIPE_SECRET_KEY=

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+# ...but the documented template is tracked.
+!.env.example
 
 # vercel
 .vercel

--- a/website/lib/billing.ts
+++ b/website/lib/billing.ts
@@ -1,3 +1,5 @@
+import { siteConfig } from "@/lib/site";
+
 export type CheckoutResult = {
   ok: boolean;
   mode: "stripe" | "waitlist";
@@ -22,11 +24,65 @@ export async function createCheckout(
     // return { ok: true, mode: "stripe", url: session.url ?? undefined };
   }
 
-  // Waitlist fallback: in production this would persist `email` + `plan`.
-  void email;
+  // Waitlist: notify the site owner of the signup (best-effort). A failed or
+  // unconfigured notification must never fail the signup, so the UI stays wired
+  // end to end; set RESEND_API_KEY to start receiving leads. Drop in Stripe
+  // later by setting STRIPE_SECRET_KEY above.
+  await notifyWaitlistSignup(plan, email);
   return {
     ok: true,
     mode: "waitlist",
     message: "You're on the list. We'll email you when Cloud opens up.",
   };
+}
+
+/**
+ * Email the site owner that someone joined the Cloud waitlist, via the Resend
+ * REST API (no SDK dependency). Gated on RESEND_API_KEY: without it the signup
+ * still succeeds and nothing is sent (the UI is wired end to end either way).
+ * Best-effort, so a notification failure never fails the signup. See
+ * .env.example for the env vars.
+ *
+ * The default sender `onboarding@resend.dev` needs no domain verification but
+ * delivers only to the Resend account's own address, which is exactly the owner
+ * notification here; verify a domain and set WAITLIST_NOTIFY_FROM to send
+ * confirmations to the signer-up.
+ */
+async function notifyWaitlistSignup(plan: string, email?: string): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return;
+
+  const to = process.env.WAITLIST_NOTIFY_TO ?? siteConfig.contactEmail;
+  const from =
+    process.env.WAITLIST_NOTIFY_FROM ?? "WebReaper Waitlist <onboarding@resend.dev>";
+
+  try {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from,
+        to: [to],
+        reply_to: email,
+        subject: `WebReaper Cloud waitlist: ${plan}`,
+        text:
+          `New WebReaper Cloud waitlist signup.\n\n` +
+          `Plan:  ${plan}\n` +
+          `Email: ${email ?? "(not provided)"}\n` +
+          `Time:  ${new Date().toISOString()}\n`,
+      }),
+    });
+    if (!res.ok) {
+      console.error(
+        "Waitlist notification failed:",
+        res.status,
+        await res.text().catch(() => ""),
+      );
+    }
+  } catch (err) {
+    console.error("Waitlist notification error:", err);
+  }
 }


### PR DESCRIPTION
## What

Final "market v11" slice: make the Cloud waitlist actually capture leads. The pricing-page modal ("Join the Cloud waitlist") was wired end to end, but `lib/billing.ts` discarded the email (`void email`), so signups showed a success message and then vanished. The waitlist branch now **emails the site owner on each signup** via the Resend REST API (no SDK dependency).

## How

- `notifyWaitlistSignup(plan, email)` POSTs to `https://api.resend.com/emails` with the plan, the lead's email, and a timestamp; `reply_to` is the lead so you can reply directly.
- **Gated on `RESEND_API_KEY`.** Without it, the signup still succeeds and nothing is sent — the UI stays wired end to end, and the build / Vercel preview are unaffected until you set the key. **Best-effort:** a Resend failure is logged, never fails the signup.
- Recipient defaults to `siteConfig.contactEmail` (`business@highcraft.io`); sender defaults to `onboarding@resend.dev` (no domain verification needed, delivers to your Resend account address — exactly the owner notification). Both overridable via env.
- `.env.example` documents `RESEND_API_KEY` + the optional overrides + the Stripe switch; a `!.env.example` gitignore exception tracks the template.

## Why not Stripe

The `STRIPE_SECRET_KEY` seam is untouched. The Cloud / managed-stealth product doesn't exist yet, so a lead-capture waitlist is the right move now, not a checkout for vaporware. Dropping Stripe in later stays a one-function change.

## To activate

Set `RESEND_API_KEY` in the Vercel project (sign up at resend.com with `business@highcraft.io` so the default sender delivers to you). That's the only required secret.

## Verification

`pnpm build` (velite + next build) passes. The Vercel preview on this PR exercises the build; the email path is inert without the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)