### PR TITLE
fix(website): keep pricing toggle knob inside its track

### DIFF
--- a/website/components/pricing/pricing-table.tsx
+++ b/website/components/pricing/pricing-table.tsx
@@ -41,8 +41,8 @@ export function PricingTable() {
         >
           <span
             className={cn(
-              "absolute top-[3px] h-[18px] w-[18px] rounded-full bg-accent transition-transform duration-200",
-              annual ? "translate-x-[20px]" : "translate-x-[2px]",
+              "absolute left-[2px] top-[2px] h-[18px] w-[18px] rounded-full bg-accent transition-transform duration-200",
+              annual ? "translate-x-[20px]" : "translate-x-0",
             )}
           />
         </button>


### PR DESCRIPTION
## Problem

On the pricing page, the billing period toggle (Monthly / Annual) rendered the bright slide-knob **overflowing its 44px track and overlapping the \"Annual\" label by 4px**. The knob span had no horizontal anchor, so its static absolute position plus the `translate-x` slide pushed it past the track edge.

Measured live (annual state, the default):
- knob right edge: 955px
- \"Annual\" left edge: 951px
- gap knob to label: **-4px** (overlap)

## Fix

Anchor the knob at `left-[2px]` and slide it `translate-x-0` to `translate-x-[20px]` so it stays fully inside the track in both states, with symmetric 2px insets.

```diff
-  absolute top-[3px] ... 
-  annual ? translate-x-[20px] : translate-x-[2px]
+  absolute left-[2px] top-[2px] ...
+  annual ? translate-x-[20px] : translate-x-0
```

## Verification

Verified locally in both states (preview deploys are SSO-gated). `pnpm build` clean.

| State | knob inside track | gap to label |
|---|---|---|
| Annual | yes (936 <= 939) | **15px** (was -4) |
| Monthly | yes (898 >= 895) | 15px |

🤖 Generated with [Claude Code](https://claude.com/claude-code)