### PR TITLE
chore(website): point canonical domain at webreaper.ai

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -3,6 +3,12 @@
 # Everything here is optional: with none set, the site builds and runs, and the
 # Cloud waitlist still accepts signups (it just does not notify anyone yet).
 
+# --- Canonical site URL ---
+# Feeds metadataBase, canonical tags, sitemap, robots, RSS, and llms.txt.
+# Defaults to https://webreaper.ai (the production domain). Override only for
+# preview/staging deploys served from a different host.
+# NEXT_PUBLIC_SITE_URL=https://webreaper.ai
+
 # --- Cloud waitlist lead notification (pricing page "Join the Cloud waitlist") ---
 # Set RESEND_API_KEY to be emailed whenever someone joins the waitlist.
 # Get a free key at https://resend.com. Without it, signups succeed silently.

--- a/website/lib/site.ts
+++ b/website/lib/site.ts
@@ -3,7 +3,7 @@ export const siteConfig = {
   shortDescription: "AI-native web scraping for .NET",
   description:
     "WebReaper is an AI-native web scraper for .NET. A single ~12 MB binary that turns any site into clean Markdown or structured data, with an LLM layer when you need it. No Docker, no signup, MIT licensed.",
-  url: process.env.NEXT_PUBLIC_SITE_URL ?? "https://webreaper.dev",
+  url: process.env.NEXT_PUBLIC_SITE_URL ?? "https://webreaper.ai",
   ogImage: "/og/default.png",
   version: "10.3.0",
   install: {


### PR DESCRIPTION
## What

Point the website's canonical domain at the newly-registered **webreaper.ai** (bought on Vercel).

`siteConfig.url` was still defaulting to the `webreaper.dev` placeholder. Flipping that one value propagates everywhere, since every SEO surface derives from it:

- `metadataBase` (`app/layout.tsx`)
- canonical tags (use-cases, blog, docs pages)
- `sitemap.ts`, `robots.ts`
- blog RSS feed, `llms.txt`

Also documents the `NEXT_PUBLIC_SITE_URL` override in `.env.example` for preview/staging hosts.

## Verification

The Vercel preview build on this PR should render the canonical/OG/sitemap URLs as `https://webreaper.ai`. Confirmed no remaining `webreaper.dev` or `*.vercel.app` hardcodes anywhere in `website/`.

## Out of scope (heads-up)

`siteConfig.version` is still `10.3.0` while v11.0.0 has shipped. Left untouched to keep this PR domain-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)