### PR TITLE
fix(website): log a warning when a waitlist signup can't be captured

### DIFF
--- a/website/lib/billing.ts
+++ b/website/lib/billing.ts
@@ -50,7 +50,18 @@ export async function createCheckout(
  */
 async function notifyWaitlistSignup(plan: string, email?: string): Promise<void> {
   const apiKey = process.env.RESEND_API_KEY;
-  if (!apiKey) return;
+  if (!apiKey) {
+    // Loud, not silent: without a key the signup is accepted but captured
+    // nowhere. Log it (visible in the project's runtime logs) so the lead is at
+    // least recoverable, and so a missing key is obvious instead of a silent
+    // funnel leak. Set RESEND_API_KEY in the project environment to fix.
+    console.warn(
+      `[waitlist] Signup received but RESEND_API_KEY is not set, so the lead was ` +
+        `NOT captured. Recover from this log: plan=${plan} email=${email ?? "(none)"}. ` +
+        `Set RESEND_API_KEY in the Vercel project env to start receiving leads.`,
+    );
+    return;
+  }
 
   const to = process.env.WAITLIST_NOTIFY_TO ?? siteConfig.contactEmail;
   const from =


### PR DESCRIPTION
## Problem

The Cloud waitlist accepts a signup and shows success, but `lib/billing.ts` captures it **only** by emailing the owner via Resend, gated on `RESEND_API_KEY`. With no key set (current production state), `notifyWaitlistSignup` returned silently and the lead vanished with no trace.

## Change

Make the no-key path **loud instead of silent**: log a `console.warn` that includes the plan and email, so:
- a missing key is obvious in the runtime logs instead of an invisible funnel leak, and
- any signup received while the key is unset is still **recoverable from the logs**.

No behavior change when `RESEND_API_KEY` is set.

## Not in this PR (on purpose)

The real fix is operational: set `RESEND_API_KEY` in the project env. Durable list capture (so leads live in an exportable list, not just an inbox ping) is a deliberate follow-up. I checked Resend's contacts/audiences REST API and it's mid-migration (top-level `/contacts` + `segments` now), so that should be done via the official `resend` SDK or Vercel KV, not a hardcoded endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)