### PR TITLE
fix(cloud): Tier A dead-end points at the CLI + correct fly.toml deploy path

### DIFF
--- a/cloud/WebReaper.PlaygroundApi/Dockerfile
+++ b/cloud/WebReaper.PlaygroundApi/Dockerfile
@@ -1,7 +1,7 @@
 # Tier A playground backend (Phase 1). The API references the WebReaper library
 # project (..\..\WebReaper), so the Docker build CONTEXT must be the REPO ROOT,
-# not this directory. fly.toml sets [build].dockerfile to this path; Fly's
-# context is always the project root, so deploy FROM the repo root:
+# not this directory. The build context is the working directory you run
+# `fly deploy` from, so deploy FROM the repo root:
 #
 #   fly deploy --config cloud/WebReaper.PlaygroundApi/fly.toml
 #

--- a/cloud/WebReaper.PlaygroundApi/Scraping/TierAScraper.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/TierAScraper.cs
@@ -67,7 +67,7 @@ public sealed class TierAScraper
                 events.Add(ClimbEvents.Blocked("http", status, $"Server returned {status}."));
                 events.Add(ClimbEvents.Exhausted(
                     "http",
-                    "This site challenges plain HTTP. The browser and stealth tiers are gated, sign in to run the full climb."));
+                    $"This site challenges plain HTTP. Run the full browser and stealth climb locally and free with the CLI: webreaper scrape --stealth {uri}"));
                 return events;
             }
 

--- a/cloud/WebReaper.PlaygroundApi/fly.toml
+++ b/cloud/WebReaper.PlaygroundApi/fly.toml
@@ -1,7 +1,10 @@
 # Fly config for the Tier A playground backend (Phase 1).
 #
-# Deploy from the REPO ROOT so the build context includes the WebReaper library
-# (Fly's context is always the project root; see the Dockerfile header):
+# Deploy from the REPO ROOT: the working directory you run `fly deploy` from is
+# the Docker build context, and it must be the repo root because the Dockerfile
+# COPYs the WebReaper library from there. `--config` resolves relative to that
+# working directory; `[build].dockerfile` (below) resolves relative to THIS
+# file's directory. See the Dockerfile header:
 #
 #   fly launch --no-deploy --config cloud/WebReaper.PlaygroundApi/fly.toml   # first time, sets app + region
 #   fly secrets set PLAYGROUND_BACKEND_SECRET=$(openssl rand -hex 32) --config cloud/WebReaper.PlaygroundApi/fly.toml
@@ -14,8 +17,10 @@ app = "webreaper-playground"
 primary_region = "iad"
 
 [build]
-  # Relative to the repo root (Fly's build context), not to this file.
-  dockerfile = "cloud/WebReaper.PlaygroundApi/Dockerfile"
+  # Resolved relative to THIS fly.toml's directory (not the build context), so it
+  # is just the local filename. The build context stays the repo root you deploy
+  # from, where the Dockerfile's COPY paths resolve.
+  dockerfile = "Dockerfile"
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
## What

Two small, independent playground loose ends (no Tier B code):

1. **Tier A dead-end message points at the CLI.** `TierAScraper` told a blocked visitor to "sign in to run the full climb", but there is no sign-in. It now points at the CLI (`webreaper scrape --stealth <url>`), which runs the real HTTP to browser to stealth climb locally and free, and is the licensed path for an end user on their own machine.
2. **`fly.toml` deploy path fixed.** `[build].dockerfile` was `cloud/WebReaper.PlaygroundApi/Dockerfile`, but Fly resolves `[build].dockerfile` relative to the **fly.toml's own directory**, so the documented `fly deploy --config cloud/WebReaper.PlaygroundApi/fly.toml` doubled the path to `cloud/WebReaper.PlaygroundApi/cloud/WebReaper.PlaygroundApi/Dockerfile` and failed (the prior workaround was copying the toml to the repo root). Set to `"Dockerfile"` and corrected the misleading comments in `fly.toml` + `Dockerfile`. The build context stays the repo root you deploy from. Verified against Fly's monorepo docs (the `fly deploy` working directory is the build context; in-toml build paths are config-dir-relative).

## Validation

`dotnet build` of the cloud project is clean (0/0). The Tier A message change reaches the live site on the next Fly redeploy (`fly deploy --config cloud/WebReaper.PlaygroundApi/fly.toml` from the repo root, which the corrected path now makes work in one shot). The `fly.toml` fix is validated by the Fly docs + the observed doubling; confirm on next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)