### PR TITLE
fix(cloud): block IPv4 tunnelled in IPv6 in the Tier A SSRF guard

### DIFF
--- a/cloud/WebReaper.PlaygroundApi.Tests/SsrfPolicyTests.cs
+++ b/cloud/WebReaper.PlaygroundApi.Tests/SsrfPolicyTests.cs
@@ -37,6 +37,14 @@ public class SsrfPolicyTests
     [InlineData("::ffff:127.0.0.1")]
     [InlineData("::ffff:10.0.0.1")]
     [InlineData("::ffff:169.254.169.254")]
+    // IPv4 tunnelled in IPv6 (compatible / 6to4 / NAT64) must also be unwrapped
+    [InlineData("::169.254.169.254")]  // IPv4-compatible, cloud metadata
+    [InlineData("::127.0.0.1")]        // IPv4-compatible, loopback
+    [InlineData("::10.0.0.1")]         // IPv4-compatible, private
+    [InlineData("2002:a9fe:a9fe::")]   // 6to4 of 169.254.169.254
+    [InlineData("2002:7f00:1::")]      // 6to4 of 127.0.0.1
+    [InlineData("64:ff9b::a9fe:a9fe")] // NAT64 of 169.254.169.254
+    [InlineData("64:ff9b::7f00:1")]    // NAT64 of 127.0.0.1
     public void Blocks_internal_and_reserved_addresses(string ip)
     {
         Assert.True(SsrfPolicy.IsBlockedAddress(IPAddress.Parse(ip)));
@@ -56,6 +64,8 @@ public class SsrfPolicyTests
     // Public IPv6
     [InlineData("2606:4700:4700::1111")]
     [InlineData("2001:4860:4860::8888")]
+    // 6to4 wrapping a public IPv4 stays allowed (we unwrap, we do not blanket-block)
+    [InlineData("2002:5db8:d822::")] // 6to4 of 93.184.216.34
     public void Allows_public_addresses(string ip)
     {
         Assert.False(SsrfPolicy.IsBlockedAddress(IPAddress.Parse(ip)));

--- a/cloud/WebReaper.PlaygroundApi/Ssrf/SsrfPolicy.cs
+++ b/cloud/WebReaper.PlaygroundApi/Ssrf/SsrfPolicy.cs
@@ -15,8 +15,9 @@ public static class SsrfPolicy
 {
     /// <summary>
     /// True if a connection to <paramref name="address"/> must be refused.
-    /// IPv4-mapped IPv6 addresses are unwrapped and judged as their IPv4 form,
-    /// so <c>::ffff:127.0.0.1</c> is blocked exactly like <c>127.0.0.1</c>.
+    /// IPv4 tunnelled inside IPv6 is unwrapped and judged as its IPv4 form, so
+    /// <c>::ffff:127.0.0.1</c> (mapped), <c>::169.254.169.254</c> (compatible),
+    /// and the 6to4 / NAT64 wrappings are blocked exactly like the bare IPv4.
     /// </summary>
     public static bool IsBlockedAddress(IPAddress address)
     {
@@ -67,8 +68,44 @@ public static class SsrfPolicy
         if (address.IsIPv6Multicast)                     // ff00::/8
             return true;
 
-        // Unique local addresses fc00::/7 (first 7 bits 1111 110x).
         var b = address.GetAddressBytes();
-        return (b[0] & 0xFE) == 0xFC;
+
+        // Unique local addresses fc00::/7 (first 7 bits 1111 110x).
+        if ((b[0] & 0xFE) == 0xFC)
+            return true;
+
+        // IPv4 tunnelled inside IPv6: judge by the embedded IPv4 so an internal
+        // target cannot slip past as a v6 literal (e.g. ::169.254.169.254 or the
+        // 6to4 / NAT64 wrappings of it). IPv4-mapped (::ffff:0:0/96) is already
+        // unwrapped in IsBlockedAddress; these are the remaining forms.
+        var embedded = EmbeddedV4(b);
+        return embedded is not null && IsBlockedV4(embedded);
+    }
+
+    /// <summary>
+    /// The IPv4 tunnelled in an IPv6 address for the IPv4-compatible
+    /// (<c>::a.b.c.d</c>), 6to4 (<c>2002::/16</c>), and NAT64 well-known prefix
+    /// (<c>64:ff9b::/96</c>) forms; <c>null</c> if none. IPv4-mapped
+    /// (<c>::ffff:0:0/96</c>) is handled earlier via <c>MapToIPv4</c>.
+    /// </summary>
+    private static byte[]? EmbeddedV4(byte[] b)
+    {
+        // 6to4: 2002:AABB:CCDD::/48 -> AABB.CCDD
+        if (b[0] == 0x20 && b[1] == 0x02)
+            return [b[2], b[3], b[4], b[5]];
+
+        // NAT64 well-known prefix 64:ff9b::/96 -> the trailing 4 bytes.
+        if (b[0] == 0x00 && b[1] == 0x64 && b[2] == 0xFF && b[3] == 0x9B
+            && b[4] == 0 && b[5] == 0 && b[6] == 0 && b[7] == 0
+            && b[8] == 0 && b[9] == 0 && b[10] == 0 && b[11] == 0)
+            return [b[12], b[13], b[14], b[15]];
+
+        // IPv4-compatible ::a.b.c.d : the high 96 bits are zero. (:: and ::1 are
+        // already handled by the IPv6Any and loopback checks upstream.)
+        for (var i = 0; i < 12; i++)
+            if (b[i] != 0)
+                return null;
+        var lowAllZero = b[12] == 0 && b[13] == 0 && b[14] == 0 && b[15] == 0;
+        return lowAllZero ? null : [b[12], b[13], b[14], b[15]];
     }
 }


### PR DESCRIPTION
## What

Closes an SSRF gap a review flagged in the Tier A guard from #209: `SsrfPolicy.IsBlockedV6` only unwrapped **IPv4-mapped** IPv6 (`::ffff:x`). Three other IPv4-in-IPv6 embeddings of an internal address slipped through as *allowed*:

- IPv4-**compatible** `::a.b.c.d` (e.g. `::169.254.169.254`)
- **6to4** `2002:V4::/48` (e.g. `2002:a9fe:a9fe::` wraps the metadata IP)
- **NAT64** `64:ff9b::/96` (e.g. `64:ff9b::7f00:1` wraps loopback)

An attacker-controlled `AAAA` record could return one of these to reach an internal target through the connect-callback.

## Fix

`IsBlockedV6` now extracts the embedded IPv4 from all three forms and re-checks it via `IsBlockedV4`. So a wrapping of an internal/reserved IP is blocked, while a 6to4 of a **public** IP stays allowed (we unwrap and judge, we don't blanket-block).

## Tests

`SsrfPolicyTests` gains the compatible / 6to4 / NAT64 wrappings of loopback, metadata, and private (blocked) plus a public-6to4 allow case. **42 tests, all green.**

Out of scope (noted): Teredo (`2001:0000::/32`) uses an obfuscated embedding; not covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)