### PR TITLE
feat(cloud): Tier A playground backend (SSRF-guarded HTTP to Markdown over SSE)

### DIFF
--- a/cloud/WebReaper.PlaygroundApi.Tests/SsrfPolicyTests.cs
+++ b/cloud/WebReaper.PlaygroundApi.Tests/SsrfPolicyTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using WebReaper.PlaygroundApi.Ssrf;
+using Xunit;
+
+namespace WebReaper.PlaygroundApi.Tests;
+
+public class SsrfPolicyTests
+{
+    [Theory]
+    // IPv4 loopback / unspecified / broadcast
+    [InlineData("127.0.0.1")]
+    [InlineData("127.255.255.255")]
+    [InlineData("0.0.0.0")]
+    [InlineData("255.255.255.255")]
+    // IPv4 private
+    [InlineData("10.0.0.1")]
+    [InlineData("172.16.0.1")]
+    [InlineData("172.31.255.255")]
+    [InlineData("192.168.1.1")]
+    // IPv4 link-local incl. cloud metadata
+    [InlineData("169.254.0.1")]
+    [InlineData("169.254.169.254")]
+    // IPv4 CGNAT
+    [InlineData("100.64.0.1")]
+    [InlineData("100.127.255.255")]
+    // IPv4 multicast / reserved
+    [InlineData("224.0.0.1")]
+    [InlineData("240.0.0.1")]
+    // IPv6 loopback / unspecified / link-local / ULA / multicast
+    [InlineData("::1")]
+    [InlineData("::")]
+    [InlineData("fe80::1")]
+    [InlineData("fc00::1")]
+    [InlineData("fd12:3456::1")]
+    [InlineData("ff02::1")]
+    // IPv4-mapped IPv6 must be judged as its IPv4 form
+    [InlineData("::ffff:127.0.0.1")]
+    [InlineData("::ffff:10.0.0.1")]
+    [InlineData("::ffff:169.254.169.254")]
+    public void Blocks_internal_and_reserved_addresses(string ip)
+    {
+        Assert.True(SsrfPolicy.IsBlockedAddress(IPAddress.Parse(ip)));
+    }
+
+    [Theory]
+    // Public IPv4 (incl. addresses just outside the private/CGNAT boundaries)
+    [InlineData("8.8.8.8")]
+    [InlineData("1.1.1.1")]
+    [InlineData("93.184.216.34")]
+    [InlineData("172.15.255.255")] // just below 172.16/12
+    [InlineData("172.32.0.1")]     // just above 172.16/12
+    [InlineData("192.169.0.1")]    // just outside 192.168/16
+    [InlineData("100.63.255.255")] // just below CGNAT
+    [InlineData("100.128.0.1")]    // just above CGNAT
+    [InlineData("11.0.0.1")]
+    // Public IPv6
+    [InlineData("2606:4700:4700::1111")]
+    [InlineData("2001:4860:4860::8888")]
+    public void Allows_public_addresses(string ip)
+    {
+        Assert.False(SsrfPolicy.IsBlockedAddress(IPAddress.Parse(ip)));
+    }
+}

--- a/cloud/WebReaper.PlaygroundApi.Tests/WebReaper.PlaygroundApi.Tests.csproj
+++ b/cloud/WebReaper.PlaygroundApi.Tests/WebReaper.PlaygroundApi.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebReaper.PlaygroundApi\WebReaper.PlaygroundApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/cloud/WebReaper.PlaygroundApi/Program.cs
+++ b/cloud/WebReaper.PlaygroundApi/Program.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using WebReaper.PlaygroundApi.Scraping;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Dev CORS: the climb component (localhost:3000 / webreaper.ai) reads this SSE
+// cross-origin. EventSource sends no credentials, so any-origin is safe here;
+// tighten to the known site origins before deploy (Phase 1 step 4).
+builder.Services.AddCors(options => options.AddDefaultPolicy(policy => policy
+    .SetIsOriginAllowed(_ => true)
+    .WithMethods("GET")
+    .AllowAnyHeader()));
+
+builder.Services.AddSingleton<TierAScraper>();
+
+var app = builder.Build();
+app.UseCors();
+
+var jsonOptions = new JsonSerializerOptions
+{
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+};
+
+app.MapGet("/health", () => Results.Text("ok"));
+
+// Tier A live scrape: GET so the browser EventSource can consume it directly.
+app.MapGet("/scrape/stream", async (HttpContext context, TierAScraper scraper, string? url, CancellationToken ct) =>
+{
+    var response = context.Response;
+    response.Headers.ContentType = "text/event-stream";
+    response.Headers.CacheControl = "no-cache";
+    response.Headers["X-Accel-Buffering"] = "no"; // disable proxy buffering so events stream
+
+    await foreach (var climbEvent in scraper.StreamAsync(url ?? string.Empty, ct))
+    {
+        var data = JsonSerializer.Serialize(climbEvent, jsonOptions);
+        await response.WriteAsync($"data: {data}\n\n", ct);
+        await response.Body.FlushAsync(ct);
+    }
+});
+
+app.Run();

--- a/cloud/WebReaper.PlaygroundApi/Scraping/ClimbEvents.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/ClimbEvents.cs
@@ -1,0 +1,31 @@
+namespace WebReaper.PlaygroundApi.Scraping;
+
+/// <summary>
+/// Factories for the wire events streamed to the climb-viz component. The shape
+/// mirrors the front-end `ClimbEvent` union (website/lib/playground/climb-events.ts)
+/// exactly, so the same component reducer consumes a recording or this live SSE
+/// stream. Serialized camelCase with nulls omitted by the endpoint.
+/// </summary>
+public static class ClimbEvents
+{
+    public static object Request(string url) => new { kind = "request", url };
+
+    public static object Attempt(string tier) => new { kind = "attempt", tier };
+
+    public static object Blocked(string tier, int? status, string reason)
+        => new { kind = "blocked", tier, status, reason };
+
+    public static object Success(string tier, int status) => new { kind = "success", tier, status };
+
+    public static object Result(string title, string markdown)
+        => new { kind = "result", title, markdown };
+
+    public static object Exhausted(string tier, string reason)
+        => new { kind = "exhausted", tier, reason };
+
+    /// <summary>
+    /// Not part of the Phase 0 union; the front-end reducer gains an `error`
+    /// arm in the wiring checkpoint. Used for invalid input and refused fetches.
+    /// </summary>
+    public static object Error(string message) => new { kind = "error", message };
+}

--- a/cloud/WebReaper.PlaygroundApi/Scraping/TierAScraper.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/TierAScraper.cs
@@ -1,0 +1,113 @@
+using System.Runtime.CompilerServices;
+using WebReaper.Core.Markdown;
+using WebReaper.PlaygroundApi.Ssrf;
+
+namespace WebReaper.PlaygroundApi.Scraping;
+
+/// <summary>
+/// Tier A: the ungated, HTTP-only path. Fetch the URL through the
+/// <see cref="GuardedHttpClient"/> (SSRF-pinned) and convert to Markdown with
+/// the library's <see cref="HtmlToMarkdown"/> primitive (ADR-0063). No browser,
+/// no LLM, no climb: a challenge status ends the run with a pointer to the
+/// gated full pipeline (Tier B). Emits the shared <c>ClimbEvent</c> shape.
+/// </summary>
+public sealed class TierAScraper
+{
+    private static readonly TimeSpan FetchTimeout = TimeSpan.FromSeconds(20);
+    private const long MaxResponseBytes = 5 * 1024 * 1024; // 5 MB
+
+    // Status codes that mean "the server challenged us"; Tier A cannot climb,
+    // so these end the run pointing at the gated Tier B.
+    private static readonly HashSet<int> ChallengeStatuses = [403, 429, 503];
+
+    public async IAsyncEnumerable<object> StreamAsync(
+        string url,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (!TryNormalizeUrl(url, out var uri))
+        {
+            yield return ClimbEvents.Error("Enter a valid http(s) URL.");
+            yield break;
+        }
+
+        yield return ClimbEvents.Request(uri.ToString());
+        await Task.Delay(250, cancellationToken);
+        yield return ClimbEvents.Attempt("http");
+
+        // The fetch wraps its own try/catch (yield is not allowed inside a
+        // try/catch), returning the events to emit for its outcome.
+        foreach (var climbEvent in await FetchAsync(uri, cancellationToken))
+            yield return climbEvent;
+    }
+
+    private static bool TryNormalizeUrl(string? url, out Uri uri)
+    {
+        uri = null!;
+        if (string.IsNullOrWhiteSpace(url))
+            return false;
+        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var parsed))
+            return false;
+        if (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps)
+            return false;
+        uri = parsed;
+        return true;
+    }
+
+    private static async Task<IReadOnlyList<object>> FetchAsync(Uri uri, CancellationToken cancellationToken)
+    {
+        var events = new List<object>();
+        try
+        {
+            using var client = GuardedHttpClient.Create(FetchTimeout, MaxResponseBytes);
+            using var response = await client.GetAsync(uri, cancellationToken);
+            var status = (int)response.StatusCode;
+
+            if (ChallengeStatuses.Contains(status))
+            {
+                events.Add(ClimbEvents.Blocked("http", status, $"Server returned {status}."));
+                events.Add(ClimbEvents.Exhausted(
+                    "http",
+                    "This site challenges plain HTTP. The browser and stealth tiers are gated, sign in to run the full climb."));
+                return events;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                events.Add(ClimbEvents.Error($"The site responded with HTTP {status}."));
+                return events;
+            }
+
+            var html = await response.Content.ReadAsStringAsync(cancellationToken);
+            events.Add(ClimbEvents.Success("http", status));
+
+            var content = HtmlToMarkdown.ExtractMainContent(html);
+            events.Add(ClimbEvents.Result(content.Title, content.Markdown));
+            return events;
+        }
+        catch (OperationCanceledException)
+        {
+            events.Add(ClimbEvents.Error("The fetch timed out."));
+            return events;
+        }
+        catch (Exception ex) when (ex is SsrfBlockedException || HasSsrfCause(ex))
+        {
+            // The guard throws inside SocketsHttpHandler.ConnectCallback, so the
+            // refusal usually surfaces wrapped in an HttpRequestException.
+            events.Add(ClimbEvents.Error("That URL resolves to a disallowed address and was refused."));
+            return events;
+        }
+        catch (HttpRequestException)
+        {
+            events.Add(ClimbEvents.Error("Could not reach that URL."));
+            return events;
+        }
+    }
+
+    private static bool HasSsrfCause(Exception exception)
+    {
+        for (var inner = exception.InnerException; inner is not null; inner = inner.InnerException)
+            if (inner is SsrfBlockedException)
+                return true;
+        return false;
+    }
+}

--- a/cloud/WebReaper.PlaygroundApi/Ssrf/GuardedHttpClient.cs
+++ b/cloud/WebReaper.PlaygroundApi/Ssrf/GuardedHttpClient.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace WebReaper.PlaygroundApi.Ssrf;
+
+/// <summary>Thrown when a fetch is refused because the target resolves to a disallowed address.</summary>
+public sealed class SsrfBlockedException(string host, string reason)
+    : Exception($"Refused to connect to '{host}': {reason}.")
+{
+    public string Host { get; } = host;
+}
+
+/// <summary>
+/// Builds an <see cref="HttpClient"/> whose connections are pinned to a
+/// <see cref="SsrfPolicy"/>-validated IP. The <see cref="SocketsHttpHandler.ConnectCallback"/>
+/// resolves the host itself, rejects the whole host if <em>any</em> resolved
+/// address is blocked, and connects to a validated address, so a DNS-rebind
+/// between resolution and connection cannot swap in an internal IP (the socket
+/// connects to the exact address we checked). Redirects open new connections,
+/// so each hop is re-validated by the same callback.
+/// </summary>
+public static class GuardedHttpClient
+{
+    public static HttpClient Create(TimeSpan timeout, long maxResponseBytes)
+    {
+        var handler = new SocketsHttpHandler
+        {
+            AllowAutoRedirect = true,
+            MaxAutomaticRedirections = 5,
+            AutomaticDecompression = DecompressionMethods.All,
+            PooledConnectionLifetime = TimeSpan.FromMinutes(1),
+            ConnectCallback = GuardedConnectAsync,
+        };
+
+        var client = new HttpClient(handler)
+        {
+            Timeout = timeout,
+            // Hard cap on buffered response bytes; ReadAsStringAsync throws past this.
+            MaxResponseContentBufferSize = maxResponseBytes,
+        };
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("WebReaperPlayground/1.0 (+https://webreaper.ai)");
+        return client;
+    }
+
+    private static async ValueTask<Stream> GuardedConnectAsync(
+        SocketsHttpConnectionContext context,
+        CancellationToken cancellationToken)
+    {
+        var host = context.DnsEndPoint.Host;
+        var port = context.DnsEndPoint.Port;
+
+        IPAddress[] addresses = IPAddress.TryParse(host, out var literal)
+            ? [literal]
+            : await Dns.GetHostAddressesAsync(host, cancellationToken);
+
+        if (addresses.Length == 0)
+            throw new SsrfBlockedException(host, "no DNS records");
+
+        // Strict: if any resolved address is blocked, refuse the whole host
+        // rather than cherry-picking a public one (mixed results are suspicious).
+        foreach (var address in addresses)
+            if (SsrfPolicy.IsBlockedAddress(address))
+                throw new SsrfBlockedException(host, $"resolves to disallowed address {address}");
+
+        var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+        try
+        {
+            await socket.ConnectAsync(addresses[0], port, cancellationToken);
+            return new NetworkStream(socket, ownsSocket: true);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+}

--- a/cloud/WebReaper.PlaygroundApi/Ssrf/SsrfPolicy.cs
+++ b/cloud/WebReaper.PlaygroundApi/Ssrf/SsrfPolicy.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace WebReaper.PlaygroundApi.Ssrf;
+
+/// <summary>
+/// The SSRF address policy: classifies a resolved IP as safe-to-reach or not.
+/// This is the pure, security-critical core of the egress guard (Phase 1 of
+/// docs/CLOUD-PLAYGROUND-PHASE-1.md), kept free of I/O so it is exhaustively
+/// unit-testable. A public any-URL fetcher MUST reject loopback, private,
+/// link-local (incl. the cloud-metadata address), CGNAT, and the IPv6
+/// equivalents, or it is an SSRF pivot.
+/// </summary>
+public static class SsrfPolicy
+{
+    /// <summary>
+    /// True if a connection to <paramref name="address"/> must be refused.
+    /// IPv4-mapped IPv6 addresses are unwrapped and judged as their IPv4 form,
+    /// so <c>::ffff:127.0.0.1</c> is blocked exactly like <c>127.0.0.1</c>.
+    /// </summary>
+    public static bool IsBlockedAddress(IPAddress address)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+
+        if (address.IsIPv4MappedToIPv6)
+            address = address.MapToIPv4();
+
+        // Loopback (127.0.0.0/8, ::1) for either family.
+        if (IPAddress.IsLoopback(address))
+            return true;
+
+        return address.AddressFamily switch
+        {
+            AddressFamily.InterNetwork => IsBlockedV4(address.GetAddressBytes()),
+            AddressFamily.InterNetworkV6 => IsBlockedV6(address),
+            // Anything that is not plain IPv4/IPv6 (Unix sockets, etc.) is not
+            // a legitimate scrape target.
+            _ => true,
+        };
+    }
+
+    private static bool IsBlockedV4(byte[] b)
+    {
+        // b is 4 bytes.
+        return b[0] switch
+        {
+            0 => true,                                   // 0.0.0.0/8  "this network" / unspecified
+            10 => true,                                  // 10.0.0.0/8 private
+            127 => true,                                 // loopback (also caught above)
+            100 when b[1] is >= 64 and <= 127 => true,   // 100.64.0.0/10 CGNAT
+            169 when b[1] == 254 => true,                // 169.254.0.0/16 link-local incl. 169.254.169.254 metadata
+            172 when b[1] is >= 16 and <= 31 => true,    // 172.16.0.0/12 private
+            192 when b[1] == 168 => true,                // 192.168.0.0/16 private
+            >= 224 => true,                              // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved + 255.255.255.255 broadcast
+            _ => false,
+        };
+    }
+
+    private static bool IsBlockedV6(IPAddress address)
+    {
+        if (address.Equals(IPAddress.IPv6Any))           // ::  unspecified
+            return true;
+        if (address.IsIPv6LinkLocal)                     // fe80::/10
+            return true;
+        if (address.IsIPv6SiteLocal)                     // fec0::/10 (deprecated, still refuse)
+            return true;
+        if (address.IsIPv6Multicast)                     // ff00::/8
+            return true;
+
+        // Unique local addresses fc00::/7 (first 7 bits 1111 110x).
+        var b = address.GetAddressBytes();
+        return (b[0] & 0xFE) == 0xFC;
+    }
+}

--- a/cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj
+++ b/cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>WebReaper.PlaygroundApi</RootNamespace>
+    <!-- The Cloud playground backend (Phase 1, Tier A). A consumer of the
+         WebReaper library, deployed separately (like website/); deliberately
+         NOT in WebReaper.sln so it stays out of the library's CI. -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WebReaper\WebReaper.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## What

The first slice of WebReaper Cloud: the **Tier A** playground backend (Phase 1 of the [build slice](https://github.com/pavlovtech/WebReaper/blob/master/docs/CLOUD-PLAYGROUND-PHASE-1.md), see #207). An ASP.NET minimal API in a new `cloud/WebReaper.PlaygroundApi/` that references the WebReaper library.

- **`GET /scrape/stream?url=`** fetches the URL and converts it to Markdown, streaming the **shared `ClimbEvent` shape** over SSE (the same shape the climb-viz component already consumes from a recording, so the live wiring is a drop-in next step).
- **SSRF guard** (`Ssrf/`): a DNS-pinned `SocketsHttpHandler.ConnectCallback` over a pure `SsrfPolicy` that blocks loopback, private, link-local (incl. the `169.254.169.254` metadata address), CGNAT, and the IPv6 equivalents. The connection is pinned to a validated IP, so a DNS-rebind can't swap in an internal address; redirects are re-validated per hop.
- **No core library change**: Tier A uses the public `HtmlToMarkdown` primitive (ADR-0063) directly rather than the crawl engine (whose page-loader seam is `internal`). The engine + climb come back for Tier B.

## Verification

- **34 `SsrfPolicy` unit tests** green (`dotnet test`), covering IPv4/IPv6 internal, reserved, CGNAT, and IPv4-mapped cases plus public allow-list boundaries.
- **Live**: `example.com` streams `request → attempt → success → result` (clean Markdown); `169.254.169.254` and `localhost` (the server's own port, the real proof the guard fires) are **refused** with an explicit "disallowed address" event.

## Notes

- Not added to `WebReaper.sln`, it is a separate deployable (like `website/`), so the library CI is untouched. Build/test it directly: `dotnet test cloud/WebReaper.PlaygroundApi.Tests`.
- Dev CORS is any-origin (EventSource sends no credentials); tighten to the site origins at the edge-gate step.

## Next (per the slice)

Wire the climb component to an `EventSource` source (local, behind a flag), then the Vercel edge gate (Turnstile + rate limit) and Fly deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)