### PR TITLE
fix(website): readable light theme + remove author byline

### DIFF
--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -31,7 +31,6 @@ export async function generateMetadata({
       url,
       type: "article",
       publishedTime: post.date,
-      authors: [post.author],
     },
   };
 }
@@ -57,8 +56,6 @@ export default async function BlogPostPage({ params }: { params: Params }) {
         <header className="mt-6 border-b border-border pb-8">
           <div className="flex flex-wrap items-center gap-3 text-sm text-muted-2">
             <span>{formatDate(post.date)}</span>
-            <span>·</span>
-            <span>{post.author}</span>
             <span>·</span>
             <span>{post.metadata.readingTime} min read</span>
           </div>

--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -80,7 +80,7 @@ export default async function BlogPostPage({ params }: { params: Params }) {
           ) : null}
         </header>
 
-        <div className="prose prose-invert mt-8 max-w-none prose-headings:scroll-mt-24 prose-headings:font-semibold prose-headings:tracking-tight prose-h2:mt-10 prose-a:font-medium prose-a:text-accent prose-a:no-underline hover:prose-a:underline prose-strong:text-foreground prose-li:marker:text-muted-2">
+        <div className="prose dark:prose-invert mt-8 max-w-none prose-headings:scroll-mt-24 prose-headings:font-semibold prose-headings:tracking-tight prose-h2:mt-10 prose-a:font-medium prose-a:text-accent prose-a:no-underline hover:prose-a:underline prose-strong:text-foreground prose-li:marker:text-muted-2">
           <MDXContent code={post.code} />
         </div>
       </article>

--- a/website/app/docs/[...slug]/page.tsx
+++ b/website/app/docs/[...slug]/page.tsx
@@ -63,7 +63,7 @@ export default async function DocPage({ params }: { params: Params }) {
           ) : null}
         </header>
 
-        <div className="prose prose-invert mt-8 max-w-none prose-headings:scroll-mt-24 prose-headings:font-semibold prose-headings:tracking-tight prose-h2:mt-10 prose-h2:border-b prose-h2:border-border prose-h2:pb-2 prose-a:font-medium prose-a:text-accent prose-a:no-underline hover:prose-a:underline prose-strong:text-foreground prose-li:marker:text-muted-2">
+        <div className="prose dark:prose-invert mt-8 max-w-none prose-headings:scroll-mt-24 prose-headings:font-semibold prose-headings:tracking-tight prose-h2:mt-10 prose-h2:border-b prose-h2:border-border prose-h2:pb-2 prose-a:font-medium prose-a:text-accent prose-a:no-underline hover:prose-a:underline prose-strong:text-foreground prose-li:marker:text-muted-2">
           <MDXContent code={doc.code} />
         </div>
 

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -35,7 +35,6 @@ export const metadata: Metadata = {
     "Firecrawl alternative",
     "WebReaper",
   ],
-  authors: [{ name: "Oleksandr Pavlov" }],
   creator: "WebReaper",
   openGraph: {
     type: "website",

--- a/website/app/use-cases/[slug]/page.tsx
+++ b/website/app/use-cases/[slug]/page.tsx
@@ -62,7 +62,7 @@ export default async function UseCasePage({ params }: { params: Params }) {
           <p className="mt-3 text-lg text-muted">{uc.description}</p>
         </header>
 
-        <div className="prose prose-invert mt-10 max-w-none prose-headings:scroll-mt-24 prose-headings:font-semibold prose-headings:tracking-tight prose-a:font-medium prose-a:text-accent prose-a:no-underline hover:prose-a:underline prose-strong:text-foreground">
+        <div className="prose dark:prose-invert mt-10 max-w-none prose-headings:scroll-mt-24 prose-headings:font-semibold prose-headings:tracking-tight prose-a:font-medium prose-a:text-accent prose-a:no-underline hover:prose-a:underline prose-strong:text-foreground">
           <MDXContent code={uc.code} />
         </div>
 

--- a/website/components/legal-page.tsx
+++ b/website/components/legal-page.tsx
@@ -21,7 +21,7 @@ export function LegalPage({ slug }: { slug: string }) {
           })}
         </p>
       ) : null}
-      <div className="prose prose-invert mt-8 max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:font-medium prose-a:text-accent prose-a:no-underline hover:prose-a:underline prose-strong:text-foreground">
+      <div className="prose dark:prose-invert mt-8 max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:font-medium prose-a:text-accent prose-a:no-underline hover:prose-a:underline prose-strong:text-foreground">
         <MDXContent code={page.code} />
       </div>
     </div>

--- a/website/content/blog/ai-native-scraping-dotnet.mdx
+++ b/website/content/blog/ai-native-scraping-dotnet.mdx
@@ -2,7 +2,6 @@
 title: "AI-native scraping in .NET: deterministic where you can, AI where you must"
 description: How WebReaper pairs deterministic CSS and Markdown extraction with an LLM fallback that only fires on empty fields, then caches the fix.
 date: 2026-05-28
-author: Oleksandr Pavlov
 tags:
   - engineering
   - ai

--- a/website/content/blog/introducing-webreaper.mdx
+++ b/website/content/blog/introducing-webreaper.mdx
@@ -2,7 +2,6 @@
 title: Introducing WebReaper
 description: An AI-native web scraper for .NET that ships as a single binary with a bundled Claude Code skill.
 date: 2026-05-30
-author: Oleksandr Pavlov
 tags:
   - announcement
 ---

--- a/website/content/blog/scraping-cloudflare-dotnet.mdx
+++ b/website/content/blog/scraping-cloudflare-dotnet.mdx
@@ -2,7 +2,6 @@
 title: "Scraping Cloudflare-protected sites from .NET"
 description: A practical walkthrough of WebReaper's browser and auto-stealth escalation for sites behind Cloudflare, DataDome, and other bot managers.
 date: 2026-05-30
-author: Oleksandr Pavlov
 tags:
   - guide
   - stealth

--- a/website/content/blog/webreaper-vs-firecrawl.mdx
+++ b/website/content/blog/webreaper-vs-firecrawl.mdx
@@ -2,7 +2,6 @@
 title: "WebReaper vs Firecrawl: a local-first, MIT-licensed alternative"
 description: An honest comparison of WebReaper and Firecrawl across distribution model, licensing, AI features, and when each one is the right call.
 date: 2026-05-29
-author: Oleksandr Pavlov
 tags:
   - comparison
 ---


### PR DESCRIPTION
Two reader-facing fixes for the articles/docs.

## 1. Article text unreadable in light theme

Every `.prose` block applied `prose-invert` unconditionally. That is Tailwind Typography's dark-mode inversion (light text for dark backgrounds), so light theme rendered body text light-gray-on-white, nearly invisible. Hidden because the site defaults to dark.

**Fix:** `prose-invert` → `dark:prose-invert` on all prose surfaces (docs, blog post, use-case, legal). Verified: light body `#374151` on white (~10:1); dark unchanged.

## 2. Remove author byline

Dropped the "Oleksandr Pavlov" name from blog bylines, the OG `article:author` metadata, the 4 post frontmatter `author:` fields, and the site-wide `authors` metadata. Blog meta now reads `date · N min read`. (This was originally done in #187 but got orphaned when that PR merged before the commit landed.)

`pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)