### PR TITLE
feat(cloud): Tier B playground backend, live HTTP-to-browser climb over SSE

### DIFF
--- a/cloud/WebReaper.PlaygroundApi.Tests/TierBClimbMappingTests.cs
+++ b/cloud/WebReaper.PlaygroundApi.Tests/TierBClimbMappingTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Threading.Channels;
+using WebReaper.Core.Loaders.Abstract;
+using WebReaper.Domain.Selectors;
+using WebReaper.PlaygroundApi.Scraping;
+using WebReaper.Sinks.Models;
+using Xunit;
+
+namespace WebReaper.PlaygroundApi.Tests;
+
+/// <summary>
+/// The Tier B climb-to-wire translation: each <see cref="ClimbStep"/> phase the
+/// EscalatingPageLoader emits (ADR-0085) must map to the exact <c>ClimbEvent</c>
+/// shape the front-end reducer consumes (website/lib/playground/climb-events.ts).
+/// Asserted on the serialized wire JSON (the same camelCase + omit-null options
+/// the SSE endpoint uses), so a drift in either the mapping or the serialization
+/// is caught.
+/// </summary>
+public class TierBClimbMappingTests
+{
+    private static readonly JsonSerializerOptions Wire = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static JsonNode WireOf(object climbEvent) =>
+        JsonNode.Parse(JsonSerializer.Serialize(climbEvent, Wire))!;
+
+    private static ClimbStep Step(ClimbPhase phase, int tierIndex, int? status = null, string? reason = null) =>
+        new(phase, "https://example.com", tierIndex, PageType.Static, status, reason);
+
+    [Fact]
+    public void Attempt_maps_to_attempt_with_tier_name()
+    {
+        var w = WireOf(ChannelClimbObserver.ToEvent(Step(ClimbPhase.Attempt, 0))!);
+        Assert.Equal("attempt", (string?)w["kind"]);
+        Assert.Equal("http", (string?)w["tier"]);
+    }
+
+    [Fact]
+    public void Attempt_index_one_is_the_browser_rung() =>
+        Assert.Equal("browser", (string?)WireOf(ChannelClimbObserver.ToEvent(Step(ClimbPhase.Attempt, 1))!)["tier"]);
+
+    [Fact]
+    public void Blocked_carries_status_and_reason()
+    {
+        var w = WireOf(ChannelClimbObserver.ToEvent(Step(ClimbPhase.Blocked, 0, status: 403, reason: "Cloudflare challenge"))!);
+        Assert.Equal("blocked", (string?)w["kind"]);
+        Assert.Equal("http", (string?)w["tier"]);
+        Assert.Equal(403, (int?)w["status"]);
+        Assert.Equal("Cloudflare challenge", (string?)w["reason"]);
+    }
+
+    [Fact]
+    public void Blocked_without_status_omits_status_and_defaults_reason()
+    {
+        var w = WireOf(ChannelClimbObserver.ToEvent(Step(ClimbPhase.Blocked, 1))!);
+        Assert.Null(w["status"]); // WhenWritingNull => the key is absent, matching TS `status?: number`
+        Assert.Equal("Blocked", (string?)w["reason"]);
+    }
+
+    [Fact]
+    public void Climbing_maps_to_escalate_to_the_next_rung()
+    {
+        var w = WireOf(ChannelClimbObserver.ToEvent(Step(ClimbPhase.Climbing, 0))!);
+        Assert.Equal("escalate", (string?)w["kind"]);
+        Assert.Equal("http", (string?)w["from"]);
+        Assert.Equal("browser", (string?)w["to"]);
+    }
+
+    [Fact]
+    public void Climbing_from_the_browser_rung_escalates_to_stealth()
+    {
+        var w = WireOf(ChannelClimbObserver.ToEvent(Step(ClimbPhase.Climbing, 1))!);
+        Assert.Equal("browser", (string?)w["from"]);
+        Assert.Equal("stealth", (string?)w["to"]);
+    }
+
+    [Fact]
+    public void Succeeded_maps_to_success_with_the_winning_rung_and_status()
+    {
+        var w = WireOf(ChannelClimbObserver.ToEvent(Step(ClimbPhase.Succeeded, 1, status: 200))!);
+        Assert.Equal("success", (string?)w["kind"]);
+        Assert.Equal("browser", (string?)w["tier"]);
+        Assert.Equal(200, (int?)w["status"]);
+    }
+
+    [Fact]
+    public void Succeeded_without_a_status_defaults_to_200()
+    {
+        // The wire shape requires a numeric status; a clean browser load that did
+        // not surface one is reported as 200.
+        var w = WireOf(ChannelClimbObserver.ToEvent(Step(ClimbPhase.Succeeded, 0))!);
+        Assert.Equal(200, (int?)w["status"]);
+    }
+
+    [Fact]
+    public void Exhausted_maps_reason_at_the_top_rung()
+    {
+        var w = WireOf(ChannelClimbObserver.ToEvent(Step(ClimbPhase.Exhausted, 2, reason: "Still challenged at the top tier"))!);
+        Assert.Equal("exhausted", (string?)w["kind"]);
+        Assert.Equal("stealth", (string?)w["tier"]);
+        Assert.Equal("Still challenged at the top tier", (string?)w["reason"]);
+    }
+
+    [Fact]
+    public async Task OnStep_writes_the_mapped_event_to_the_channel()
+    {
+        var channel = Channel.CreateUnbounded<object>();
+        var observer = new ChannelClimbObserver(channel.Writer);
+
+        observer.OnStep(Step(ClimbPhase.Attempt, 0));
+        channel.Writer.Complete();
+
+        var w = WireOf(await Single(channel.Reader));
+        Assert.Equal("attempt", (string?)w["kind"]);
+        Assert.Equal("http", (string?)w["tier"]);
+    }
+
+    [Fact]
+    public async Task ResultSink_emits_a_result_event_with_title_and_markdown()
+    {
+        var channel = Channel.CreateUnbounded<object>();
+        var sink = new MarkdownResultSink(channel.Writer);
+
+        var data = new JsonObject { ["title"] = "Example", ["markdown"] = "# Example\n\nBody." };
+        await sink.EmitAsync(new ParsedData("https://example.com", data));
+        channel.Writer.Complete();
+
+        var w = WireOf(await Single(channel.Reader));
+        Assert.Equal("result", (string?)w["kind"]);
+        Assert.Equal("Example", (string?)w["title"]);
+        Assert.Equal("# Example\n\nBody.", (string?)w["markdown"]);
+    }
+
+    private static async Task<object> Single(ChannelReader<object> reader)
+    {
+        var events = new List<object>();
+        await foreach (var e in reader.ReadAllAsync())
+            events.Add(e);
+        return Assert.Single(events);
+    }
+}

--- a/cloud/WebReaper.PlaygroundApi/Dockerfile.tierb
+++ b/cloud/WebReaper.PlaygroundApi/Dockerfile.tierb
@@ -1,0 +1,76 @@
+# Tier B playground backend image: the same app as the lean Tier A Dockerfile,
+# plus the two browsers the live climb needs baked in. The vanilla Chromium rung
+# is Debian's `chromium` (which also pulls the shared-library closure the
+# CloakBrowser fork links against); the stealth rung is CloakBrowser's
+# source-patched Chromium fork, fetched and checksum-verified from its GitHub
+# release. Tier A keeps its lean browser-less image (this is a separate
+# Dockerfile, deployed to the dedicated Tier B Fly org in step 4).
+#
+# Build context = the REPO ROOT (the app references the library projects):
+#
+#   docker build -f cloud/WebReaper.PlaygroundApi/Dockerfile.tierb -t webreaper-playground-tierb .
+
+# --- fetch + checksum-verify the CloakBrowser stealth binary ---
+FROM debian:bookworm-slim AS cloakbrowser
+# Pin the version + its SHA256 from the release's SHA256SUMS. linux-x64 is the
+# only Linux asset CloakBrowser publishes (no arm64), so the image is amd64.
+ARG CLOAK_VERSION=chromium-v146.0.7680.177.5
+ARG CLOAK_SHA256=4a12bcde95fa1bb1beef2b41ab5e5c27c36be78e3be3d0dac8c64d705216670e
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /opt/cloakbrowser \
+    && curl -fsSL -o /tmp/cloakbrowser.tar.gz \
+        "https://github.com/CloakHQ/CloakBrowser/releases/download/${CLOAK_VERSION}/cloakbrowser-linux-x64.tar.gz" \
+    && echo "${CLOAK_SHA256}  /tmp/cloakbrowser.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/cloakbrowser.tar.gz -C /opt/cloakbrowser \
+    && rm /tmp/cloakbrowser.tar.gz \
+    && test -x /opt/cloakbrowser/chrome
+
+# --- build the app (SDK tag matches global.json) ---
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+# Restore as its own layer: copy the shared build props + the csprojs only (the
+# whole project graph: WebReaper -> Cdp -> Stealth.CloakBrowser -> the API), so a
+# source-only change does not re-run restore.
+COPY global.json Directory.Build.props ./
+COPY WebReaper/WebReaper.csproj WebReaper/
+COPY WebReaper.Cdp/WebReaper.Cdp.csproj WebReaper.Cdp/
+COPY WebReaper.Stealth.CloakBrowser/WebReaper.Stealth.CloakBrowser.csproj WebReaper.Stealth.CloakBrowser/
+COPY cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj cloud/WebReaper.PlaygroundApi/
+RUN dotnet restore cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj
+# Sources, then publish (framework-dependent; the aspnet base carries the runtime).
+COPY WebReaper/ WebReaper/
+COPY WebReaper.Cdp/ WebReaper.Cdp/
+COPY WebReaper.Stealth.CloakBrowser/ WebReaper.Stealth.CloakBrowser/
+COPY cloud/WebReaper.PlaygroundApi/ cloud/WebReaper.PlaygroundApi/
+RUN dotnet publish cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj \
+    -c Release -o /app --no-restore
+
+# --- runtime: Debian + ASP.NET 10 runtime + both browsers ---
+# Debian (not the .NET aspnet image): .NET 10 ships Ubuntu-only base images, and
+# Ubuntu's `chromium` apt package is a container-hostile snap stub. Debian's
+# `chromium` is a real .deb that runs headless in a container AND pulls the
+# shared-library closure the CloakBrowser fork links against; fonts-liberation
+# keeps headless rendering sane. The ASP.NET Core 10 runtime is installed via the
+# official script (distro-independent).
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        chromium fonts-liberation libicu72 ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && bash /tmp/dotnet-install.sh --channel 10.0 --runtime aspnetcore --install-dir /usr/share/dotnet \
+    && ln -sf /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm /tmp/dotnet-install.sh
+WORKDIR /app
+COPY --from=build /app ./
+COPY --from=cloakbrowser /opt/cloakbrowser /opt/cloakbrowser
+# The browsers launch with --no-sandbox (the Firecracker VM is the trust boundary,
+# decision 5), so the container runs as root, unlike the lean Tier A image.
+# PLAYGROUND_CHROMIUM_PATH / _CLOAKBROWSER_PATH name the two baked binaries.
+ENV ASPNETCORE_URLS=http://+:8080 \
+    PLAYGROUND_CHROMIUM_PATH=/usr/bin/chromium \
+    PLAYGROUND_CLOAKBROWSER_PATH=/opt/cloakbrowser/chrome
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "WebReaper.PlaygroundApi.dll"]

--- a/cloud/WebReaper.PlaygroundApi/Program.cs
+++ b/cloud/WebReaper.PlaygroundApi/Program.cs
@@ -32,8 +32,14 @@ var backendSecret = Environment.GetEnvironmentVariable("PLAYGROUND_BACKEND_SECRE
 // the CDP launcher searches PATH (local dev). Fail-soft seam, like the others.
 var chromiumPath = Environment.GetEnvironmentVariable("PLAYGROUND_CHROMIUM_PATH");
 
+// Tier B's stealth rung. When PLAYGROUND_CLOAKBROWSER_PATH names a baked
+// CloakBrowser binary the climb gains a stealth tier above the vanilla browser;
+// unset => HTTP + vanilla only. Stays behind the X-Playground-Secret gate (never
+// the public edge route) until the CloakHQ OEM license lands.
+var cloakBrowserPath = Environment.GetEnvironmentVariable("PLAYGROUND_CLOAKBROWSER_PATH");
+
 builder.Services.AddSingleton<TierAScraper>();
-builder.Services.AddSingleton(new TierBScraper(chromiumPath));
+builder.Services.AddSingleton(new TierBScraper(chromiumPath, cloakBrowserPath));
 
 var app = builder.Build();
 app.UseCors();

--- a/cloud/WebReaper.PlaygroundApi/Program.cs
+++ b/cloud/WebReaper.PlaygroundApi/Program.cs
@@ -23,11 +23,17 @@ builder.Services.AddCors(options => options.AddDefaultPolicy(policy =>
 // Once the Vercel edge gate (Turnstile + rate limit) fronts this service, the
 // backend must refuse direct public traffic, or the gate is trivially bypassed
 // by hitting the Fly URL. When PLAYGROUND_BACKEND_SECRET is set, the scrape
-// endpoint requires it (the edge injects X-Playground-Secret); unset => local
+// endpoints require it (the edge injects X-Playground-Secret); unset => local
 // dev, allowed. /health stays open for the Fly health check.
 var backendSecret = Environment.GetEnvironmentVariable("PLAYGROUND_BACKEND_SECRET");
 
+// Tier B launches a baked Chromium for the vanilla browser rung. In Docker the
+// Playwright base image's Chromium is named in PLAYGROUND_CHROMIUM_PATH; unset =>
+// the CDP launcher searches PATH (local dev). Fail-soft seam, like the others.
+var chromiumPath = Environment.GetEnvironmentVariable("PLAYGROUND_CHROMIUM_PATH");
+
 builder.Services.AddSingleton<TierAScraper>();
+builder.Services.AddSingleton(new TierBScraper(chromiumPath));
 
 var app = builder.Build();
 app.UseCors();
@@ -40,28 +46,48 @@ var jsonOptions = new JsonSerializerOptions
 
 app.MapGet("/health", () => Results.Text("ok"));
 
-// Tier A live scrape: GET so the browser EventSource can consume it directly.
+// Tier A live scrape: HTTP to Markdown, no climb (its own direct primitive). GET
+// so the browser EventSource can consume it directly.
 app.MapGet("/scrape/stream", async (HttpContext context, TierAScraper scraper, string? url, CancellationToken ct) =>
 {
-    // Reject direct public traffic when fronted by the edge gate (see above).
-    var provided = context.Request.Headers["X-Playground-Secret"].ToString();
-    if (!string.IsNullOrEmpty(backendSecret) && !string.Equals(provided, backendSecret, StringComparison.Ordinal))
-    {
-        context.Response.StatusCode = StatusCodes.Status403Forbidden;
-        return;
-    }
+    if (GateRejects(context)) return;
+    await WriteEventStreamAsync(context, scraper.StreamAsync(url ?? string.Empty, ct), ct);
+});
 
+// Tier B live scrape: the real HTTP-to-browser climb over the ADR-0085 observer
+// seam. A distinct route so the two code paths coexist in one app (Phase 2 doc).
+app.MapGet("/tier-b/scrape/stream", async (HttpContext context, TierBScraper scraper, string? url, CancellationToken ct) =>
+{
+    if (GateRejects(context)) return;
+    await WriteEventStreamAsync(context, scraper.StreamAsync(url ?? string.Empty, ct), ct);
+});
+
+app.Run();
+return;
+
+// Reject direct public traffic when fronted by the edge gate (see backendSecret).
+// Sets 403 and returns true when the request must be refused.
+bool GateRejects(HttpContext context)
+{
+    if (string.IsNullOrEmpty(backendSecret)) return false;
+    var provided = context.Request.Headers["X-Playground-Secret"].ToString();
+    if (string.Equals(provided, backendSecret, StringComparison.Ordinal)) return false;
+    context.Response.StatusCode = StatusCodes.Status403Forbidden;
+    return true;
+}
+
+// Stream a sequence of climb events to the response as Server-Sent Events.
+async Task WriteEventStreamAsync(HttpContext context, IAsyncEnumerable<object> events, CancellationToken ct)
+{
     var response = context.Response;
     response.Headers.ContentType = "text/event-stream";
     response.Headers.CacheControl = "no-cache";
     response.Headers["X-Accel-Buffering"] = "no"; // disable proxy buffering so events stream
 
-    await foreach (var climbEvent in scraper.StreamAsync(url ?? string.Empty, ct))
+    await foreach (var climbEvent in events.WithCancellation(ct))
     {
         var data = JsonSerializer.Serialize(climbEvent, jsonOptions);
         await response.WriteAsync($"data: {data}\n\n", ct);
         await response.Body.FlushAsync(ct);
     }
-});
-
-app.Run();
+}

--- a/cloud/WebReaper.PlaygroundApi/Scraping/ChannelClimbObserver.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/ChannelClimbObserver.cs
@@ -1,0 +1,64 @@
+using System.Threading.Channels;
+using WebReaper.Core.Loaders.Abstract;
+
+namespace WebReaper.PlaygroundApi.Scraping;
+
+/// <summary>
+/// Bridges the core <see cref="IClimbObserver"/> (ADR-0085) to the playground's
+/// SSE wire shape. Each <see cref="ClimbStep"/> the <c>EscalatingPageLoader</c>
+/// emits as it climbs is mapped to a <c>ClimbEvent</c> and written to the bounded
+/// channel the Tier B SSE endpoint drains. The backend owns the rung
+/// index-to-name map because it built the ladder and core never names a rung
+/// "stealth" (ADR-0009): 0 = http, 1 = browser, 2 = stealth.
+/// </summary>
+public sealed class ChannelClimbObserver : IClimbObserver
+{
+    // The ladder TierBScraper composes: the HTTP rung, then the vanilla browser
+    // rung, then (build-order step 3) the stealth rung. The index is the rung
+    // identity carried on ClimbStep.TierIndex.
+    private static readonly string[] TierNames = ["http", "browser", "stealth"];
+
+    private readonly ChannelWriter<object> _writer;
+
+    public ChannelClimbObserver(ChannelWriter<object> writer)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        _writer = writer;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Non-blocking and never throws, per the ADR-0085 <c>OnStep</c> contract: a
+    /// bounded-channel <see cref="ChannelWriter{T}.TryWrite"/> returns false
+    /// rather than awaiting if the reader ever falls behind (it does not in
+    /// practice: a climb emits a handful of steps and the SSE reader drains
+    /// immediately). An unmapped phase is dropped, not thrown.
+    /// </remarks>
+    public void OnStep(ClimbStep step)
+    {
+        if (ToEvent(step) is { } climbEvent)
+            _writer.TryWrite(climbEvent);
+    }
+
+    /// <summary>
+    /// Map one <see cref="ClimbStep"/> to its <c>ClimbEvent</c> wire object (the
+    /// shape in <c>website/lib/playground/climb-events.ts</c>). Pure, so the
+    /// translation and the index-to-name map are unit-testable without a channel
+    /// or a running engine. Returns <c>null</c> for an unknown phase.
+    /// </summary>
+    public static object? ToEvent(ClimbStep step) => step.Phase switch
+    {
+        ClimbPhase.Attempt => ClimbEvents.Attempt(TierName(step.TierIndex)),
+        ClimbPhase.Blocked => ClimbEvents.Blocked(TierName(step.TierIndex), step.HttpStatus, step.Reason ?? "Blocked"),
+        ClimbPhase.Climbing => ClimbEvents.Escalate(TierName(step.TierIndex), TierName(step.TierIndex + 1)),
+        // Succeeded is the first time core reports the winning rung and its
+        // status. The wire shape requires a numeric status; a clean load that did
+        // not surface one (some browser loads) is reported as 200.
+        ClimbPhase.Succeeded => ClimbEvents.Success(TierName(step.TierIndex), step.HttpStatus ?? 200),
+        ClimbPhase.Exhausted => ClimbEvents.Exhausted(TierName(step.TierIndex), step.Reason ?? "Still blocked at the top tier"),
+        _ => null,
+    };
+
+    private static string TierName(int index) =>
+        index >= 0 && index < TierNames.Length ? TierNames[index] : $"tier{index}";
+}

--- a/cloud/WebReaper.PlaygroundApi/Scraping/ClimbEvents.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/ClimbEvents.cs
@@ -15,6 +15,12 @@ public static class ClimbEvents
     public static object Blocked(string tier, int? status, string reason)
         => new { kind = "blocked", tier, status, reason };
 
+    /// <summary>
+    /// The climb from one rung to the next. Tier A never climbs, so only Tier B
+    /// emits this; <c>from</c> / <c>to</c> are tier names, not indices.
+    /// </summary>
+    public static object Escalate(string from, string to) => new { kind = "escalate", from, to };
+
     public static object Success(string tier, int status) => new { kind = "success", tier, status };
 
     public static object Result(string title, string markdown)

--- a/cloud/WebReaper.PlaygroundApi/Scraping/MarkdownResultSink.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/MarkdownResultSink.cs
@@ -1,0 +1,35 @@
+using System.Threading.Channels;
+using WebReaper.Sinks.Abstract;
+using WebReaper.Sinks.Models;
+
+namespace WebReaper.PlaygroundApi.Scraping;
+
+/// <summary>
+/// The Tier B result sink. The Markdown extraction (ADR-0040) produces one
+/// <see cref="ParsedData"/> for the scraped page, shaped <c>title</c> +
+/// <c>markdown</c> (<c>MarkdownContentExtractor</c>); this writes it to the SSE
+/// channel as a <c>result</c> ClimbEvent. The climb steps arrive on the
+/// <see cref="ChannelClimbObserver"/> (the load stage); the result arrives here
+/// (post-extraction), the two-payload split ADR-0085 draws.
+/// </summary>
+public sealed class MarkdownResultSink : IScraperSink
+{
+    private readonly ChannelWriter<object> _writer;
+
+    public MarkdownResultSink(ChannelWriter<object> writer)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        _writer = writer;
+    }
+
+    // Part of the IScraperSink contract; there is nothing to wipe on start for a
+    // channel destination.
+    public bool DataCleanupOnStart { get; set; }
+
+    public async Task EmitAsync(ParsedData entity, CancellationToken cancellationToken = default)
+    {
+        var title = entity.Data["title"]?.GetValue<string>() ?? string.Empty;
+        var markdown = entity.Data["markdown"]?.GetValue<string>() ?? string.Empty;
+        await _writer.WriteAsync(ClimbEvents.Result(title, markdown), cancellationToken);
+    }
+}

--- a/cloud/WebReaper.PlaygroundApi/Scraping/TierBScraper.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/TierBScraper.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using WebReaper.Builders;
 using WebReaper.Cdp;
+using WebReaper.Stealth.CloakBrowser;
 
 namespace WebReaper.PlaygroundApi.Scraping;
 
@@ -9,21 +10,26 @@ namespace WebReaper.PlaygroundApi.Scraping;
 /// Tier B: the gated, live browser climb. Where Tier A is a direct HTTP-to-Markdown
 /// fetch with no climb (<see cref="TierAScraper"/>), Tier B builds a real WebReaper
 /// engine so the ADR-0083 <c>EscalatingPageLoader</c> does the climbing: the start
-/// page enters at the HTTP rung and auto-climbs to the vanilla browser rung on a
-/// block. The live climb streams over the ADR-0085 <c>IClimbObserver</c> seam (not
+/// page enters at the HTTP rung and auto-climbs to the vanilla browser rung, then
+/// (when a CloakBrowser binary is configured) the stealth rung, on each block. The
+/// live climb streams over the ADR-0085 <c>IClimbObserver</c> seam (not
 /// log-scraping); the extracted Markdown arrives on an <c>IScraperSink</c>. Both
 /// feed one bounded channel the SSE endpoint drains, so the same climb-viz the
 /// canned hero uses renders live and user-driven. Emits the shared <c>ClimbEvent</c>
 /// shape.
 /// <para>
-/// This is build-order step 2 (Phase 2 doc): HTTP + vanilla browser only, no
-/// stealth rung yet (legally clean, bakeable). The stealth rung
-/// (<c>WithCloakBrowser</c>) is appended in step 3, behind the secret gate until
-/// the CloakHQ OEM license lands.
+/// The stealth rung is included only when a CloakBrowser binary path is supplied
+/// (the baked binary, named in <c>PLAYGROUND_CLOAKBROWSER_PATH</c>); unset means
+/// HTTP + vanilla browser only. Per the Phase 2 doc it stays behind the
+/// <c>X-Playground-Secret</c> gate (never wired to the public edge route) until the
+/// CloakHQ OEM license lands.
 /// </para>
 /// </summary>
 public sealed class TierBScraper
 {
+    private static readonly string[] ChromiumNames =
+        ["google-chrome", "chromium", "chrome", "microsoft-edge", "msedge"];
+
     // A climb emits a handful of steps and the SSE reader drains immediately, so
     // the channel sits near-empty; the bound just caps it so a stalled reader
     // cannot grow it without limit.
@@ -34,11 +40,19 @@ public sealed class TierBScraper
     private static readonly TimeSpan RunTimeout = TimeSpan.FromSeconds(45);
 
     private readonly string? _chromiumPath;
+    private readonly string? _cloakBrowserPath;
 
     /// <param name="chromiumPath">Absolute path to the baked Chromium binary (the
     /// Docker image's Playwright Chromium). <c>null</c> lets the CDP launcher
     /// search PATH and conventional install locations (the local-dev path).</param>
-    public TierBScraper(string? chromiumPath = null) => _chromiumPath = chromiumPath;
+    /// <param name="cloakBrowserPath">Absolute path to the baked CloakBrowser
+    /// binary. When set, a stealth rung is appended above the vanilla browser rung;
+    /// <c>null</c> means HTTP + vanilla browser only.</param>
+    public TierBScraper(string? chromiumPath = null, string? cloakBrowserPath = null)
+    {
+        _chromiumPath = chromiumPath;
+        _cloakBrowserPath = cloakBrowserPath;
+    }
 
     public async IAsyncEnumerable<object> StreamAsync(
         string url,
@@ -73,7 +87,7 @@ public sealed class TierBScraper
         }
         finally
         {
-            // Observe the background task and let it tear the engine + browser
+            // Observe the background task and let it tear the engine + browsers
             // down (it has finished by the time the channel closes; on an early
             // disconnect the linked token cancels it).
             await climb;
@@ -85,20 +99,21 @@ public sealed class TierBScraper
         // Link the request-abort token with the per-job budget: a client
         // disconnect cancels cancellationToken; the 45s budget cancels via
         // CancelAfter. Either tears the engine down through RunAsync, and the
-        // browser through the await using below.
+        // browsers through the await using below.
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeout.CancelAfter(RunTimeout);
 
-        // We own the vanilla-browser rung's process. The lazy
-        // WithCdpPageLoader(CdpLaunchOptions) overload would defer teardown to
-        // transport disposal, but the engine never disposes page-load transports
-        // (EscalatingPageLoader is not IAsyncDisposable and nothing registers the
-        // transport via OnTeardown), so on a long-running host its spawned Chrome
-        // leaks per request. Instead we launch lazily (only when the climb
-        // actually reaches the browser rung, keeping an HTTP-success scrape
-        // browser-free) and kill the process tree ourselves here, the model-B
-        // per-job recycle (decision 3).
-        await using var browser = new LazyBrowserRung(_chromiumPath);
+        // We own each browser rung's process. The lazy WithCdpPageLoader overloads
+        // would defer teardown to transport disposal, but the engine never disposes
+        // page-load transports (EscalatingPageLoader is not IAsyncDisposable and
+        // nothing registers the transport via OnTeardown), so on a long-running
+        // host a spawned browser leaks per request. Instead each rung launches
+        // lazily (only when the climb actually reaches it, so an HTTP-success scrape
+        // stays browser-free and most scrapes never spawn the stealth browser) and
+        // we kill the process trees ourselves here, the model-B per-job recycle
+        // (decision 3).
+        await using var vanilla = new LazyCdpRung(LaunchVanillaAsync);
+        await using var stealth = _cloakBrowserPath is not null ? new LazyCdpRung(LaunchStealthAsync) : null;
 
         try
         {
@@ -109,14 +124,22 @@ public sealed class TierBScraper
             // so the start page enters at the HTTP rung and the viz shows HTTP
             // challenged before the climb. No link selectors => a single page (the
             // scrape-one-URL non-goal holds). WithLoadTransport is the public seam
-            // WithCdpPageLoader wraps; we use it directly so we can hold the
-            // browser handle and own its teardown.
-            await using var engine = await ScraperEngineBuilder
+            // WithCdpPageLoader wraps; we use it directly so we can hold each browser
+            // handle and own its teardown. Rung order is HTTP (0), vanilla (1),
+            // stealth (2), the index the ChannelClimbObserver maps to a tier name.
+            var builder = ScraperEngineBuilder
                 .Crawl(uri.ToString())
                 .AsMarkdown()
                 .WithLoadTransport((cookies, proxy, logger, actionResolver) =>
-                    new CdpPageLoadTransport(browser.ProvideCdpUrlAsync, disposeUrlProvider: null,
-                        cookies, proxy, logger, actionResolver))
+                    new CdpPageLoadTransport(vanilla.ProvideCdpUrlAsync, disposeUrlProvider: null,
+                        cookies, proxy, logger, actionResolver));
+
+            if (stealth is not null)
+                builder = builder.WithLoadTransport((cookies, proxy, logger, actionResolver) =>
+                    new CdpPageLoadTransport(stealth.ProvideCdpUrlAsync, disposeUrlProvider: null,
+                        cookies, proxy, logger, actionResolver));
+
+            await using var engine = await builder
                 .WithClimbObserver(observer)
                 .AddSink(sink)
                 .StopWhenAllLinksProcessed()
@@ -145,12 +168,40 @@ public sealed class TierBScraper
         }
     }
 
+    // The vanilla browser rung (Apache/BSD Chromium). Launches lazily on the first
+    // browser-rung load.
+    private Task<LaunchedCdpEndpoint> LaunchVanillaAsync(CancellationToken cancellationToken)
+    {
+        var executable = _chromiumPath
+            ?? CdpLaunchHelpers.FindOnPath(ChromiumNames)
+            ?? throw new InvalidOperationException(
+                "No Chromium binary found. Set PLAYGROUND_CHROMIUM_PATH or install Chrome/Chromium.");
+        return CdpLaunchHelpers.LaunchAsync(
+            new CdpLaunchSpec(
+                executable,
+                ["--headless=new", "--no-sandbox", "--disable-dev-shm-usage"],
+                StartupTimeout: TimeSpan.FromSeconds(20)),
+            cancellationToken);
+    }
+
+    // The stealth rung (CloakBrowser, gated on the configured binary). The vendor's
+    // RecommendedArgs are hardened-Chromium sanity flags; the stealth is in the
+    // binary. --no-sandbox is added because the container runs as root (the VM is
+    // the trust boundary, decision 5).
+    private Task<LaunchedCdpEndpoint> LaunchStealthAsync(CancellationToken cancellationToken)
+    {
+        var args = new List<string>(CloakBrowserLauncher.RecommendedArgs) { "--no-sandbox", "--headless=new" };
+        return CdpLaunchHelpers.LaunchAsync(
+            new CdpLaunchSpec(_cloakBrowserPath!, args, StartupTimeout: TimeSpan.FromSeconds(30)),
+            cancellationToken);
+    }
+
     private static string DescribeFailure(Exception ex) => ex switch
     {
-        // No Chromium baked or on PATH, or a bad PLAYGROUND_CHROMIUM_PATH.
+        // No browser binary at the configured path / on PATH.
         InvalidOperationException or FileNotFoundException =>
-            "The browser climb could not start (no Chromium available).",
-        // The browser launched but never published its CDP endpoint in time.
+            "The browser climb could not start (no browser binary available).",
+        // A browser launched but never published its CDP endpoint in time.
         TimeoutException => "The browser did not start in time.",
         _ => "The climb failed before it could finish.",
     };
@@ -169,23 +220,20 @@ public sealed class TierBScraper
     }
 
     /// <summary>
-    /// A single browser rung whose Chromium process is launched lazily (on the
-    /// first browser-rung load) and owned here, so it is killed deterministically
-    /// on disposal regardless of how the run ends. The CDP-URL provider is handed
-    /// to the <see cref="CdpPageLoadTransport"/>; the first call spawns Chromium
-    /// with <c>--remote-debugging-port=0</c> and returns its WebSocket URL,
-    /// subsequent calls reuse it.
+    /// One browser rung whose CDP process is launched lazily (on the first load
+    /// that reaches it) by the supplied launcher and owned here, so it is killed
+    /// deterministically on disposal regardless of how the run ends. The CDP-URL
+    /// provider is handed to the <see cref="CdpPageLoadTransport"/>; the first call
+    /// launches the browser and returns its WebSocket URL, subsequent calls reuse
+    /// it.
     /// </summary>
-    private sealed class LazyBrowserRung : IAsyncDisposable
+    private sealed class LazyCdpRung : IAsyncDisposable
     {
-        private static readonly string[] ChromiumNames =
-            ["google-chrome", "chromium", "chrome", "microsoft-edge", "msedge"];
-
-        private readonly string? _chromiumPath;
+        private readonly Func<CancellationToken, Task<LaunchedCdpEndpoint>> _launch;
         private readonly SemaphoreSlim _launchLock = new(1, 1);
         private LaunchedCdpEndpoint? _endpoint;
 
-        public LazyBrowserRung(string? chromiumPath) => _chromiumPath = chromiumPath;
+        public LazyCdpRung(Func<CancellationToken, Task<LaunchedCdpEndpoint>> launch) => _launch = launch;
 
         public async Task<string> ProvideCdpUrlAsync(CancellationToken cancellationToken)
         {
@@ -194,16 +242,7 @@ public sealed class TierBScraper
             try
             {
                 if (_endpoint is not null) return _endpoint.CdpUrl;
-                var executable = _chromiumPath
-                    ?? CdpLaunchHelpers.FindOnPath(ChromiumNames)
-                    ?? throw new InvalidOperationException(
-                        "No Chromium binary found. Set PLAYGROUND_CHROMIUM_PATH or install Chrome/Chromium.");
-                _endpoint = await CdpLaunchHelpers.LaunchAsync(
-                    new CdpLaunchSpec(
-                        executable,
-                        ["--headless=new", "--no-sandbox", "--disable-dev-shm-usage"],
-                        StartupTimeout: TimeSpan.FromSeconds(20)),
-                    cancellationToken);
+                _endpoint = await _launch(cancellationToken);
                 return _endpoint.CdpUrl;
             }
             finally

--- a/cloud/WebReaper.PlaygroundApi/Scraping/TierBScraper.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/TierBScraper.cs
@@ -1,0 +1,222 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using WebReaper.Builders;
+using WebReaper.Cdp;
+
+namespace WebReaper.PlaygroundApi.Scraping;
+
+/// <summary>
+/// Tier B: the gated, live browser climb. Where Tier A is a direct HTTP-to-Markdown
+/// fetch with no climb (<see cref="TierAScraper"/>), Tier B builds a real WebReaper
+/// engine so the ADR-0083 <c>EscalatingPageLoader</c> does the climbing: the start
+/// page enters at the HTTP rung and auto-climbs to the vanilla browser rung on a
+/// block. The live climb streams over the ADR-0085 <c>IClimbObserver</c> seam (not
+/// log-scraping); the extracted Markdown arrives on an <c>IScraperSink</c>. Both
+/// feed one bounded channel the SSE endpoint drains, so the same climb-viz the
+/// canned hero uses renders live and user-driven. Emits the shared <c>ClimbEvent</c>
+/// shape.
+/// <para>
+/// This is build-order step 2 (Phase 2 doc): HTTP + vanilla browser only, no
+/// stealth rung yet (legally clean, bakeable). The stealth rung
+/// (<c>WithCloakBrowser</c>) is appended in step 3, behind the secret gate until
+/// the CloakHQ OEM license lands.
+/// </para>
+/// </summary>
+public sealed class TierBScraper
+{
+    // A climb emits a handful of steps and the SSE reader drains immediately, so
+    // the channel sits near-empty; the bound just caps it so a stalled reader
+    // cannot grow it without limit.
+    private const int ChannelCapacity = 64;
+
+    // Per-job wall-clock ceiling (Phase 2 doc decision 3: the ~45s kill). Caps a
+    // hostile or pathological page so one job cannot hold a pooled VM open.
+    private static readonly TimeSpan RunTimeout = TimeSpan.FromSeconds(45);
+
+    private readonly string? _chromiumPath;
+
+    /// <param name="chromiumPath">Absolute path to the baked Chromium binary (the
+    /// Docker image's Playwright Chromium). <c>null</c> lets the CDP launcher
+    /// search PATH and conventional install locations (the local-dev path).</param>
+    public TierBScraper(string? chromiumPath = null) => _chromiumPath = chromiumPath;
+
+    public async IAsyncEnumerable<object> StreamAsync(
+        string url,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (!TryNormalizeUrl(url, out var uri))
+        {
+            yield return ClimbEvents.Error("Enter a valid http(s) URL.");
+            yield break;
+        }
+
+        yield return ClimbEvents.Request(uri.ToString());
+
+        var channel = Channel.CreateBounded<object>(new BoundedChannelOptions(ChannelCapacity)
+        {
+            SingleReader = true,
+            // The observer (load stage) and the sink (post-extraction) both write.
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.Wait,
+        });
+
+        // Run the climb on a background task that owns the engine + browser
+        // lifecycle and always completes the channel (writing an error event on
+        // failure first), so the drain loop below needs no try/catch around its
+        // yields.
+        var climb = RunClimbAsync(uri, channel.Writer, cancellationToken);
+
+        try
+        {
+            await foreach (var climbEvent in channel.Reader.ReadAllAsync(cancellationToken))
+                yield return climbEvent;
+        }
+        finally
+        {
+            // Observe the background task and let it tear the engine + browser
+            // down (it has finished by the time the channel closes; on an early
+            // disconnect the linked token cancels it).
+            await climb;
+        }
+    }
+
+    private async Task RunClimbAsync(Uri uri, ChannelWriter<object> writer, CancellationToken cancellationToken)
+    {
+        // Link the request-abort token with the per-job budget: a client
+        // disconnect cancels cancellationToken; the 45s budget cancels via
+        // CancelAfter. Either tears the engine down through RunAsync, and the
+        // browser through the await using below.
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(RunTimeout);
+
+        // We own the vanilla-browser rung's process. The lazy
+        // WithCdpPageLoader(CdpLaunchOptions) overload would defer teardown to
+        // transport disposal, but the engine never disposes page-load transports
+        // (EscalatingPageLoader is not IAsyncDisposable and nothing registers the
+        // transport via OnTeardown), so on a long-running host its spawned Chrome
+        // leaks per request. Instead we launch lazily (only when the climb
+        // actually reaches the browser rung, keeping an HTTP-success scrape
+        // browser-free) and kill the process tree ourselves here, the model-B
+        // per-job recycle (decision 3).
+        await using var browser = new LazyBrowserRung(_chromiumPath);
+
+        try
+        {
+            var observer = new ChannelClimbObserver(writer);
+            var sink = new MarkdownResultSink(writer);
+
+            // Composition is all public builder surface. Crawl (not CrawlWithBrowser)
+            // so the start page enters at the HTTP rung and the viz shows HTTP
+            // challenged before the climb. No link selectors => a single page (the
+            // scrape-one-URL non-goal holds). WithLoadTransport is the public seam
+            // WithCdpPageLoader wraps; we use it directly so we can hold the
+            // browser handle and own its teardown.
+            await using var engine = await ScraperEngineBuilder
+                .Crawl(uri.ToString())
+                .AsMarkdown()
+                .WithLoadTransport((cookies, proxy, logger, actionResolver) =>
+                    new CdpPageLoadTransport(browser.ProvideCdpUrlAsync, disposeUrlProvider: null,
+                        cookies, proxy, logger, actionResolver))
+                .WithClimbObserver(observer)
+                .AddSink(sink)
+                .StopWhenAllLinksProcessed()
+                .BuildAsync();
+
+            await engine.RunAsync(timeout.Token);
+            writer.TryComplete();
+        }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            // The 45s budget fired and the client is still connected; report the
+            // stop as a real outcome rather than swallowing it.
+            writer.TryWrite(ClimbEvents.Error("The climb exceeded the time budget and was stopped."));
+            writer.TryComplete();
+        }
+        catch (OperationCanceledException)
+        {
+            // The client disconnected (cancellationToken). No one is listening;
+            // just close the channel so the drain loop ends.
+            writer.TryComplete();
+        }
+        catch (Exception ex)
+        {
+            writer.TryWrite(ClimbEvents.Error(DescribeFailure(ex)));
+            writer.TryComplete();
+        }
+    }
+
+    private static string DescribeFailure(Exception ex) => ex switch
+    {
+        // No Chromium baked or on PATH, or a bad PLAYGROUND_CHROMIUM_PATH.
+        InvalidOperationException or FileNotFoundException =>
+            "The browser climb could not start (no Chromium available).",
+        // The browser launched but never published its CDP endpoint in time.
+        TimeoutException => "The browser did not start in time.",
+        _ => "The climb failed before it could finish.",
+    };
+
+    private static bool TryNormalizeUrl(string? url, out Uri uri)
+    {
+        uri = null!;
+        if (string.IsNullOrWhiteSpace(url))
+            return false;
+        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var parsed))
+            return false;
+        if (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps)
+            return false;
+        uri = parsed;
+        return true;
+    }
+
+    /// <summary>
+    /// A single browser rung whose Chromium process is launched lazily (on the
+    /// first browser-rung load) and owned here, so it is killed deterministically
+    /// on disposal regardless of how the run ends. The CDP-URL provider is handed
+    /// to the <see cref="CdpPageLoadTransport"/>; the first call spawns Chromium
+    /// with <c>--remote-debugging-port=0</c> and returns its WebSocket URL,
+    /// subsequent calls reuse it.
+    /// </summary>
+    private sealed class LazyBrowserRung : IAsyncDisposable
+    {
+        private static readonly string[] ChromiumNames =
+            ["google-chrome", "chromium", "chrome", "microsoft-edge", "msedge"];
+
+        private readonly string? _chromiumPath;
+        private readonly SemaphoreSlim _launchLock = new(1, 1);
+        private LaunchedCdpEndpoint? _endpoint;
+
+        public LazyBrowserRung(string? chromiumPath) => _chromiumPath = chromiumPath;
+
+        public async Task<string> ProvideCdpUrlAsync(CancellationToken cancellationToken)
+        {
+            if (_endpoint is not null) return _endpoint.CdpUrl;
+            await _launchLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_endpoint is not null) return _endpoint.CdpUrl;
+                var executable = _chromiumPath
+                    ?? CdpLaunchHelpers.FindOnPath(ChromiumNames)
+                    ?? throw new InvalidOperationException(
+                        "No Chromium binary found. Set PLAYGROUND_CHROMIUM_PATH or install Chrome/Chromium.");
+                _endpoint = await CdpLaunchHelpers.LaunchAsync(
+                    new CdpLaunchSpec(
+                        executable,
+                        ["--headless=new", "--no-sandbox", "--disable-dev-shm-usage"],
+                        StartupTimeout: TimeSpan.FromSeconds(20)),
+                    cancellationToken);
+                return _endpoint.CdpUrl;
+            }
+            finally
+            {
+                _launchLock.Release();
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            // Kills the spawned process tree and removes its temp user-data-dir.
+            if (_endpoint is not null) await _endpoint.DisposeAsync();
+            _launchLock.Dispose();
+        }
+    }
+}

--- a/cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj
+++ b/cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj
@@ -13,10 +13,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\WebReaper\WebReaper.csproj" />
     <!-- Tier B's vanilla-browser rung: the raw-CDP transport (WithCdpPageLoader).
-         WebReaper.Cdp is self-contained (no PuppeteerSharp / Microsoft.Playwright),
-         so this one reference covers the HTTP-to-browser climb. The stealth rung
-         (WebReaper.Stealth.CloakBrowser) is added in build-order step 3. -->
+         WebReaper.Cdp is self-contained (no PuppeteerSharp / Microsoft.Playwright). -->
     <ProjectReference Include="..\..\WebReaper.Cdp\WebReaper.Cdp.csproj" />
+    <!-- Tier B's stealth rung: CloakBrowser's recommended launch flags. We launch
+         the binary lazily ourselves (not via the eager WithCloakBrowser) so it
+         only spawns when the climb reaches the stealth tier. -->
+    <ProjectReference Include="..\..\WebReaper.Stealth.CloakBrowser\WebReaper.Stealth.CloakBrowser.csproj" />
   </ItemGroup>
 
 </Project>

--- a/cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj
+++ b/cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj
@@ -12,6 +12,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\WebReaper\WebReaper.csproj" />
+    <!-- Tier B's vanilla-browser rung: the raw-CDP transport (WithCdpPageLoader).
+         WebReaper.Cdp is self-contained (no PuppeteerSharp / Microsoft.Playwright),
+         so this one reference covers the HTTP-to-browser climb. The stealth rung
+         (WebReaper.Stealth.CloakBrowser) is added in build-order step 3. -->
+    <ProjectReference Include="..\..\WebReaper.Cdp\WebReaper.Cdp.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Build-order **step 2** of [CLOUD-PLAYGROUND-PHASE-2.md](docs/CLOUD-PLAYGROUND-PHASE-2.md) (Tier B). Adds the live `TierBScraper` code path beside `TierAScraper`: a real WebReaper engine whose ADR-0083 `EscalatingPageLoader` climbs HTTP to the vanilla browser rung, streamed live to the climb-viz over SSE. HTTP + vanilla browser only; the stealth rung (`WithCloakBrowser`) is step 3.

## What's here

- **`TierBScraper`** composes `Crawl(url).AsMarkdown().WithLoadTransport(cdp).WithClimbObserver(obs).AddSink(sink).StopWhenAllLinksProcessed()`. `Crawl` (not `CrawlWithBrowser`) so the start page enters at the HTTP rung and the viz shows HTTP challenged before the climb.
- **`ChannelClimbObserver`** maps each ADR-0085 `ClimbStep` to the `ClimbEvent` wire shape (`website/lib/playground/climb-events.ts`) and owns the rung index-to-name map (`0 http, 1 browser, 2 stealth`), since core never names "stealth" (ADR-0009). Non-blocking `TryWrite` per the `OnStep` contract.
- **`MarkdownResultSink`** writes the extracted `{title, markdown}` as the `result` event. Climb on the observer, result on the sink (the ADR-0085 two-payload split).
- **`ClimbEvents.Escalate`** is new (Tier A never climbs).
- New **`GET /tier-b/scrape/stream`** endpoint; the `X-Playground-Secret` gate and SSE-write are factored into shared helpers with the unchanged Tier A route.

## Browser lifecycle (a leak fix)

The engine never disposes page-load transports (`EscalatingPageLoader` is not `IAsyncDisposable` and nothing registers the transport via `OnTeardown`), so the lazy `WithCdpPageLoader(CdpLaunchOptions)` overload leaks its spawned Chrome on a long-running host. The CLI masks this by exiting per scrape; a server cannot. So Tier B launches Chromium **lazily** (only when the climb actually reaches the browser rung, keeping an HTTP-success scrape browser-free per the decision-6 cost model) via the public `CdpLaunchHelpers`, owns the endpoint, and **kills the process tree deterministically** on disposal (the model-B per-job recycle, decision 3). Also enforces the ~45s per-job kill.

> **Upstream follow-up (not in this PR):** `WithCdpPageLoader(CdpLaunchOptions)` should register its teardown via `OnTeardown` the way `WithCloakBrowser` does, so it stops leaking on any long-running host. Worth its own change in `WebReaper.Cdp` (with a `Cdp.Tests` case + release notes).

## Verification

- **53 unit tests green** (42 existing SSRF + 11 new): every `ClimbStep` phase to `ClimbEvent` mapping, tier-name indexing, the success-status 200 fallback, the observer channel write, the result sink.
- **Local end to end** (Chrome via `PLAYGROUND_CHROMIUM_PATH`):
  - `example.com` streams `request -> attempt(http) -> success(http,200) -> result`, **no browser launched** (lazy).
  - `httpbin.org/status/403` climbs `request -> attempt(http) -> blocked(http,403) -> escalate(http->browser) -> attempt(browser) -> success(browser,200) -> result` with a real Chromium launch, **killed after the job** (no leaked process).

The `cloud/` projects are not in `WebReaper.sln`; local + Docker build is the gate (CI excludes them).

## Deferred

- **Dockerfile Chromium baking** to the step-3/4 image work (decision 5 bakes Chromium + CloakBrowser into one image; the live Fly deploy still runs Tier A on `/scrape/stream` and is untouched here). The new route is dormant until the edge gate (step 5) points at it.

## Notes

- Block-driven climb: a plain JS SPA returning 200 is **not** flagged by the detector and stays at the HTTP rung; the climb fires on a real challenge (403/429/503, `cf-mitigated`, or a body marker). The Phase 2 doc's "JS-SPA climbs to browser" phrasing is imprecise in that respect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)