### PR TITLE
feat(cloud): playground edge gate + Fly deploy (Phase 1 steps 4-5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the Fly/Docker build context (the repo root, for the playground backend
+# image) free of noise. Source dirs stay in; only heavy/irrelevant artifacts are
+# excluded. See cloud/WebReaper.PlaygroundApi/Dockerfile.
+.git
+.github
+.claude
+**/bin
+**/obj
+**/node_modules
+**/.next
+**/.vs
+*.user

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,0 +1,86 @@
+# WebReaper Cloud playground backend
+
+The Tier A live-scrape service: paste a URL, get clean Markdown streamed back
+over Server-Sent Events. It is a thin ASP.NET minimal API over the WebReaper
+library, deployed separately from the NuGet packages (like `website/`), and is
+the seed of WebReaper Cloud's scrape endpoint.
+
+Design: [docs/CLOUD-SCRAPE-PLAYGROUND-PLAN.md](../docs/CLOUD-SCRAPE-PLAYGROUND-PLAN.md)
+and the Phase 1 slice [docs/CLOUD-PLAYGROUND-PHASE-1.md](../docs/CLOUD-PLAYGROUND-PHASE-1.md).
+
+## Architecture
+
+```
+[playground component, /playground]  --EventSource-->  [Vercel edge route /api/playground/scrape]
+                                                          verify Turnstile, per-IP + global rate limit
+                                                          proxy SSE through (backend URL stays private,
+                                                          inject the shared secret)
+                                                              |
+                                                              v
+                                       [this app, on Fly]  GET /scrape/stream?url=...  -> SSE of ClimbEvent
+                                                          require X-Playground-Secret (refuse direct traffic)
+                                                          SSRF-guarded handler; concurrency cap; per-job timeout
+```
+
+## Run locally
+
+The `#210` client defaults to `http://localhost:5179`, so run on that port:
+
+```bash
+ASPNETCORE_URLS=http://localhost:5179 dotnet run --project cloud/WebReaper.PlaygroundApi
+# stream a scrape (no gate locally, since no secret is set):
+curl -N "http://localhost:5179/scrape/stream?url=https://example.com"
+```
+
+With no env set the backend is open (dev mode). It is intentionally NOT in
+`WebReaper.sln`, so it stays out of the library CI.
+
+## Deploy (Fly)
+
+Needs a Fly.io account + `flyctl`. Deploy from the **repo root** so the build
+context includes the WebReaper library (Fly's context is always the project
+root; the Dockerfile copies `WebReaper/`):
+
+```bash
+fly launch --no-deploy --config cloud/WebReaper.PlaygroundApi/fly.toml   # first time: set app name + region
+fly secrets set PLAYGROUND_BACKEND_SECRET=$(openssl rand -hex 32) \
+  --config cloud/WebReaper.PlaygroundApi/fly.toml
+fly deploy --config cloud/WebReaper.PlaygroundApi/fly.toml
+```
+
+Then set the matching values in the Vercel project (see `website/.env.example`):
+`PLAYGROUND_BACKEND_URL` (the Fly app URL), `PLAYGROUND_BACKEND_SECRET` (the same
+secret), `TURNSTILE_SECRET_KEY` + `NEXT_PUBLIC_TURNSTILE_SITE_KEY`, and the
+Upstash REST vars.
+
+## Environment
+
+| Side | Variable | Purpose |
+|---|---|---|
+| Fly (backend) | `PLAYGROUND_BACKEND_SECRET` | Shared secret; the backend rejects `/scrape/stream` without a matching `X-Playground-Secret`. Unset => open (dev). |
+| Fly (backend) | `PLAYGROUND_ALLOWED_ORIGINS` | Comma-separated CORS allowlist. Unset => any-origin (dev). |
+| Vercel (edge) | `PLAYGROUND_BACKEND_URL` | Private Fly URL the edge route proxies to. |
+| Vercel (edge) | `PLAYGROUND_BACKEND_SECRET` | Same secret as Fly; injected on every proxied request. |
+| Vercel (edge) | `TURNSTILE_SECRET_KEY` | Cloudflare Turnstile server secret. Unset => verification skipped (dev). |
+| Vercel (edge) | `UPSTASH_REDIS_REST_URL` / `_TOKEN` | Rate-limit store. Unset => limiting disabled (dev). |
+
+Every variable is a fail-soft seam: unset means "off, dev mode" with a loud
+server warning, never a crash. An unconfigured production deploy is therefore
+open, so set the secrets before announcing the URL.
+
+## Activation note (client side)
+
+The edge gate is live and self-contained, but it only takes effect once the
+playground **client** routes through it. As of `#210` the component points its
+`EventSource` straight at the backend (`NEXT_PUBLIC_PLAYGROUND_API`), which
+bypasses the gate. To switch the public site onto the gated path, two one-line
+client changes belong with that work (kept out of this change to avoid touching
+`#210`'s files):
+
+1. Point the `EventSource` at the same-origin route `/api/playground/scrape`
+   instead of the public backend origin.
+2. Append the Turnstile token as `&cf=<token>` (EventSource is GET-only and
+   cannot send headers).
+
+Until then the gate is dormant; the backend secret + CORS allowlist still let
+you lock the Fly app down independently.

--- a/cloud/WebReaper.PlaygroundApi/Dockerfile
+++ b/cloud/WebReaper.PlaygroundApi/Dockerfile
@@ -1,0 +1,38 @@
+# Tier A playground backend (Phase 1). The API references the WebReaper library
+# project (..\..\WebReaper), so the Docker build CONTEXT must be the REPO ROOT,
+# not this directory. fly.toml sets [build].dockerfile to this path; Fly's
+# context is always the project root, so deploy FROM the repo root:
+#
+#   fly deploy --config cloud/WebReaper.PlaygroundApi/fly.toml
+#
+# To build by hand, also pass the root as context:
+#   docker build -f cloud/WebReaper.PlaygroundApi/Dockerfile -t webreaper-playground .
+
+# SDK tag matches global.json (10.0.100, rollForward latestMinor).
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Restore as its own layer: copy the shared build props + the csprojs only, so
+# a source-only change does not re-run restore. WebReaper.csproj has no project
+# references, so the API + the library are the whole graph.
+COPY global.json Directory.Build.props ./
+COPY WebReaper/WebReaper.csproj WebReaper/
+COPY cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj cloud/WebReaper.PlaygroundApi/
+RUN dotnet restore cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj
+
+# Now the sources, and publish (framework-dependent; the aspnet base carries the
+# runtime). Not AOT: this is a web host referencing the library, not the CLI.
+COPY WebReaper/ WebReaper/
+COPY cloud/WebReaper.PlaygroundApi/ cloud/WebReaper.PlaygroundApi/
+RUN dotnet publish cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj \
+    -c Release -o /app --no-restore
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app ./
+# Listen on 8080 (fly.toml internal_port) and run as the non-root user the
+# aspnet image ships (APP_UID, since .NET 8).
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+USER $APP_UID
+ENTRYPOINT ["dotnet", "WebReaper.PlaygroundApi.dll"]

--- a/cloud/WebReaper.PlaygroundApi/Program.cs
+++ b/cloud/WebReaper.PlaygroundApi/Program.cs
@@ -4,13 +4,28 @@ using WebReaper.PlaygroundApi.Scraping;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Dev CORS: the climb component (localhost:3000 / webreaper.ai) reads this SSE
-// cross-origin. EventSource sends no credentials, so any-origin is safe here;
-// tighten to the known site origins before deploy (Phase 1 step 4).
-builder.Services.AddCors(options => options.AddDefaultPolicy(policy => policy
-    .SetIsOriginAllowed(_ => true)
-    .WithMethods("GET")
-    .AllowAnyHeader()));
+// CORS: in production the browser hits the same-origin Vercel edge proxy, not
+// this backend directly, so cross-origin access is limited to the known site
+// origins. Set PLAYGROUND_ALLOWED_ORIGINS (comma-separated) to lock it down;
+// unset => any-origin, for local dev only. EventSource sends no credentials.
+var allowedOrigins = (Environment.GetEnvironmentVariable("PLAYGROUND_ALLOWED_ORIGINS") ?? string.Empty)
+    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+builder.Services.AddCors(options => options.AddDefaultPolicy(policy =>
+{
+    policy.WithMethods("GET").AllowAnyHeader();
+    if (allowedOrigins.Length > 0)
+        policy.WithOrigins(allowedOrigins);
+    else
+        policy.SetIsOriginAllowed(_ => true); // dev fallback
+}));
+
+// Once the Vercel edge gate (Turnstile + rate limit) fronts this service, the
+// backend must refuse direct public traffic, or the gate is trivially bypassed
+// by hitting the Fly URL. When PLAYGROUND_BACKEND_SECRET is set, the scrape
+// endpoint requires it (the edge injects X-Playground-Secret); unset => local
+// dev, allowed. /health stays open for the Fly health check.
+var backendSecret = Environment.GetEnvironmentVariable("PLAYGROUND_BACKEND_SECRET");
 
 builder.Services.AddSingleton<TierAScraper>();
 
@@ -28,6 +43,14 @@ app.MapGet("/health", () => Results.Text("ok"));
 // Tier A live scrape: GET so the browser EventSource can consume it directly.
 app.MapGet("/scrape/stream", async (HttpContext context, TierAScraper scraper, string? url, CancellationToken ct) =>
 {
+    // Reject direct public traffic when fronted by the edge gate (see above).
+    var provided = context.Request.Headers["X-Playground-Secret"].ToString();
+    if (!string.IsNullOrEmpty(backendSecret) && !string.Equals(provided, backendSecret, StringComparison.Ordinal))
+    {
+        context.Response.StatusCode = StatusCodes.Status403Forbidden;
+        return;
+    }
+
     var response = context.Response;
     response.Headers.ContentType = "text/event-stream";
     response.Headers.CacheControl = "no-cache";

--- a/cloud/WebReaper.PlaygroundApi/fly.toml
+++ b/cloud/WebReaper.PlaygroundApi/fly.toml
@@ -1,0 +1,49 @@
+# Fly config for the Tier A playground backend (Phase 1).
+#
+# Deploy from the REPO ROOT so the build context includes the WebReaper library
+# (Fly's context is always the project root; see the Dockerfile header):
+#
+#   fly launch --no-deploy --config cloud/WebReaper.PlaygroundApi/fly.toml   # first time, sets app + region
+#   fly secrets set PLAYGROUND_BACKEND_SECRET=$(openssl rand -hex 32) --config cloud/WebReaper.PlaygroundApi/fly.toml
+#   fly deploy --config cloud/WebReaper.PlaygroundApi/fly.toml
+#
+# The same secret goes in the Vercel project as PLAYGROUND_BACKEND_SECRET, and
+# the Fly app URL as PLAYGROUND_BACKEND_URL. Secrets are NEVER committed here.
+
+app = "webreaper-playground"
+primary_region = "iad"
+
+[build]
+  # Relative to the repo root (Fly's build context), not to this file.
+  dockerfile = "cloud/WebReaper.PlaygroundApi/Dockerfile"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  # Scale to zero between demos; cold start is a few seconds for a small API.
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  # Global concurrency cap (the plan's Tier A guard): Fly load-balances beyond
+  # soft_limit and refuses new connections beyond hard_limit.
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 20
+    hard_limit = 25
+
+  [[http_service.checks]]
+    method = "GET"
+    path = "/health"
+    interval = "15s"
+    timeout = "2s"
+    grace_period = "5s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+
+[env]
+  # Non-secret config. PLAYGROUND_ALLOWED_ORIGINS tightens CORS to the site;
+  # PLAYGROUND_BACKEND_SECRET is a SECRET set via `fly secrets set`, not here.
+  PLAYGROUND_ALLOWED_ORIGINS = "https://webreaper.ai"

--- a/website/.env.example
+++ b/website/.env.example
@@ -26,3 +26,32 @@ RESEND_API_KEY=
 # Set this to switch the subscribe flow from the waitlist to real Stripe
 # Checkout (see lib/billing.ts). Leave empty until the Cloud product exists.
 # STRIPE_SECRET_KEY=
+
+# --- Cloud playground gate (Tier A live scrape; see app/api/playground/scrape) ---
+# All optional: with none set, the gate is OPEN and the route proxies straight
+# to a local backend (dev mode, logged loudly). Set these to arm it in prod.
+
+# The private Fly backend URL the edge route proxies to. NOT NEXT_PUBLIC: the
+# browser never sees it. Defaults to the local backend dev port.
+# PLAYGROUND_BACKEND_URL=https://webreaper-playground.fly.dev
+
+# Shared secret so the backend refuses direct (ungated) public traffic. Generate
+# with `openssl rand -hex 32`; set the SAME value as a Fly secret on the backend.
+# PLAYGROUND_BACKEND_SECRET=
+
+# Cloudflare Turnstile. Server secret here; the public site key is the client
+# widget's NEXT_PUBLIC_TURNSTILE_SITE_KEY (used by the playground component).
+# Get keys at https://dash.cloudflare.com (Turnstile). Without the secret,
+# verification is skipped (dev only).
+# TURNSTILE_SECRET_KEY=
+# NEXT_PUBLIC_TURNSTILE_SITE_KEY=
+
+# Rate-limit store (Upstash Redis REST). Without it, rate limiting is disabled
+# (dev only). Free database at https://console.upstash.com.
+# UPSTASH_REDIS_REST_URL=
+# UPSTASH_REDIS_REST_TOKEN=
+
+# Optional limit overrides (defaults: 5/min and 25/day per IP, 5000/day global).
+# PLAYGROUND_IP_PER_MIN=5
+# PLAYGROUND_IP_PER_DAY=25
+# PLAYGROUND_GLOBAL_PER_DAY=5000

--- a/website/app/api/playground/scrape/route.ts
+++ b/website/app/api/playground/scrape/route.ts
@@ -1,0 +1,78 @@
+import {
+  SSE_HEADERS,
+  checkRateLimits,
+  clientIp,
+  sseError,
+  verifyTurnstile,
+} from "@/lib/playground/gate";
+
+// SSE must never be cached, and the handler runs as long as the scrape streams.
+// (Edge Runtime is deprecated in Next 16; this uses the default Node runtime,
+// whose Web Streams support is enough to proxy the backend SSE through.)
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// The Fly backend stays private behind this gate. NEXT_PUBLIC is deliberately
+// absent: the browser never learns the backend URL. Local dev default matches
+// the backend's launch port.
+const BACKEND_URL = process.env.PLAYGROUND_BACKEND_URL ?? "http://localhost:5179";
+
+/**
+ * Tier A playground gate. GET (so the client EventSource can consume it):
+ *   /api/playground/scrape?url=<encoded>&cf=<turnstile-token>
+ * Verifies Turnstile, applies rate limits, then streams the backend
+ * /scrape/stream SSE through, injecting the shared secret so the backend can
+ * refuse direct public traffic.
+ */
+export async function GET(req: Request): Promise<Response> {
+  const params = new URL(req.url).searchParams;
+  const target = safeHttpUrl(params.get("url"));
+  if (!target) return sseError("Enter a valid http(s) URL to scrape.");
+
+  const ip = clientIp(req);
+
+  const turnstile = await verifyTurnstile(params.get("cf"), ip);
+  if (!turnstile.ok) return sseError(turnstile.reason);
+
+  const limit = await checkRateLimits(ip);
+  if (!limit.ok) return sseError(limit.reason);
+
+  const upstreamUrl = `${BACKEND_URL}/scrape/stream?url=${encodeURIComponent(target.href)}`;
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl, {
+      headers: backendHeaders(),
+      // Propagate client disconnect so the backend stops scraping when the
+      // EventSource closes.
+      signal: req.signal,
+    });
+  } catch (err) {
+    console.error("[playground] backend unreachable:", err);
+    return sseError("The scrape service is unavailable right now. Please try again.");
+  }
+
+  if (!upstream.ok || !upstream.body) {
+    return sseError("The scrape service returned an error. Please try again.");
+  }
+
+  return new Response(upstream.body, { status: 200, headers: SSE_HEADERS });
+}
+
+function backendHeaders(): HeadersInit {
+  const secret = process.env.PLAYGROUND_BACKEND_SECRET;
+  return secret ? { "x-playground-secret": secret } : {};
+}
+
+// Light pre-check only; the backend's SSRF-guarded handler is the authoritative
+// address policy (DNS-pinned, redirect re-validated). This just rejects obvious
+// junk and non-http schemes before opening an upstream connection.
+function safeHttpUrl(raw: string | null): URL | null {
+  if (!raw) return null;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+}

--- a/website/lib/playground/gate.ts
+++ b/website/lib/playground/gate.ts
@@ -1,0 +1,182 @@
+/**
+ * Server-side gate for the Tier A playground (Phase 1, step 4). The route
+ * handler at app/api/playground/scrape composes these: verify the Cloudflare
+ * Turnstile token, enforce per-IP + global rate limits, then proxy the backend
+ * SSE through (so the Fly URL stays private and gating is centralized).
+ *
+ * Everything here is a fail-soft seam, matching lib/billing.ts: with no env
+ * configured the gate is OPEN (so local dev and unconfigured previews still
+ * work), and a loud server warning makes an unconfigured PRODUCTION deploy
+ * obvious. Set TURNSTILE_SECRET_KEY + the Upstash vars to arm it.
+ */
+
+// Headers for a Server-Sent Events response. no-transform + x-accel-buffering
+// stop intermediary proxies from buffering the stream.
+export const SSE_HEADERS: Record<string, string> = {
+  "content-type": "text/event-stream; charset=utf-8",
+  "cache-control": "no-cache, no-transform",
+  "x-accel-buffering": "no",
+};
+
+/** Best-effort client IP. request.ip was removed in Next 16; read the headers. */
+export function clientIp(req: Request): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0]!.trim();
+  return req.headers.get("x-real-ip")?.trim() || "0.0.0.0";
+}
+
+// The error event the gate emits on rejection. Mirrors the playground client's
+// ClimbEvent "error" arm (added client-side in the #210 live-source work); kept
+// as a local shape so this route compiles independently of that branch.
+type GateErrorEvent = { kind: "error"; message: string };
+
+/**
+ * A gate rejection as a complete SSE response. Returns 200 with a single
+ * {kind:"error"} event (not a 4xx) so the message reaches the client reducer;
+ * EventSource surfaces a 4xx only as a generic onerror. The client closes on a
+ * terminal event, so the stream end does not trigger an auto-reconnect loop.
+ */
+export function sseError(message: string): Response {
+  const event: GateErrorEvent = { kind: "error", message };
+  return new Response(`data: ${JSON.stringify(event)}\n\n`, {
+    status: 200,
+    headers: SSE_HEADERS,
+  });
+}
+
+type GateVerdict = { ok: true } | { ok: false; reason: string };
+
+const TURNSTILE_VERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+/**
+ * Verify a Turnstile token server-side. Unconfigured (no secret) => allow, with
+ * a warning. Configured but the token is missing or rejected => block. A verify
+ * call that throws => block (a broken verifier must not open the gate).
+ */
+export async function verifyTurnstile(
+  token: string | null,
+  ip: string,
+): Promise<GateVerdict> {
+  const secret = process.env.TURNSTILE_SECRET_KEY;
+  if (!secret) {
+    console.warn(
+      "[playground] TURNSTILE_SECRET_KEY unset; skipping verification (dev mode).",
+    );
+    return { ok: true };
+  }
+  if (!token) return { ok: false, reason: "Please complete the challenge." };
+
+  try {
+    const body = new URLSearchParams({ secret, response: token, remoteip: ip });
+    const res = await fetch(TURNSTILE_VERIFY_URL, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body,
+    });
+    const data = (await res.json()) as { success?: boolean };
+    return data.success
+      ? { ok: true }
+      : { ok: false, reason: "Verification failed. Refresh and try again." };
+  } catch (err) {
+    console.error("[playground] Turnstile verify error:", err);
+    return { ok: false, reason: "Verification is temporarily unavailable." };
+  }
+}
+
+function intEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  const n = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+type Window = { key: string; max: number; ttlSec: number; global: boolean };
+
+// Fixed-window counters. Defaults: 5/min and 25/day per IP, 5000/day globally.
+function windowsFor(ip: string): Window[] {
+  const now = Date.now();
+  const day = Math.floor(now / 86_400_000);
+  const minute = Math.floor(now / 60_000);
+  return [
+    {
+      key: `pg:global:d:${day}`,
+      max: intEnv("PLAYGROUND_GLOBAL_PER_DAY", 5000),
+      ttlSec: 86_400,
+      global: true,
+    },
+    {
+      key: `pg:ip:${ip}:m:${minute}`,
+      max: intEnv("PLAYGROUND_IP_PER_MIN", 5),
+      ttlSec: 60,
+      global: false,
+    },
+    {
+      key: `pg:ip:${ip}:d:${day}`,
+      max: intEnv("PLAYGROUND_IP_PER_DAY", 25),
+      ttlSec: 86_400,
+      global: false,
+    },
+  ];
+}
+
+/**
+ * Per-IP + global rate limit, backed by Upstash Redis REST (atomic INCR+EXPIRE
+ * via /multi-exec). Unconfigured => allow, with a warning. A store outage =>
+ * allow (fail open): cost/abuse protection must not take the demo down on a
+ * Redis blip, and SSRF + the backend secret are separate, harder guards.
+ */
+export async function checkRateLimits(ip: string): Promise<GateVerdict> {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    console.warn(
+      "[playground] Upstash not configured; rate limiting disabled (dev mode).",
+    );
+    return { ok: true };
+  }
+
+  for (const w of windowsFor(ip)) {
+    let count: number;
+    try {
+      count = await incrWithExpire(url, token, w.key, w.ttlSec);
+    } catch (err) {
+      console.error("[playground] rate-limit store error:", err);
+      return { ok: true };
+    }
+    if (count > w.max) {
+      return {
+        ok: false,
+        reason: w.global
+          ? "The live demo is at capacity right now. Try again later, or sign up for Cloud."
+          : "You have hit the demo limit. Try again later, or run WebReaper locally.",
+      };
+    }
+  }
+  return { ok: true };
+}
+
+async function incrWithExpire(
+  baseUrl: string,
+  token: string,
+  key: string,
+  ttlSec: number,
+): Promise<number> {
+  const res = await fetch(`${baseUrl}/multi-exec`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify([
+      ["INCR", key],
+      ["EXPIRE", key, String(ttlSec)],
+    ]),
+  });
+  if (!res.ok) throw new Error(`Upstash HTTP ${res.status}`);
+  const results = (await res.json()) as Array<{ result?: number; error?: string }>;
+  const incr = results[0];
+  if (!incr || typeof incr.result !== "number") {
+    throw new Error(incr?.error ?? "unexpected INCR result");
+  }
+  return incr.result;
+}


### PR DESCRIPTION
## What

Phase 1 **steps 4 and 5** of the [Cloud playground plan](docs/CLOUD-PLAYGROUND-PHASE-1.md): the Vercel edge gate and the Fly deploy config that turn the Tier A backend (#209) into something safe to expose publicly.

- **Edge gate** (`website/app/api/playground/scrape/route.ts` + `lib/playground/gate.ts`): a GET route handler the client's `EventSource` hits. Verifies a Cloudflare Turnstile token, enforces per-IP (5/min, 25/day) plus global (5000/day) rate limits via Upstash Redis REST, then proxies the backend SSE straight through so the Fly URL stays private. Every dependency is a fail-soft seam matching `lib/billing.ts`: unset env means "off, dev mode" with a loud server warning, never a crash.
- **Backend lock-down** (`Program.cs`): requires a shared `X-Playground-Secret` on `/scrape/stream` so the Fly app refuses direct, ungated traffic (otherwise the gate is trivially bypassed by hitting the Fly URL). CORS tightened to an env-driven origin allowlist, closing the file's own "tighten before deploy" TODO.
- **Deploy** (`Dockerfile`, `fly.toml`, root `.dockerignore`): multi-stage build with the repo root as context (the API references the WebReaper library), a global concurrency cap, scale-to-zero, and a `/health` check.
- **Docs** (`cloud/README.md`, `website/.env.example`): local run, the exact Fly deploy commands, a full env table for both sides, and the activation note below.

## Verification

- `dotnet build` of the backend: 0 warnings, 0 errors.
- `tsc --noEmit`: clean on the two new TS files (the unrelated `@/.velite` errors are pre-existing, from installing without the Velite codegen step).
- All output scanned for em-dashes (0).

## Needs your accounts (not done here)

The code and config are complete and locally verifiable; the live deploy needs:
- **Fly.io**: `fly launch` plus `fly deploy` (commands in `cloud/README.md`).
- **Cloudflare Turnstile** site plus secret keys.
- **Upstash Redis** (or another store) for the rate limiter.

Set the env vars listed in `website/.env.example` once provisioned.

## Activation note (coordinated with #210)

The gate is self-contained but **dormant until the client routes through it**. #210 currently points the `EventSource` straight at the backend (`NEXT_PUBLIC_PLAYGROUND_API`), which bypasses the gate. Two one-line client changes activate it, and they belong with #210 to avoid touching its files here:

1. Point the `EventSource` at the same-origin `/api/playground/scrape`.
2. Append the Turnstile token as `&cf=<token>` (EventSource is GET-only).

Until then, the backend secret plus CORS allowlist still let you lock the Fly app down independently.

Builds on the SSRF guard in #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
