### PR TITLE
docs: playground Phase 2 (Tier B) build slice + ADR-0085 climb observer seam

### DIFF
--- a/docs/CLOUD-PLAYGROUND-PHASE-2.md
+++ b/docs/CLOUD-PLAYGROUND-PHASE-2.md
@@ -1,0 +1,144 @@
+# WebReaper Cloud Playground, Phase 2 Build Slice (Tier B, live browser + stealth climb)
+
+**Status:** Proposed build slice. Implements Phase 2 (Tier B) of [CLOUD-SCRAPE-PLAYGROUND-PLAN.md](CLOUD-SCRAPE-PLAYGROUND-PLAN.md).
+**Date:** 2026-05-31
+**Owner:** Alex
+**Decision trail:** the 2026-05-31 Tier B scope grill. Phase 0 (canned climb hero) and Phase 1 (Tier A, HTTP to Markdown, live at `webreaper.ai/playground`) shipped. This slice adds the browser and stealth rungs so the live HTTP to browser to stealth climb, the product's headline, works end to end and user-driven.
+
+## What this depends on (read first)
+
+**A CloakHQ OEM/SaaS license is a pre-public-launch dependency.** The live stealth tier runs the CloakBrowser binary on our infrastructure to serve third-party visitors' URLs. That is browser-as-a-service, which CloakBrowser's `BINARY-LICENSE.md` ("Cloud, Container & Integration Use") puts behind a separate OEM/SaaS license (`cloakhq@pm.me`). Two consequences, both verified against the license text, not the ADR-0054 paraphrase:
+
+- **Baking the binary into the image is permitted** (the license explicitly allows storing and running the unmodified binary in Docker images for internal infrastructure). The blocker is never redistribution or cold-start mechanics; it is the *purpose* of serving third parties.
+- **The stealth rung must not be exposed to public traffic until the license is signed.** The vanilla browser rung (Playwright Chromium, Apache/BSD) carries no such constraint and can go public freely. Dev and staging behind the existing `X-Playground-Secret` gate are fine now; this slice is built on the assumption the license lands before the stealth rung is unsecreted.
+
+## Goal
+
+Paste any URL, watch the real climb live (HTTP challenged, vanilla browser challenged, stealth gets through), get clean Markdown. The same animation that is already the canned homepage hero becomes live and user-driven. Tier B is gated (email capture) and capped, and is WebReaper Cloud's first metered product surface, not a free toggle.
+
+## Architecture (extends Phase 1)
+
+```
+[playground client, /playground]  --EventSource /api/playground/scrape?url=&cf=-->
+   [Vercel edge gate]  Turnstile + email-capture + per-IP/global rate limit + daily-budget kill switch
+                       proxy SSE through; backend URL stays private; inject X-Playground-Secret
+        |
+        v
+   [Tier B app, Fly, DEDICATED ORG]   GET /scrape/stream?url=...  -> SSE of ClimbEvent
+        require X-Playground-Secret; concurrency soft_limit = 1; per-job ~45s kill; auto-stop
+        in-VM nftables egress firewall (no RFC1918 / loopback / link-local / fdaa::/8)
+        baked image: Chromium + CloakBrowser binary, ~2 GB RAM Machine, --ipc=host
+        |
+        v
+   ScraperEngineBuilder.Crawl(url).AsMarkdown()
+        .WithCdpPageLoader(vanilla)        // rung 1
+        .WithCloakBrowser(baked, no-download)   // rung 2
+        .WithClimbObserver(observer)       // ADR-0085: per-rung steps
+        .AddSink(resultSink)               // the `result` event
+   -> EscalatingPageLoader climbs HTTP -> browser -> stealth (ADR-0083)
+   -> observer -> bounded Channel -> SSE;  resultSink -> SSE `result`
+```
+
+Tier A stays exactly as shipped (its own direct `HtmlToMarkdown` path). Tier B is a second code path in the same app.
+
+## Decisions
+
+### 1. The backend drives the engine climb, not Tier A's direct primitive
+
+Tier A calls `HtmlToMarkdown.ExtractMainContent` directly because an HTTP fetch has no climb. Tier B builds a real engine so the ADR-0083 `EscalatingPageLoader` does the climbing. The composition is all **public** builder surface (verified: `WithLoadTransport` is public at `ScraperEngineBuilder:640`; `WithCdpPageLoader` and `WithCloakBrowser` wrap it; the internal `SpiderBuilder` assembles the rungs into the `EscalatingPageLoader` at `:345-362`):
+
+```csharp
+var observer = new ChannelClimbObserver();   // OnStep -> bounded Channel -> SSE
+var sink     = new MarkdownResultSink();      // EmitAsync -> the `result` event
+
+await using var engine = await ScraperEngineBuilder
+    .Crawl(url)                               // rung 0: HTTP (Static); start here so the viz shows the whole ladder
+    .AsMarkdown()                             // MarkdownContentExtractor; output fans out to sinks
+    .WithCdpPageLoader(new CdpLaunchOptions { // rung 1: vanilla Chromium (Dynamic)
+        ExecutablePath = bakedChromiumPath,
+        AdditionalArgs = ["--no-sandbox", "--disable-dev-shm-usage"],
+    })
+    .WithCloakBrowser(new CloakBrowserOptions { // rung 2: stealth (Dynamic), binary baked in
+        ExecutablePath = bakedCloakBrowserPath,
+        AutoInstall    = AutoInstallPolicy.Disabled,  // never download at runtime
+    })
+    .WithClimbObserver(observer)              // ADR-0085
+    .AddSink(sink)
+    .BuildAsync();
+
+var report = await engine.RunAsync();          // climb runs; observer + sink stream; report carries the residual-block tally
+```
+
+`Crawl` (not `CrawlWithBrowser`) so the start page enters at the HTTP rung and the viz shows HTTP being challenged before the climb. No link selectors, so it is a single page (the plan's scrape-one-URL non-goal holds).
+
+### 2. Climb to SSE via the ADR-0085 observer seam, not log-scraping
+
+The grill rejected reconstructing the climb from the loader's `ILogger` strings (brittle; no success, winning rung, or status). [ADR-0085](adr/0085-climb-progress-observer-seam.md) adds a first-class `IClimbObserver` the loader notifies per rung. The backend maps `ClimbStep` to the existing `ClimbEvent` wire shape (`website/lib/playground/climb-events.ts`) one to one. The backend owns the index-to-name map because it built the ladder (`0=http, 1=browser, 2=stealth`); core never names "stealth" (ADR-0009):
+
+| `ClimbStep.Phase` | source | `ClimbEvent` |
+|---|---|---|
+| `Attempt` | observer | `{ kind: "attempt", tier }` |
+| `Blocked` | observer | `{ kind: "blocked", tier, status, reason }` |
+| `Climbing` | observer | `{ kind: "escalate", from, to }` (to = idx+1) |
+| `Succeeded` | observer | `{ kind: "success", tier, status }` |
+| `Exhausted` | observer | `{ kind: "exhausted", tier, reason }` |
+| (page output) | `IScraperSink.EmitAsync` | `{ kind: "result", title, markdown }` |
+| (wrapper) | backend | `{ kind: "request", url }` / `{ kind: "error", message }` |
+
+The observer feeds a bounded `Channel<ClimbStep>` (the `OnStep` contract is cheap, non-blocking, thread-safe); the SSE endpoint drains the channel plus the sink in order. The `result` stays on a custom `IScraperSink` because the observer is load-stage and the Markdown is post-extraction.
+
+### 3. Isolation: pooled, one job per VM, recycled (model B)
+
+A normal Fly app, `concurrency soft_limit = 1` per Machine (one hostile job per VM at a time), a fresh browser **context** per job, the browser **process recycled** and killed on a ~45s timeout, `auto_stop_machines` for scale-to-zero. Firecracker VM + per-job recycle + the egress firewall (decision 4) + the gate/caps (decision 6) is the industry-standard posture for running arbitrary web content (Browserless et al. pool; they do not microVM-per-request). It is continuous with the Tier A app already deployed.
+
+**Per-request ephemeral Machine (model A)** (create / run / destroy a VM per job via the Machines API) is the documented production-hardening upgrade if abuse or a Chromium-escape tail risk ever warrants it. Each job is already stateless, so the design does not foreclose it.
+
+### 4. Browser-layer SSRF: in-VM egress firewall + a dedicated org
+
+Phase 1's SSRF defense is a DNS-pinned `SocketsHttpHandler.ConnectCallback` inside `HttpClient`. Once Chromium drives the page it issues its own requests (subresources, redirects, `fetch`/XHR, WebSocket) straight from the OS stack, bypassing that handler. Fly has **no built-in egress firewall** (verified: its network controls are ingress-side, public vs Flycast/6PN; every Machine sits on `fdaa::/8` 6PN with other org apps reachable by default). So:
+
+- **In-VM nftables egress firewall** applied at container start: drop outbound to RFC1918, loopback, `169.254.0.0/16`, `fc00::/7` (covers Fly's `fdaa::/8` ULA), `fe80::/10`, and IPv4-in-IPv6 embeddings. This is the `SsrfPolicy` blocklist (already unit-tested in Phase 1) lifted to the network layer, where it covers every rung including the browser.
+- **A dedicated Fly org** for this app, so even a 6PN reach finds nothing sensitive (Tier B moves out of org `personal`).
+- The app-layer DNS-pinned guard is no longer needed on the HTTP rung: the engine's default `HttpPageLoadTransport` runs unguarded, but the network-layer firewall contains it along with the browser. (This is why we do **not** promote `HttpPageLoadTransport`'s internal handler-factory ctor to public for Tier B; the network layer is the single control.)
+
+### 5. Browsers baked into the image
+
+Both the vanilla Chromium (via the Playwright base image `mcr.microsoft.com/playwright/dotnet:vN-noble`, which carries Chromium + system deps) and the CloakBrowser binary are baked in. `WithCloakBrowser(AutoInstall: Disabled, ExecutablePath: <baked>)` never downloads at runtime. Run with `--ipc=host` (avoids Chromium OOM on `/dev/shm`) and `--no-sandbox` (the Firecracker VM is the trust boundary), on a ~2 GB RAM Machine. Image lands ~1 GB+, which Fly pulls fine. This is what the license's internal-Docker-use allowance buys; there is no cold-download step.
+
+### 6. Gate + cost (carried from the 2026-05-30 resolution; cost model shifted to browser-minutes)
+
+Unchanged decisions: **email-capture gate** on Tier B (feeds the Stripe-ready waitlist), **Turnstile**, per-IP + global **rate limit** (Upstash, still unprovisioned), a **daily-budget kill switch** that flips the playground to "demo at capacity, sign up". What changed: the $5/day ceiling now meters **browser-machine-time**, not LLM tokens (LLM extraction is deferred, see non-goals), so the kill switch keys off Machine-seconds, and BYO-key rides with the deferred LLM slice (nothing to BYO a key for yet). For dev and staging, the `X-Playground-Secret` gate already protects the endpoint; the email gate + Upstash + budget wire on before the stealth rung goes public.
+
+### 7. Honest-loss UX (already built) + the Tier A dead-end fix
+
+A residual block at the top rung emits `exhausted` and the UI shows the real outcome plus "captcha tier on the roadmap", never a bare error (already shipped in the climb component). This slice also fixes the standing Tier A loose end: `TierAScraper`'s "sign in to run the full climb" message points at a sign-in that does not exist; repoint it at the CLI (`webreaper scrape <url> --stealth`, which does the real climb locally and free, and is the licensed path for an end user on their own machine).
+
+## Repo placement
+
+Extend `cloud/WebReaper.PlaygroundApi/` with a `TierBScraper` (engine + `ChannelClimbObserver` + `MarkdownResultSink`) beside `TierAScraper`. The project gains references to `WebReaper.Cdp`, `WebReaper.Playwright`, and `WebReaper.Stealth.CloakBrowser`. Still not in `WebReaper.sln` (separate deployable; local + Docker build is the gate, as in Phase 1).
+
+## Buildable now (no accounts) vs needs your accounts
+
+- **Now, locally verifiable:** the ADR-0085 seam in core (`IClimbObserver` + `ClimbStep` + `WithClimbObserver` + the four notify sites + `NullClimbObserver`) + unit tests; the `TierBScraper` engine climb + observer-to-Channel-to-SSE + the result sink; the index-to-name mapping; the `Dockerfile` baking Chromium + a real CloakBrowser binary; the nftables egress script; a local Docker run that climbs a known-hard target end to end and curl-verifies the SSE.
+- **Needs your accounts / secrets:** the CloakHQ OEM license (before the stealth rung goes public); a dedicated Fly org + a ~2 GB Machine; Upstash (rate limit, still unprovisioned from Phase 1); Cloudflare Turnstile keys; the email-capture store.
+
+## Build order (tracer-bullet, legal-clean rung first)
+
+1. **ADR-0085 seam in core** (`IClimbObserver`, `ClimbStep`, `WithClimbObserver`, four notify sites, `NullClimbObserver`) + unit tests. The contract everything else consumes; additive, no behavior change.
+2. **`TierBScraper`, HTTP + vanilla browser rungs only** (no stealth yet, legally clean, bakeable): engine climb, observer-to-Channel-to-SSE, the result sink. Local Docker, curl-verifiable against a JS-rendered SPA (climbs HTTP to browser).
+3. **Add the stealth rung** (`WithCloakBrowser` + the baked binary). Behind the `X-Playground-Secret` gate only until the OEM license lands. Verify against a known hard-Cloudflare target.
+4. **Isolation + egress on Fly:** in-VM nftables firewall, dedicated org, ~2 GB Machine, `concurrency = 1`, `auto_stop`, per-job timeout + recycle.
+5. **Edge gate additions:** email capture + the browser-minutes budget kill switch (Turnstile + Upstash were designed in Phase 1; wire them on and provision Upstash).
+6. **Refresh the canned hero** from a real Tier B climb recording (optional; the hero already exists).
+
+## Non-goals (this slice)
+
+- **LLM extraction / `ExtractWithPrompt`** (deferred by default this grill, flip if wanted). Tier B's output is empty-prompt Markdown; the plain-English prompt and its LLM budget + BYO-key are a later additive slice.
+- **Per-request ephemeral Machine isolation (model A)** (documented hardening upgrade, not this slice).
+- **Accounts / API keys / billing** (Phase 3, WebReaper Cloud proper).
+- **Crawl / map in the playground** (scrape-one-URL only).
+- **A captcha-solver rung** (the fourth rung above stealth; ADR-0083's residual-block `RunReport` signal is its future integration point).
+
+## Linked
+
+[CLOUD-SCRAPE-PLAYGROUND-PLAN.md](CLOUD-SCRAPE-PLAYGROUND-PLAN.md) · [CLOUD-PLAYGROUND-PHASE-1.md](CLOUD-PLAYGROUND-PHASE-1.md) · [ADR-0083](adr/0083-escalating-page-loader.md) (the climb) · [ADR-0085](adr/0085-climb-progress-observer-seam.md) (the observer seam) · [ADR-0054](adr/0054-stealth-backend-pattern-cloakbrowser.md) (the stealth satellite + its license model)

--- a/docs/adr/0085-climb-progress-observer-seam.md
+++ b/docs/adr/0085-climb-progress-observer-seam.md
@@ -1,0 +1,110 @@
+# Climb-progress observer seam: an `IClimbObserver` the escalating loader notifies per rung, so a consumer streams the live climb without scraping logs
+
+## Status
+
+**Proposed** (2026-05-31). Design-pass-first draft for review.
+
+- **Extends [ADR-0083](0083-escalating-page-loader.md)** (the block-aware escalating loader). 0083 built the HTTP to browser to stealth climb; this ADR makes the climb *observable* through a first-class push seam instead of only through `ILogger` side effects.
+- **Touches [ADR-0004](0004-one-page-loader-transport-seam.md)** (the seam stays single; the observer is a collaborator on the loader, not a new loader), **[ADR-0066](0066-engine-cost-telemetry.md)** (`RunReport` stays the post-hoc aggregate; live per-rung progress is a separate streaming concern, argued below), and **[ADR-0022](0022-crawl-driver-and-outstanding-work-latch.md)** (the driver stays transport-blind; observing the climb is a loader concern, like the climb itself).
+- **Motivated by** the WebReaper Cloud playground Tier B live-climb UX ([docs/CLOUD-PLAYGROUND-PHASE-2.md](../CLOUD-PLAYGROUND-PHASE-2.md)) and the still-unbuilt CLI `--progress json` NDJSON affordance named in [docs/CLOUD-SCRAPE-PLAYGROUND-PLAN.md](../CLOUD-SCRAPE-PLAYGROUND-PLAN.md). Both need per-rung progress as data, not as log text.
+- **Minor (additive).** No existing contract changes. See SemVer.
+
+## Context
+
+ADR-0083 turned the page loader into a climbing loader: for one page it loads at the current rung, runs the `IBlockDetector`, and climbs HTTP to browser to stealth on a block. The climb is now the product's headline behaviour. The cloud playground animates it live; the CLI wants to print it.
+
+But the loader surfaces the climb only as `ILogger` information lines, and only partially. Reading `EscalatingPageLoader.LoadAsync` (the climb loop):
+
+- It logs the **attempt** ("Loading {PageType} page {Url} at tier {Tier}"), the **block-and-climb** ("Page {Url} blocked at tier {Tier} ({Reason}); climbing to tier {Next}"), and the **residual block** ("Page {Url} still blocked at the top tier: {Reason}").
+- It does **not** log the **success**, the **winning rung**, or the **HTTP status**. On a clean load it returns the result with no log line at all.
+
+So a consumer that wants to render the climb has only two unappealing routes:
+
+1. **Scrape the logs.** Register an `ILoggerProvider`, filter the loader's category, and parse the message templates' structured state back into events. This makes a set of debug log strings an undocumented wire protocol for a product surface: a future reader who rewords a log line silently breaks the live demo. And it still cannot recover success, the winning rung, or the status, because those are never logged. The winning rung has to be *inferred* ("the last attempt with no following block") and the status is simply absent.
+2. **Reconstruct from the `RunReport`.** The report (ADR-0066) carries the residual-block tally, but it is a per-run post-hoc summary available only after the run completes. A live climb needs a push *during* the run, rung by rung.
+
+"Do not make every consumer reinvent this" is exactly the argument ADR-0083 used to pull block detection into a core `IBlockDetector`. Climb progress is intrinsic to a climbing loader; forcing each consumer to scrape logs for it is the same anti-pattern one layer along.
+
+## Decision
+
+Add a core push seam the loader notifies at each rung transition. Three types and one builder method.
+
+### 1. The observer and the step
+
+```csharp
+public enum ClimbPhase { Attempt, Blocked, Climbing, Succeeded, Exhausted }
+
+public sealed record ClimbStep(
+    ClimbPhase Phase,
+    string Url,
+    int TierIndex,
+    PageType PageType,
+    int? HttpStatus,   // the loaded result's status; null pre-load (Attempt) or when a transport cannot determine it
+    string? Reason);   // the block verdict's reason on Blocked / Exhausted; null otherwise
+
+public interface IClimbObserver
+{
+    // Called on the load hot path, possibly concurrently (a crawl loads pages
+    // under Parallel.ForEachAsync). Implementations must be cheap, non-blocking,
+    // and thread-safe (e.g. a Channel write). Must not throw back into the loader.
+    void OnStep(ClimbStep step);
+}
+```
+
+`Url` rides on every step so a concurrent crawl's interleaved climbs are disambiguable by the consumer; a single-URL `scrape` ignores it.
+
+### 2. The loader notifies; it does not change what it does
+
+`EscalatingPageLoader` takes an `IClimbObserver` defaulting to a `NullClimbObserver` no-op singleton, the same null-object idiom the loader already uses for `IPageCache` (`NullPageCache`) and the Spider for `IActionResolver` (`NullActionResolver`). It calls `OnStep` at the four points it already reaches:
+
+- before each rung load, `Attempt`;
+- on a block with a higher real rung, `Blocked` then `Climbing` (the consumer reads the escalation as `TierIndex` to `TierIndex + 1`);
+- on the clean-load return, `Succeeded` (the first time the winning rung and its status are reported at all);
+- at the ceiling (still blocked at the top rung), `Exhausted`.
+
+`HttpStatus` and `Reason` come straight off the `PageLoadResult` and the `BlockVerdict` the loop already holds, so the two gaps that made log-scraping lossy (status, winning rung) close by construction. No control flow changes; the null-object default means an unwired engine behaves and performs exactly as before.
+
+### 3. Wiring: a public builder method, the index stays the identity
+
+`ScraperEngineBuilder.WithClimbObserver(IClimbObserver)` forwards to the internal `SpiderBuilder`, which passes it into the `EscalatingPageLoader` constructor next to the `IBlockDetector` and `HostTierFloor` it already supplies. This mirrors `WithBlockDetector` and `WithRetryPolicy` exactly.
+
+A `ClimbStep` identifies its rung by **index**, not a name. A `PageLoadTier` is `(PageType, IPageLoadTransport)`; a vanilla browser rung and a stealth rung are both `Dynamic` CDP transports, indistinguishable to core, and ADR-0009 quarantine means core must not learn the word "stealth". The consumer built the ladder (HTTP is 0, then each `WithLoadTransport` rung in registration order), so it owns the index-to-label map. Core reports structure; the consumer names it.
+
+### 4. The result stays on the sink
+
+The observer is load-stage: it reports the climb, not the extracted data. The page's Markdown or records continue to reach a consumer through `IScraperSink` (ADR-0031), exactly as today. A consumer that wants both the climb and the output (the cloud backend does) wires an observer and a sink. This keeps the observer pure over the load stage, the same line ADR-0083 drew when it kept `IBlockDetector` pure and let record count re-enter one layer up at the driver.
+
+## Considered options
+
+- **An injected `IClimbObserver` push seam (chosen).** Matches the codebase's interface-seam convention (`IBlockDetector`, `IScraperSink`, `IPageLoader`); the null-object default is zero-cost and non-breaking; it reports the status and winning rung that the logs never had.
+- **Log interception (rejected).** Zero core change, but it turns debug log templates into a product wire protocol, cannot recover success / winning rung / status, and forces a winning-rung heuristic. That fragility is the whole reason this ADR exists.
+- **`IProgress<ClimbStep>` instead of a named interface (rejected).** The BCL idiom, but `Progress<T>` captures and posts to the `SynchronizationContext`, unwanted on a server hot path, and it reads less intentionally than the explicit seam the rest of the loader uses. `OnStep` is `IProgress<T>.Report` by another, house-style name.
+- **A C# `event` on the loader (rejected).** `EscalatingPageLoader` is internal and per-engine; a consumer never holds the instance to subscribe to. Threading an injected collaborator through the builder is the established shape, the way every other loader collaborator arrives.
+- **Carry climb steps on `RunReport` (rejected).** The report is the per-run post-hoc summary (ADR-0066); per-step live progress is a push during the run. The same split ADR-0083 made when it put the per-page verdict on `PageLoadResult` rather than only in the run aggregate.
+- **Reuse `IScraperSink` for progress (rejected).** The sink is the post-extraction target-data fan-out; it never sees a blocked or climbing load, and it is keyed to records, not rungs. Different lifecycle, different payload.
+
+## Accepted cost
+
+- **One more public seam to keep stable.** A new interface, record, enum, and builder method enter the public surface. The null-object default keeps every existing consumer and benchmark unchanged.
+- **The observer is on the load hot path.** A slow or throwing observer would stall or break the climb. The contract (cheap, non-blocking, thread-safe, never throw) is documented on `OnStep`, not enforced; the cloud backend satisfies it with a non-blocking `Channel` write. A defensive try/catch around the call site is a reasonable hardening if a misbehaving observer ever bites, deferred until it does.
+- **The consumer owns rung naming.** Core emits an index; the human label ("HTTP", "Headless browser", "Stealth browser") lives with the consumer that built the ladder. Trivial today (the cloud backend and the CLI each know their own ladder), named here so a future "core should label rungs" suggestion has its rejection on record: it would force core to name a stealth rung it deliberately cannot see (ADR-0009).
+- **Two payloads to wire for the full picture.** Climb on the observer, result on the sink. Deliberate (load-stage purity), but a consumer must remember both.
+
+## Deliberate consequences
+
+- **The live climb streams without log-scraping.** The cloud playground Tier B backend maps `ClimbStep` to its existing `ClimbEvent` SSE shape one-to-one, with no dependency on log message wording.
+- **The CLI `--progress json` affordance (the PLAN doc) gets a clean target.** The same seam serves the NDJSON-on-stderr progress stream the original playground plan called for and never built.
+- **The loader reports success for the first time.** The clean-load path was silent; `Succeeded` now carries the winning rung and its HTTP status, useful to any consumer (telemetry, the CLI exit summary, the demo).
+- **Log lines stay logs.** The information lines in the climb loop remain for operators and are now free to change wording without breaking a consumer, because they are no longer the progress contract.
+
+## SemVer
+
+**Minor (additive).** A new public interface, record, enum, and `ScraperEngineBuilder.WithClimbObserver` method; a new optional constructor parameter on the internal `EscalatingPageLoader` and a new field on the internal `SpiderBuilder`. No existing public contract changes, and the default null-object preserves current behaviour exactly. Ships within the v11.0.0 wave alongside ADR-0083 but is not itself a breaking change.
+
+## v2 deferrals (named so they don't drift)
+
+- **A per-rung label on the seam.** If a second non-cloud consumer also has to reconstruct index-to-name, carry an optional rung label (sourced from the `WithLoadTransport` registration) on `ClimbStep`. The index suffices for the two consumers in hand.
+- **The Markdown / result on the observer.** Keeps load-stage purity today; revisit only if a consumer genuinely cannot also wire a sink.
+- **An async `OnStep` for backpressure.** The sync fire-and-forget plus a bounded `Channel` covers the streaming case; an async observer is a change to make only if a real consumer needs the loader to await it.
+- **A defensive guard around the `OnStep` call.** Add the try/catch if a misbehaving observer ever threatens a real run; left out now to keep the hot path bare.
+- **`CONTEXT.md` glossary terms** (`climb observer`, `climb step`, `climb phase`) land with the implementation PR, when the types exist, keeping the glossary a description of built state (the ADR-0083 precedent).


### PR DESCRIPTION
## What

Two design docs scoping **Tier B** of the cloud playground (the live HTTP to browser to stealth climb), from the 2026-05-31 scope grill. Docs only, no code.

## Contents

- **ADR-0085 (Proposed)** `docs/adr/0085-climb-progress-observer-seam.md`: a first-class `IClimbObserver` seam the escalating loader (ADR-0083) notifies per rung, so a consumer streams the live climb without treating debug log strings as a wire protocol. Additive/minor, `NullClimbObserver` default. Closes the gaps that made log-scraping lossy (success, winning rung, HTTP status).
- **Phase 2 build slice** `docs/CLOUD-PLAYGROUND-PHASE-2.md`:
  - engine-driven climb composed from public builder APIs (verified against the code), `ClimbStep` to `ClimbEvent` SSE mapping;
  - browser-layer SSRF contained at the network layer (in-VM nftables + dedicated Fly org), because Fly exposes no built-in egress firewall (verified against Fly docs);
  - pooled per-job isolation (concurrency 1 + per-job recycle), per-request ephemeral Machine documented as the hardening upgrade;
  - both browsers baked into the image (the CloakBrowser license permits internal Docker use);
  - legal-clean-rung-first build order (vanilla browser, then stealth behind the secret gate until the OEM license lands).

## Key finding

The CloakBrowser stealth blocker is a **commercial-licensing** question, not redistribution. Its BINARY-LICENSE permits baking into images for internal use but puts *serving third parties* (browser-as-a-service) behind an OEM/SaaS license. Captured as a pre-public-launch dependency; the vanilla browser rung is unaffected.

## Deferred (flagged for review)

LLM `ExtractWithPrompt` is out of this slice; Tier B outputs empty-prompt Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)