### PR TITLE
fix(website): wire the live playground through the gate route (+ Turnstile)

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -31,6 +31,10 @@ RESEND_API_KEY=
 # All optional: with none set, the gate is OPEN and the route proxies straight
 # to a local backend (dev mode, logged loudly). Set these to arm it in prod.
 
+# Show the "Try it live" section on /playground. Set to 1 once the backend is
+# deployed and PLAYGROUND_BACKEND_URL is set; otherwise the section is hidden.
+# NEXT_PUBLIC_PLAYGROUND_LIVE=1
+
 # The private Fly backend URL the edge route proxies to. NOT NEXT_PUBLIC: the
 # browser never sees it. Defaults to the local backend dev port.
 # PLAYGROUND_BACKEND_URL=https://webreaper-playground.fly.dev

--- a/website/components/playground/climb-demo.tsx
+++ b/website/components/playground/climb-demo.tsx
@@ -115,22 +115,26 @@ function urlOf(script: ClimbScript): string {
   return req && req.event.kind === "request" ? req.event.url : "";
 }
 
-const DEFAULT_API_BASE = "http://localhost:5179";
+// The same-origin gate (website/app/api/playground/scrape): it verifies
+// Turnstile, rate-limits, then proxies the private backend's SSE through, so the
+// browser never talks to the backend directly.
+const PLAYGROUND_ENDPOINT = "/api/playground/scrape";
 
 /**
  * Drives the climb view from one of two sources, both folding into the same
- * reducer: a recorded `script` (the canned hero / demos) or a live backend SSE
- * stream (`liveUrl`). Exactly one is expected.
+ * reducer: a recorded `script` (the canned hero / demos) or a live SSE stream
+ * from the gate (`liveUrl`). Exactly one is expected. `turnstileToken` is
+ * forwarded to the gate as `cf` when Turnstile is configured.
  */
 export function ClimbDemo({
   script,
   liveUrl,
-  apiBase = DEFAULT_API_BASE,
+  turnstileToken,
   className,
 }: {
   script?: ClimbScript;
   liveUrl?: string;
-  apiBase?: string;
+  turnstileToken?: string;
   className?: string;
 }) {
   const [state, dispatch] = useReducer(rootReduce, undefined, initialState);
@@ -143,9 +147,9 @@ export function ClimbDemo({
 
     // Live mode: drive the reducer from the backend SSE stream.
     if (liveUrl) {
-      const source = new EventSource(
-        `${apiBase}/scrape/stream?url=${encodeURIComponent(liveUrl)}`,
-      );
+      const params = new URLSearchParams({ url: liveUrl });
+      if (turnstileToken) params.set("cf", turnstileToken);
+      const source = new EventSource(`${PLAYGROUND_ENDPOINT}?${params.toString()}`);
       source.onmessage = (e) => {
         let event: ClimbEvent;
         try {
@@ -176,7 +180,7 @@ export function ClimbDemo({
       return () => clearTimeout(t);
     }
     return playScript(script.events, dispatch);
-  }, [script, liveUrl, apiBase, runId]);
+  }, [script, liveUrl, turnstileToken, runId]);
 
   const replay = () => setRunId((n) => n + 1);
 

--- a/website/components/playground/live-climb.tsx
+++ b/website/components/playground/live-climb.tsx
@@ -3,22 +3,34 @@
 import { type FormEvent, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { ClimbDemo } from "./climb-demo";
+import { TurnstileWidget } from "./turnstile";
 
-// The Tier A backend (cloud/WebReaper.PlaygroundApi). Defaults to the local
-// dev port; set NEXT_PUBLIC_PLAYGROUND_API to the deployed origin later.
-const API_BASE = process.env.NEXT_PUBLIC_PLAYGROUND_API ?? "http://localhost:5179";
+// The component streams from the same-origin gate (/api/playground/scrape),
+// never the backend directly. Turnstile is shown only when a site key is set;
+// without it the gate skips verification (the backend's SSRF guard + shared
+// secret are the real protections).
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
 
 export function LiveClimb({ className }: { className?: string }) {
   const [input, setInput] = useState("https://example.com");
   const [submitted, setSubmitted] = useState<string | null>(null);
-  // Remount ClimbDemo on each submit so the SSE stream restarts cleanly,
-  // even when the URL is unchanged.
+  // `token` is the fresh widget token (for the next run); `activeToken` is the
+  // snapshot the currently-mounted ClimbDemo streams with, so resetting the
+  // widget after submit cannot re-fire the in-flight stream.
+  const [token, setToken] = useState<string | null>(null);
+  const [activeToken, setActiveToken] = useState<string | null>(null);
+  // Remount ClimbDemo on each submit so the SSE stream restarts cleanly (and
+  // drive a Turnstile reset for a fresh token).
   const [runKey, setRunKey] = useState(0);
+
+  const needsToken = Boolean(TURNSTILE_SITE_KEY);
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
     const url = input.trim();
     if (!url) return;
+    if (needsToken && !token) return; // wait for the challenge to produce a token
+    setActiveToken(token);
     setSubmitted(url);
     setRunKey((n) => n + 1);
   };
@@ -36,14 +48,26 @@ export function LiveClimb({ className }: { className?: string }) {
         />
         <button
           type="submit"
-          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-accent px-4 py-2.5 text-sm font-medium text-accent-foreground transition hover:bg-accent-strong"
+          disabled={needsToken && !token}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-accent px-4 py-2.5 text-sm font-medium text-accent-foreground transition hover:bg-accent-strong disabled:cursor-not-allowed disabled:opacity-50"
         >
           Scrape
           <ArrowRight className="h-4 w-4" />
         </button>
       </form>
 
-      {submitted ? <ClimbDemo key={runKey} liveUrl={submitted} apiBase={API_BASE} /> : null}
+      {TURNSTILE_SITE_KEY ? (
+        <TurnstileWidget
+          siteKey={TURNSTILE_SITE_KEY}
+          onToken={setToken}
+          resetNonce={runKey}
+          className="mb-4 flex justify-center"
+        />
+      ) : null}
+
+      {submitted ? (
+        <ClimbDemo key={runKey} liveUrl={submitted} turnstileToken={activeToken ?? undefined} />
+      ) : null}
     </div>
   );
 }

--- a/website/components/playground/turnstile.tsx
+++ b/website/components/playground/turnstile.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type TurnstileApi = {
+  render: (el: HTMLElement, opts: TurnstileRenderOptions) => string;
+  reset: (id?: string) => void;
+};
+
+type TurnstileRenderOptions = {
+  sitekey: string;
+  callback: (token: string) => void;
+  "expired-callback"?: () => void;
+  "error-callback"?: () => void;
+  theme?: "auto" | "light" | "dark";
+};
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+  }
+}
+
+const SCRIPT_SRC =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+function ensureScript(): Promise<void> {
+  if (window.turnstile) return Promise.resolve();
+  return new Promise((resolve) => {
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${SCRIPT_SRC}"]`,
+    );
+    if (existing) {
+      existing.addEventListener("load", () => resolve(), { once: true });
+      if (window.turnstile) resolve();
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.addEventListener("load", () => resolve(), { once: true });
+    document.head.appendChild(script);
+  });
+}
+
+/**
+ * Cloudflare Turnstile widget. Renders once for the configured site key and
+ * reports a fresh token via `onToken` (null on expiry/error). Bumping
+ * `resetNonce` fetches a new token, since Turnstile tokens are single-use.
+ * Rendered only by callers that have a site key, so it is a no-op otherwise.
+ */
+export function TurnstileWidget({
+  siteKey,
+  onToken,
+  resetNonce,
+  className,
+}: {
+  siteKey: string;
+  onToken: (token: string | null) => void;
+  resetNonce: number;
+  className?: string;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetId = useRef<string | null>(null);
+  // Keep the latest callback without re-rendering the widget.
+  const onTokenRef = useRef(onToken);
+  onTokenRef.current = onToken;
+
+  useEffect(() => {
+    let cancelled = false;
+    void ensureScript().then(() => {
+      if (cancelled || widgetId.current || !containerRef.current || !window.turnstile) {
+        return;
+      }
+      widgetId.current = window.turnstile.render(containerRef.current, {
+        sitekey: siteKey,
+        theme: "dark",
+        callback: (token) => onTokenRef.current(token),
+        "expired-callback": () => onTokenRef.current(null),
+        "error-callback": () => onTokenRef.current(null),
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [siteKey]);
+
+  useEffect(() => {
+    if (resetNonce > 0 && widgetId.current && window.turnstile) {
+      onTokenRef.current(null);
+      window.turnstile.reset(widgetId.current);
+    }
+  }, [resetNonce]);
+
+  return <div ref={containerRef} className={className} />;
+}


### PR DESCRIPTION
## What

Reconciles a parallel-development seam: [#210](https://github.com/pavlovtech/WebReaper/pull/210) (live SSE wiring) and [#212](https://github.com/pavlovtech/WebReaper/pull/212) (the edge gate + Fly deploy) were built off the same base and **didn't meet**. The component streamed from `${NEXT_PUBLIC_PLAYGROUND_API}/scrape/stream` (the backend *directly*), but the gate lives at the same-origin `/api/playground/scrape`. As merged, pointing the site at the Fly URL would **bypass the gate** and be **rejected by the backend's required shared secret**, so `/playground` would break in production.

## Changes

- `ClimbDemo` live mode now streams from **`/api/playground/scrape?url=...`** (same-origin; the gate owns the private backend URL), forwarding a Turnstile token as `&cf=` when present. Drops the `NEXT_PUBLIC_PLAYGROUND_API` client→backend hop.
- New **`TurnstileWidget`**: renders only when `NEXT_PUBLIC_TURNSTILE_SITE_KEY` is set, reports a fresh single-use token, resets after each run. An `activeToken` snapshot keeps a mid-stream reset from re-firing the stream.
- `.env.example` documents `NEXT_PUBLIC_PLAYGROUND_LIVE`.

## Verification

Ran the backend + website dev locally and drove the form: the browser hits **`/api/playground/scrape`** (confirmed via the resource timing, no direct `:5179` call) and renders the real `# Example Domain` Markdown through the gate. Turnstile widget correctly absent with no site key. `pnpm build` clean.

**Caveat:** the Turnstile-*enabled* path is wired per Cloudflare's documented client API but I couldn't end-to-end test it without a real site key. Smoke-test it when you enable Turnstile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)