### PR TITLE
chore(website): land 11.0.0 version bump missed by #191 squash

### DIFF
--- a/website/lib/site.ts
+++ b/website/lib/site.ts
@@ -5,7 +5,7 @@ export const siteConfig = {
     "WebReaper is an AI-native web scraper for .NET. A single ~12 MB binary that turns any site into clean Markdown or structured data, with an LLM layer when you need it. No Docker, no signup, MIT licensed.",
   url: process.env.NEXT_PUBLIC_SITE_URL ?? "https://webreaper.ai",
   ogImage: "/og/default.png",
-  version: "10.3.0",
+  version: "11.0.0",
   install: {
     brew: "brew install pavlovtech/webreaper/webreaper",
     curl: "curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh",


### PR DESCRIPTION
## What

Lands the `siteConfig.version` bump `10.3.0` → `11.0.0` on `master`. One line, no behaviour change.

## Why it's a separate PR

[#191](https://github.com/pavlovtech/WebReaper/pull/191) was squash-merged with only its first commit (the domain change). The version-bump commit was pushed to the branch moments later, so the squash didn't capture it.

Production already serves `11.0.0` (it was deployed from the branch tip, ahead of the merge), so this just reconciles `master` with what is already live. Verified: `origin/master:website/lib/site.ts` currently reads `10.3.0`; the live site renders `11.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)