### PR TITLE
release: prepare v11.1.1 (MCP extract_with_prompt + AI discoverability)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 11.1.1: AI extraction in the MCP server + discoverability
+
+A small additive release on top of v11.1.0's AI extraction.
+
+- **MCP `extract_with_prompt` tool.** `WebReaper.Mcp` gains a schema-free LLM extraction tool: extract structured data from a URL by a natural-language instruction (no CSS schema), returning JSON Lines. Built on the `WebReaper.AI.Http` OpenAI-compatible client. Configure the endpoint via the `WEBREAPER_LLM_MODEL` and `WEBREAPER_LLM_BASE_URL` environment variables, with the key in `WEBREAPER_LLM_API_KEY` (or `OPENAI_API_KEY`).
+- **Discoverability.** The bundled Agent Skill (`webreaper init`) and the README now teach the CLI's `--prompt` / `--infer` / `--output-dir` flags, with a guide to choosing between schema, prompt, infer, and Markdown extraction.
+
+All 14 packages ship at 11.1.1 (lockstep).
+
 ## 11.1.0: AI extraction in the CLI
 
 `webreaper scrape` and `webreaper crawl` can now extract structured data with an LLM, on the AOT single binary, with your own key. This is the [ADR-0084](docs/adr/0084-ai-extraction-in-the-aot-cli.md) wave. It is additive: no breaking changes, one new package.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,7 @@
   -->
 
   <PropertyGroup>
-    <Version>11.1.0</Version>
+    <Version>11.1.1</Version>
 
     <Authors>Alex Pavlov</Authors>
     <Company>Alex Pavlov</Company>


### PR DESCRIPTION
Release prep for v11.1.1. Version bump 11.1.0 to 11.1.1 (lockstep, all 14 packages) plus the 11.1.1 CHANGELOG section. Ships the additive changes already merged to master: the `WebReaper.Mcp` `extract_with_prompt` tool (#204) and the Agent Skill + README AI-discoverability docs (#203). CANDIDATES is unchanged (`WebReaper.AI.Http` was added in 11.1.0). Merging this then pushing tag `v11.1.1` triggers the release; the NuGet push stays gated on your approval.