### PR TITLE
fix(website): drop outputFileTracingRoot so Vercel git builds succeed

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -9,8 +9,10 @@ if (process.argv.includes("dev") && !process.env.VELITE_STARTED) {
   void import("velite").then((m) => m.build({ watch: true, clean: false }));
 }
 
-const nextConfig: NextConfig = {
-  outputFileTracingRoot: __dirname,
-};
+// Do NOT set `outputFileTracingRoot` to the website dir. The Vercel project's
+// Root Directory is "website"; a subdir tracing root makes Vercel's build resolve
+// `.next` one level too high and fail with ENOENT on
+// routes-manifest-deterministic.json. Let Next/Vercel infer the root instead.
+const nextConfig: NextConfig = {};
 
 export default withFlowbiteReact(nextConfig);


### PR DESCRIPTION
## Problem

After connecting the Vercel project to GitHub, every git-triggered deploy **ERRORed** even though the build itself completed:

```
ENOENT: no such file or directory, lstat '/vercel/path0/.next/routes-manifest-deterministic.json'
errorStep: buildStep
```

CLI deploys (`vercel deploy` from inside `website/`) succeeded, which masked it.

## Cause

`next.config.ts` set `outputFileTracingRoot: __dirname` (the `website` subdir). The Vercel project's **Root Directory** is now `website`, so Vercel clones the repo to `/vercel/path0`, builds in `/vercel/path0/website` (output at `/vercel/path0/website/.next`), but the subdir tracing root made the deterministic-manifest step look at `/vercel/path0/.next` (one level too high) → ENOENT. The CLI path worked only because it uploaded `website/` *as* the root, so both paths coincided.

## Fix

Remove the `outputFileTracingRoot` override. With Root Directory set on the Vercel side, Next/Vercel infer the correct root. No shared packages live above `website/`, so nothing needs a wider tracing root.

Verified via this PR's Vercel preview build (must be READY before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)