### PR TITLE
feat(core): IClimbObserver climb-progress seam on the escalating loader (ADR-0085)

### DIFF
--- a/WebReaper.Tests/WebReaper.UnitTests/EscalatingPageLoaderTests.cs
+++ b/WebReaper.Tests/WebReaper.UnitTests/EscalatingPageLoaderTests.cs
@@ -224,6 +224,81 @@ public class EscalatingPageLoaderTests
         Assert.Equal("http", result.Html); // the successful load is still returned
     }
 
+    // --- ADR-0085: the climb-progress observer seam ---
+
+    private sealed class RecordingClimbObserver : IClimbObserver
+    {
+        public List<ClimbStep> Steps { get; } = [];
+        public void OnStep(ClimbStep step) => Steps.Add(step);
+    }
+
+    [Fact]
+    public async Task Observer_sees_attempt_then_succeeded_on_a_clean_load()
+    {
+        var observer = new RecordingClimbObserver();
+        var loader = new EscalatingPageLoader(
+            [Http(new CountingTransport("http", 200)), Browser(new CountingTransport("browser"))],
+            NeverBlocked, new HostTierFloor(), NullLogger.Instance, null, observer);
+
+        await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        Assert.Collection(observer.Steps,
+            s => { Assert.Equal(ClimbPhase.Attempt, s.Phase); Assert.Equal(0, s.TierIndex); },
+            s =>
+            {
+                Assert.Equal(ClimbPhase.Succeeded, s.Phase);
+                Assert.Equal(0, s.TierIndex);
+                Assert.Equal(200, s.HttpStatus);
+            });
+    }
+
+    [Fact]
+    public async Task Observer_sees_attempt_blocked_climbing_then_succeeded_on_a_climb()
+    {
+        var observer = new RecordingClimbObserver();
+        var loader = new EscalatingPageLoader(
+            [Http(new CountingTransport("http", 403)), Browser(new CountingTransport("browser", 200))],
+            BlockHigh("http"), new HostTierFloor(), NullLogger.Instance, null, observer);
+
+        await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        Assert.Collection(observer.Steps,
+            s => { Assert.Equal(ClimbPhase.Attempt, s.Phase); Assert.Equal(0, s.TierIndex); },
+            s =>
+            {
+                Assert.Equal(ClimbPhase.Blocked, s.Phase);
+                Assert.Equal(0, s.TierIndex);
+                Assert.Equal(403, s.HttpStatus);
+                Assert.NotNull(s.Reason);
+            },
+            s => { Assert.Equal(ClimbPhase.Climbing, s.Phase); Assert.Equal(0, s.TierIndex); },
+            s => { Assert.Equal(ClimbPhase.Attempt, s.Phase); Assert.Equal(1, s.TierIndex); },
+            s =>
+            {
+                Assert.Equal(ClimbPhase.Succeeded, s.Phase);
+                Assert.Equal(1, s.TierIndex);
+                Assert.Equal(200, s.HttpStatus);
+            });
+    }
+
+    [Fact]
+    public async Task Observer_sees_exhausted_when_blocked_at_the_top_tier()
+    {
+        var observer = new RecordingClimbObserver();
+        var loader = new EscalatingPageLoader(
+            [Http(new CountingTransport("http", 403)), Browser(new CountingTransport("browser", 403))],
+            BlockHigh("http", "browser"), new HostTierFloor(), NullLogger.Instance, null, observer);
+
+        await loader.LoadAsync(new PageRequest("https://x.test/", PageType.Static));
+
+        var last = observer.Steps[^1];
+        Assert.Equal(ClimbPhase.Exhausted, last.Phase);
+        Assert.Equal(1, last.TierIndex);
+        Assert.Equal(403, last.HttpStatus);
+        Assert.Contains(observer.Steps, s => s.Phase == ClimbPhase.Climbing);
+        Assert.DoesNotContain(observer.Steps, s => s.Phase == ClimbPhase.Succeeded);
+    }
+
     private sealed class ThrowingWriteCache : IPageCache
     {
         public Task<PageLoadResult?> TryReadAsync(string url, PageType pageType, CancellationToken cancellationToken)

--- a/WebReaper/Builders/ScraperEngineBuilder.cs
+++ b/WebReaper/Builders/ScraperEngineBuilder.cs
@@ -886,6 +886,21 @@ public class ScraperEngineBuilder
     }
 
     /// <summary>
+    /// Register a custom <see cref="IClimbObserver"/> (ADR-0085) notified at each
+    /// rung of the escalating loader's climb (attempt / blocked / climbing /
+    /// succeeded / exhausted), so a consumer can stream the live climb without
+    /// scraping logs. The default is the no-op <c>NullClimbObserver</c>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="observer"/> is null.</exception>
+    public ScraperEngineBuilder WithClimbObserver(IClimbObserver observer)
+    {
+        ArgumentNullException.ThrowIfNull(observer);
+        SpiderBuilder.WithClimbObserver(observer);
+        return this;
+    }
+
+    /// <summary>
     /// Register a custom <see cref="IPageCache"/> at the page-loader's
     /// cache-aside position (ADR-0041). The default is the no-op
     /// <c>NullPageCache</c>; the firecrawl-shaped TTL adapter is

--- a/WebReaper/Builders/SpiderBuilder.cs
+++ b/WebReaper/Builders/SpiderBuilder.cs
@@ -97,6 +97,10 @@ internal class SpiderBuilder
     private IBlockDetector BlockDetector { get; set; } =
         new Core.Blocking.Concrete.BlockDetector();
 
+    // ADR-0085: the climb-progress observer the EscalatingPageLoader notifies per
+    // rung; default no-op. Replaced via ScraperEngineBuilder.WithClimbObserver.
+    private IClimbObserver ClimbObserver { get; set; } = NullClimbObserver.Instance;
+
     public SpiderBuilder WithContentExtractor(IContentExtractor extractor)
     {
         ContentExtractor = extractor;
@@ -288,6 +292,15 @@ internal class SpiderBuilder
         return this;
     }
 
+    /// <summary>Register a custom <see cref="IClimbObserver"/> (ADR-0085); the
+    /// default is the no-op <see cref="NullClimbObserver"/>.</summary>
+    public SpiderBuilder WithClimbObserver(IClimbObserver climbObserver)
+    {
+        ArgumentNullException.ThrowIfNull(climbObserver);
+        ClimbObserver = climbObserver;
+        return this;
+    }
+
     /// <summary>Register a custom <see cref="IPageCache"/> (ADR-0041);
     /// the default is <see cref="NullPageCache"/> (no cache).</summary>
     public SpiderBuilder WithPageCache(IPageCache cache)
@@ -358,7 +371,8 @@ internal class SpiderBuilder
                 BlockDetector,
                 new HostTierFloor(),
                 Logger,
-                PageCache);
+                PageCache,
+                ClimbObserver);
         }
 
         CookieStorage.AddAsync(Cookies);

--- a/WebReaper/Core/Loaders/Abstract/IClimbObserver.cs
+++ b/WebReaper/Core/Loaders/Abstract/IClimbObserver.cs
@@ -1,0 +1,64 @@
+using WebReaper.Domain.Selectors;
+
+namespace WebReaper.Core.Loaders.Abstract;
+
+/// <summary>
+/// The phase of a climb step the <c>EscalatingPageLoader</c> reports (ADR-0085).
+/// </summary>
+public enum ClimbPhase
+{
+    /// <summary>About to load the page at <see cref="ClimbStep.TierIndex"/>.</summary>
+    Attempt,
+
+    /// <summary>The load at this rung was classified as a block.</summary>
+    Blocked,
+
+    /// <summary>Climbing from this rung to the next (escalation).</summary>
+    Climbing,
+
+    /// <summary>A clean (non-blocked) load; this rung won.</summary>
+    Succeeded,
+
+    /// <summary>Still blocked at the top rung; the climb is exhausted.</summary>
+    Exhausted,
+}
+
+/// <summary>
+/// One step of an <c>EscalatingPageLoader</c> climb (ADR-0085): the load-stage
+/// progress of one page, namely which rung was tried and whether it blocked,
+/// climbed, won, or exhausted. Tier identity is the ladder <see cref="TierIndex"/>
+/// (0 = HTTP, then each configured Dynamic rung in registration order); core does
+/// not name a rung "browser" or "stealth" (ADR-0009), so a consumer that built the
+/// ladder maps the index to a label.
+/// </summary>
+/// <param name="Phase">The step's phase.</param>
+/// <param name="Url">The page URL (lets a concurrent crawl disambiguate interleaved climbs).</param>
+/// <param name="TierIndex">The ladder rung this step concerns, lowest = 0. On <see cref="ClimbPhase.Climbing"/> this is the rung being left; the next rung is <c>TierIndex + 1</c>.</param>
+/// <param name="PageType">The load mode the rung serves.</param>
+/// <param name="HttpStatus">The loaded result's status; null pre-load (<see cref="ClimbPhase.Attempt"/> / <see cref="ClimbPhase.Climbing"/>) or when a transport cannot determine it.</param>
+/// <param name="Reason">The block verdict's reason on <see cref="ClimbPhase.Blocked"/> / <see cref="ClimbPhase.Exhausted"/>; null otherwise.</param>
+public sealed record ClimbStep(
+    ClimbPhase Phase,
+    string Url,
+    int TierIndex,
+    PageType PageType,
+    int? HttpStatus,
+    string? Reason);
+
+/// <summary>
+/// A sink for the <see cref="ClimbStep"/>s an <c>EscalatingPageLoader</c> emits as
+/// it climbs (ADR-0085). The default is the no-op <c>NullClimbObserver</c>; a
+/// consumer (the cloud playground's live SSE stream, the CLI's <c>--progress json</c>)
+/// wires its own to observe the climb without scraping logs.
+/// </summary>
+/// <remarks>
+/// <see cref="OnStep"/> is called on the load hot path, possibly concurrently (a
+/// crawl loads pages under <c>Parallel.ForEachAsync</c>). Implementations must be
+/// cheap, non-blocking, and thread-safe (for example a channel write), and must
+/// not throw back into the loader.
+/// </remarks>
+public interface IClimbObserver
+{
+    /// <summary>Report one climb step. Must not throw.</summary>
+    void OnStep(ClimbStep step);
+}

--- a/WebReaper/Core/Loaders/Concrete/EscalatingPageLoader.cs
+++ b/WebReaper/Core/Loaders/Concrete/EscalatingPageLoader.cs
@@ -38,13 +38,15 @@ internal sealed class EscalatingPageLoader : IPageLoader
     private readonly HostTierFloor _hostTierFloor;
     private readonly IPageCache _cache;
     private readonly ILogger _logger;
+    private readonly IClimbObserver _observer;
 
     public EscalatingPageLoader(
         IReadOnlyList<PageLoadTier> tiers,
         IBlockDetector blockDetector,
         HostTierFloor hostTierFloor,
         ILogger logger,
-        IPageCache? cache = null)
+        IPageCache? cache = null,
+        IClimbObserver? observer = null)
     {
         ArgumentNullException.ThrowIfNull(tiers);
         if (tiers.Count == 0)
@@ -59,6 +61,8 @@ internal sealed class EscalatingPageLoader : IPageLoader
         _logger = logger;
         // ADR-0041: NullPageCache preserves the no-cache behaviour exactly.
         _cache = cache ?? new NullPageCache();
+        // ADR-0085: NullClimbObserver is the zero-overhead default.
+        _observer = observer ?? NullClimbObserver.Instance;
     }
 
     public async Task<PageLoadResult> LoadAsync(PageRequest request, CancellationToken cancellationToken = default)
@@ -83,6 +87,8 @@ internal sealed class EscalatingPageLoader : IPageLoader
             _logger.LogInformation(
                 "Loading {PageType} page {Url} at tier {Tier}",
                 _tiers[tier].PageType, request.Url, tier);
+            _observer.OnStep(new ClimbStep(
+                ClimbPhase.Attempt, request.Url, tier, _tiers[tier].PageType, null, null));
 
             // ADR-0083: a climb bypasses the cache for the higher rung (no read
             // here), so a stale cached lower-tier result can never silently
@@ -97,6 +103,8 @@ internal sealed class EscalatingPageLoader : IPageLoader
                 // Only clean results are cached (so the read above is always
                 // safe to serve). A cache-write failure must not fail the load.
                 await TryWriteCacheAsync(request, result, cancellationToken);
+                _observer.OnStep(new ClimbStep(
+                    ClimbPhase.Succeeded, request.Url, tier, _tiers[tier].PageType, result.HttpStatus, null));
                 return result;
             }
 
@@ -121,12 +129,18 @@ internal sealed class EscalatingPageLoader : IPageLoader
                 _logger.LogInformation(
                     "Page {Url} still blocked at the top tier: {Reason}",
                     request.Url, verdict.Reason);
+                _observer.OnStep(new ClimbStep(
+                    ClimbPhase.Exhausted, request.Url, tier, _tiers[tier].PageType, result.HttpStatus, verdict.Reason));
                 return result;
             }
 
             _logger.LogInformation(
                 "Page {Url} blocked at tier {Tier} ({Reason}); climbing to tier {Next}",
                 request.Url, tier, verdict.Reason, tier + 1);
+            _observer.OnStep(new ClimbStep(
+                ClimbPhase.Blocked, request.Url, tier, _tiers[tier].PageType, result.HttpStatus, verdict.Reason));
+            _observer.OnStep(new ClimbStep(
+                ClimbPhase.Climbing, request.Url, tier, _tiers[tier].PageType, null, null));
         }
 
         // Unreachable: the loop returns on the first clean load or at the

--- a/WebReaper/Core/Loaders/Concrete/NullClimbObserver.cs
+++ b/WebReaper/Core/Loaders/Concrete/NullClimbObserver.cs
@@ -1,0 +1,19 @@
+using WebReaper.Core.Loaders.Abstract;
+
+namespace WebReaper.Core.Loaders.Concrete;
+
+/// <summary>
+/// The no-op <see cref="IClimbObserver"/> (ADR-0085): the default when no observer
+/// is wired, so the climb has zero observation overhead and unchanged behaviour.
+/// The same null-object idiom as <c>NullPageCache</c> and <c>NullActionResolver</c>.
+/// </summary>
+public sealed class NullClimbObserver : IClimbObserver
+{
+    /// <summary>The shared instance.</summary>
+    public static readonly NullClimbObserver Instance = new();
+
+    private NullClimbObserver() { }
+
+    /// <inheritdoc />
+    public void OnStep(ClimbStep step) { }
+}


### PR DESCRIPTION
## What

Implements **ADR-0085**: a first-class `IClimbObserver` seam on the escalating page loader (ADR-0083), so a consumer can stream the live HTTP to browser to stealth climb without scraping debug logs. This is build-order step 1 of the Tier B cloud playground (`CLOUD-PLAYGROUND-PHASE-2.md`); it is also the clean target for the CLI's deferred `--progress json`.

## Why

`EscalatingPageLoader` only logged attempt / blocked / climb / exhausted and returned silently on a clean load, so **success, the winning rung, and the HTTP status were unrecoverable** without treating log message templates as a wire protocol. The seam closes those gaps at the source.

## Changes

- New `IClimbObserver.OnStep(ClimbStep)` + `ClimbPhase` (Attempt, Blocked, Climbing, Succeeded, Exhausted) in `Core/Loaders/Abstract`; `NullClimbObserver` no-op default in `Core/Loaders/Concrete`.
- `EscalatingPageLoader` notifies at the four climb points; `HttpStatus` + winning rung read straight off `PageLoadResult` / the verdict.
- `ScraperEngineBuilder.WithClimbObserver(...)` -> `SpiderBuilder` -> the loader ctor (mirrors `WithBlockDetector`). Tier identity is the ladder **index**; core never names "stealth" (ADR-0009), the consumer maps index to label.

## Safety

Additive/minor: a new public interface + builder method + one optional ctor param with a null-object default. No existing contract changes. **555 unit tests green**, including 3 new observer tests (clean-load, climb, exhausted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)