### PR TITLE
feat(website): wire the climb component to the live Tier A backend (SSE)

### DIFF
--- a/website/app/playground/page.tsx
+++ b/website/app/playground/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Shield } from "lucide-react";
 import { PlaygroundShowcase } from "@/components/playground/playground-showcase";
+import { LiveClimb } from "@/components/playground/live-climb";
 
 export const metadata: Metadata = {
   title: "Playground",
@@ -12,6 +13,10 @@ export const metadata: Metadata = {
 };
 
 export default function PlaygroundPage() {
+  // Live Tier A demo is dev/preview-gated: it points at the playground backend
+  // (localhost in dev). Enable with NEXT_PUBLIC_PLAYGROUND_LIVE=1 until the
+  // backend is deployed and the edge gate is in place.
+  const liveEnabled = process.env.NEXT_PUBLIC_PLAYGROUND_LIVE === "1";
   return (
     <div className="relative">
       <div className="glow-accent pointer-events-none absolute inset-x-0 top-0 h-72" aria-hidden />
@@ -44,6 +49,22 @@ export default function PlaygroundPage() {
           </Link>
           .
         </p>
+
+        {liveEnabled && (
+          <div className="mt-16 border-t border-border pt-12">
+            <div className="text-center">
+              <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+                Try it live
+              </h2>
+              <p className="mx-auto mt-3 max-w-xl text-sm text-muted">
+                Paste any URL. This runs the real Tier A backend, an HTTP fetch to
+                clean Markdown; the browser and stealth tiers are gated. Internal and
+                private addresses are refused.
+              </p>
+            </div>
+            <LiveClimb className="mt-8" />
+          </div>
+        )}
       </section>
     </div>
   );

--- a/website/components/playground/climb-demo.tsx
+++ b/website/components/playground/climb-demo.tsx
@@ -28,7 +28,9 @@ type State = {
   tiers: Record<TierName, TierState>;
   climbingTo: TierName | null;
   result: { title: string; markdown: string } | null;
-  outcome: "running" | "won" | "lost";
+  outcome: "running" | "won" | "lost" | "error";
+  lostReason?: string;
+  error?: string;
 };
 
 const TIER_ICON: Record<TierName, typeof Globe> = {
@@ -90,11 +92,14 @@ function reduce(state: State, event: ClimbEvent): State {
       return {
         ...state,
         outcome: "lost",
+        lostReason: event.reason,
         tiers: {
           ...state.tiers,
           [event.tier]: { status: "exhausted", pill: "blocked", reason: event.reason },
         },
       };
+    case "error":
+      return { ...state, outcome: "error", error: event.message };
     default:
       return state;
   }
@@ -110,14 +115,60 @@ function urlOf(script: ClimbScript): string {
   return req && req.event.kind === "request" ? req.event.url : "";
 }
 
-export function ClimbDemo({ script, className }: { script: ClimbScript; className?: string }) {
+const DEFAULT_API_BASE = "http://localhost:5179";
+
+/**
+ * Drives the climb view from one of two sources, both folding into the same
+ * reducer: a recorded `script` (the canned hero / demos) or a live backend SSE
+ * stream (`liveUrl`). Exactly one is expected.
+ */
+export function ClimbDemo({
+  script,
+  liveUrl,
+  apiBase = DEFAULT_API_BASE,
+  className,
+}: {
+  script?: ClimbScript;
+  liveUrl?: string;
+  apiBase?: string;
+  className?: string;
+}) {
   const [state, dispatch] = useReducer(rootReduce, undefined, initialState);
-  // Bumping runId re-fires the playback effect, which resets then replays.
+  // Bumping runId re-fires the effect, which resets then replays / re-streams.
   const [runId, setRunId] = useState(0);
-  const url = urlOf(script);
+  const url = liveUrl ?? (script ? urlOf(script) : "");
 
   useEffect(() => {
     dispatch({ kind: "reset" });
+
+    // Live mode: drive the reducer from the backend SSE stream.
+    if (liveUrl) {
+      const source = new EventSource(
+        `${apiBase}/scrape/stream?url=${encodeURIComponent(liveUrl)}`,
+      );
+      source.onmessage = (e) => {
+        let event: ClimbEvent;
+        try {
+          event = JSON.parse(e.data) as ClimbEvent;
+        } catch {
+          return;
+        }
+        dispatch(event);
+        // Close on a terminal event; otherwise EventSource auto-reconnects when
+        // the server closes the stream, which would re-run the scrape.
+        if (event.kind === "result" || event.kind === "exhausted" || event.kind === "error") {
+          source.close();
+        }
+      };
+      source.onerror = () => {
+        source.close();
+        dispatch({ kind: "error", message: "Lost connection to the scrape service." });
+      };
+      return () => source.close();
+    }
+
+    // Canned mode: play the recorded script.
+    if (!script) return;
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     if (reduceMotion) {
       // Jump straight to the final state: dispatch every event with no delay.
@@ -125,7 +176,7 @@ export function ClimbDemo({ script, className }: { script: ClimbScript; classNam
       return () => clearTimeout(t);
     }
     return playScript(script.events, dispatch);
-  }, [script, runId]);
+  }, [script, liveUrl, apiBase, runId]);
 
   const replay = () => setRunId((n) => n + 1);
 
@@ -178,7 +229,12 @@ export function ClimbDemo({ script, className }: { script: ClimbScript; classNam
           ))}
         </ol>
 
-        <ResultPanel outcome={state.outcome} result={state.result} />
+        <ResultPanel
+          outcome={state.outcome}
+          result={state.result}
+          lostReason={state.lostReason}
+          error={state.error}
+        />
       </div>
     </div>
   );
@@ -281,17 +337,29 @@ function StatusPill({ status, pill }: { status: TierStatus; pill?: string }) {
 function ResultPanel({
   outcome,
   result,
+  lostReason,
+  error,
 }: {
   outcome: State["outcome"];
   result: State["result"];
+  lostReason?: string;
+  error?: string;
 }) {
   if (outcome === "running") return null;
+
+  if (outcome === "error") {
+    return (
+      <div className="mt-4 rounded-lg border border-red-500/20 bg-red-500/5 p-4">
+        <p className="text-[13px] text-zinc-300">{error ?? "Something went wrong."}</p>
+      </div>
+    );
+  }
 
   if (outcome === "lost") {
     return (
       <div className="mt-4 rounded-lg border border-red-500/20 bg-red-500/5 p-4">
         <p className="text-[13px] text-zinc-300">
-          Still blocked at the stealth tier.
+          {lostReason ?? "Still blocked at the top tier."}
         </p>
         <p className="mt-1 text-[12px] text-zinc-500">
           WebReaper reports the block instead of returning challenge-page garbage. A

--- a/website/components/playground/live-climb.tsx
+++ b/website/components/playground/live-climb.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { type FormEvent, useState } from "react";
+import { ArrowRight } from "lucide-react";
+import { ClimbDemo } from "./climb-demo";
+
+// The Tier A backend (cloud/WebReaper.PlaygroundApi). Defaults to the local
+// dev port; set NEXT_PUBLIC_PLAYGROUND_API to the deployed origin later.
+const API_BASE = process.env.NEXT_PUBLIC_PLAYGROUND_API ?? "http://localhost:5179";
+
+export function LiveClimb({ className }: { className?: string }) {
+  const [input, setInput] = useState("https://example.com");
+  const [submitted, setSubmitted] = useState<string | null>(null);
+  // Remount ClimbDemo on each submit so the SSE stream restarts cleanly,
+  // even when the URL is unchanged.
+  const [runKey, setRunKey] = useState(0);
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    const url = input.trim();
+    if (!url) return;
+    setSubmitted(url);
+    setRunKey((n) => n + 1);
+  };
+
+  return (
+    <div className={className}>
+      <form onSubmit={submit} className="mx-auto mb-4 flex max-w-xl items-center gap-2">
+        <input
+          type="url"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="https://example.com"
+          aria-label="URL to scrape"
+          className="min-w-0 flex-1 rounded-lg border border-border bg-surface/60 px-4 py-2.5 font-mono text-sm text-foreground outline-none transition placeholder:text-muted-2 focus:border-accent/50"
+        />
+        <button
+          type="submit"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-accent px-4 py-2.5 text-sm font-medium text-accent-foreground transition hover:bg-accent-strong"
+        >
+          Scrape
+          <ArrowRight className="h-4 w-4" />
+        </button>
+      </form>
+
+      {submitted ? <ClimbDemo key={runKey} liveUrl={submitted} apiBase={API_BASE} /> : null}
+    </div>
+  );
+}

--- a/website/lib/playground/climb-events.ts
+++ b/website/lib/playground/climb-events.ts
@@ -28,7 +28,9 @@ export type ClimbEvent =
   | { kind: "escalate"; from: TierName; to: TierName }
   | { kind: "success"; tier: TierName; status: number }
   | { kind: "result"; title: string; markdown: string }
-  | { kind: "exhausted"; tier: TierName; reason: string };
+  | { kind: "exhausted"; tier: TierName; reason: string }
+  // Emitted by the live backend for invalid input or a refused (SSRF) fetch.
+  | { kind: "error"; message: string };
 
 /** A `ClimbEvent` plus its millisecond offset from the start of playback. */
 export type TimedEvent = { at: number; event: ClimbEvent };


### PR DESCRIPTION
## What

Step 3 of the playground build slice: the climb-viz component now drives from a **live backend SSE stream**, not just the recorded script. Closes the loop between the [Tier A backend](https://github.com/pavlovtech/WebReaper/pull/209) and the [Phase 0 component](https://github.com/pavlovtech/WebReaper/pull/205).

## Changes

- **`ClimbDemo` gains a `liveUrl` mode**: opens an `EventSource` to the backend's `/scrape/stream`, dispatches the `ClimbEvent`s into the **same reducer** the canned script uses, and closes on a terminal event so `EventSource` doesn't auto-reconnect and re-scrape. The `script` (hero/canned) path is unchanged.
- **`error` arm** added to `ClimbEvent` + reducer + result panel, for the backend's invalid-input / SSRF-refused cases. The "lost" panel now shows the event's reason (accurate for Tier A's HTTP block, not a hardcoded "stealth tier").
- **`LiveClimb`**: a URL input that drives `ClimbDemo` live.
- **`/playground`** shows a "Try it live" section gated behind `NEXT_PUBLIC_PLAYGROUND_LIVE` (dev/preview only, points at the local backend) until the edge gate + deploy land.

## Verification

Ran the Tier A backend locally and drove the UI:
- `example.com` → the live climb streamed and rendered the **real** "# Example Domain" Markdown from the backend.
- `localhost` (the backend's own port) → refused, surfaced as a **"disallowed address"** error in the UI (the new error arm).
- `pnpm build` clean, no console errors.

## Notes

- The live section is off by default (flag-gated); it does nothing in production until the backend is deployed and `NEXT_PUBLIC_PLAYGROUND_API` points at it.
- Next: the Vercel edge gate (Turnstile + rate limit) and the Fly deploy, which need a Fly.io account, Turnstile keys, and a rate-limit store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)