### PR TITLE
feat(website): enable Vercel Web Analytics

### DIFF
--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 import { siteConfig } from "@/lib/site";
 import { Navbar } from "@/components/site/navbar";
@@ -78,6 +79,7 @@ export default function RootLayout({
         </main>
         <Footer />
         <SearchCommand index={getSearchIndex()} />
+        <Analytics />
       </body>
     </html>
   );

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,7 @@
     "velite": "velite"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "clsx": "^2.1.1",
     "flowbite-react": "^0.12.17",
     "lucide-react": "^1.17.0",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1149,6 +1152,35 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3859,6 +3891,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    optionalDependencies:
+      next: 16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:


### PR DESCRIPTION
## What

Enables Vercel Web Analytics on the marketing/docs site.

- Adds `@vercel/analytics` (`^2.0.1`) to `website/`.
- Renders `<Analytics />` from `@vercel/analytics/next` in the root layout (`website/app/layout.tsx`), per the [Next.js App Router quickstart](https://vercel.com/docs/analytics/quickstart).

## Why

Analytics is enabled in the Vercel dashboard; the project just needs the client component to start collecting page views and visitor data.

## Notes

- The component is a no-op locally and in dev; it only injects the tracking script on Vercel production deploys, so there's nothing visually observable.
- Verified with a clean `pnpm build` (velite + `next build`): all 40 routes compile, no type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)