### PR TITLE
fix(cdp): register the launch-and-connect transport for engine teardown (ADR-0058)

### DIFF
--- a/WebReaper.Cdp/CdpPageLoaderBuilderExtensions.cs
+++ b/WebReaper.Cdp/CdpPageLoaderBuilderExtensions.cs
@@ -33,8 +33,9 @@ public static class CdpPageLoaderBuilderExtensions
 
     /// <summary>Launch-and-connect: the transport spawns Chromium via
     /// <see cref="CdpLaunchHelpers"/> with the supplied
-    /// <paramref name="options"/>, then connects. Lifecycle owned by the
-    /// transport — Dispose tears down the spawned process.</summary>
+    /// <paramref name="options"/>, then connects. The transport is registered
+    /// for engine teardown (ADR-0058), so disposing the engine kills the
+    /// spawned process.</summary>
     public static ScraperEngineBuilder WithCdpPageLoader(this ScraperEngineBuilder builder, CdpLaunchOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
@@ -78,6 +79,19 @@ public static class CdpPageLoaderBuilderExtensions
         }
 
         return builder.WithLoadTransport((cookies, proxy, logger, actionResolver) =>
-            new CdpPageLoadTransport(ProvideAsync, DisposeAsync, cookies, proxy, logger, actionResolver));
+        {
+            var transport = new CdpPageLoadTransport(ProvideAsync, DisposeAsync, cookies, proxy, logger, actionResolver);
+            // ADR-0058: register the transport for engine teardown. The engine
+            // does not dispose page-load transports itself (EscalatingPageLoader
+            // is not IAsyncDisposable), so without this the lazily-spawned browser
+            // process leaks on a long-running host (OS-reaped only on host exit,
+            // the same gap WithCloakBrowser already closed for its subprocess).
+            // This factory runs during BuildAsync, before the engine reads the
+            // teardown-hook list, so the hook lands; disposal is idempotent and a
+            // no-op when the browser was never launched (an HTTP-only scrape that
+            // never reached the Dynamic rung).
+            builder.OnTeardown(transport);
+            return transport;
+        });
     }
 }

--- a/WebReaper.Tests/WebReaper.IntegrationTests/CdpLoaderTeardownTests.cs
+++ b/WebReaper.Tests/WebReaper.IntegrationTests/CdpLoaderTeardownTests.cs
@@ -1,0 +1,37 @@
+using WebReaper.Builders;
+using WebReaper.Cdp;
+using Xunit;
+
+namespace WebReaper.IntegrationTests;
+
+/// <summary>
+/// ADR-0058: the launch-and-connect <c>WithCdpPageLoader(CdpLaunchOptions)</c>
+/// overload must register its lazily-spawned browser for engine teardown, the
+/// same way <c>WithCloakBrowser</c> registers its subprocess. The engine does not
+/// dispose page-load transports itself (<c>EscalatingPageLoader</c> is not
+/// <see cref="IAsyncDisposable"/>), so without the registration the spawned
+/// Chrome leaks on a long-running host (it OS-reaps only on host exit). Asserted
+/// without launching a browser: the lazy launch never fires for a build-only
+/// engine, so this runs in CI with no browser dependency.
+/// </summary>
+public sealed class CdpLoaderTeardownTests
+{
+    [Fact]
+    public async Task WithCdpPageLoader_options_registers_the_transport_for_teardown()
+    {
+        var builder = ScraperEngineBuilder
+            .Crawl("https://example.com")
+            .AsMarkdown()
+            .WithCdpPageLoader(new CdpLaunchOptions());
+
+        // The registration happens when the transport factory runs (at build),
+        // not at WithCdpPageLoader call time, so nothing is registered yet.
+        Assert.Equal(0, builder.TeardownHookCountForTests);
+
+        await using var engine = await builder.BuildAsync();
+
+        // After BuildAsync the transport has registered itself, so disposing the
+        // engine tears it down (and kills any spawned browser) instead of leaking.
+        Assert.Equal(1, builder.TeardownHookCountForTests);
+    }
+}

--- a/WebReaper/Builders/ScraperEngineBuilder.cs
+++ b/WebReaper/Builders/ScraperEngineBuilder.cs
@@ -697,6 +697,11 @@ public class ScraperEngineBuilder
         return this;
     }
 
+    // Test seam (mirrors the other *ForTests internals): the number of registered
+    // ADR-0058 teardown hooks, so a test can assert a satellite or transport
+    // registered itself for engine disposal without launching a real subprocess.
+    internal int TeardownHookCountForTests => _teardownHooks.Count;
+
     /// <summary>Rotate over proxies from <paramref name="source"/>, keeping
     /// only those every <paramref name="validators"/> approves.</summary>
     public ScraperEngineBuilder WithValidatedProxies(


### PR DESCRIPTION
## The gap

`WithCdpPageLoader(CdpLaunchOptions)` (launch-and-connect) spawns a Chromium process lazily, but **nothing disposed the transport that owns it**. The engine does not dispose page-load transports (`EscalatingPageLoader` is not `IAsyncDisposable`), and this overload, unlike `WithCloakBrowser`, never called `OnTeardown`. So the launched browser process **leaked on a long-running host**, OS-reaped only on host exit.

The CLI masks this by exiting per scrape (the orphan dies with the short-lived process), so it went unnoticed. A long-running host does not, this surfaced building the Cloud playground Tier B backend ([WebReaper#217](https://github.com/pavlovtech/WebReaper/pull/217)), where a Chrome leaked per request. That PR worked around it by owning the browser handle in the backend; this fixes it at the source for every consumer.

## The fix

The transport factory registers the transport via `OnTeardown`. The transport is already `IAsyncDisposable` and its `DisposeAsync` kills the launched process through the existing dispose handle, the engine just never called it. The factory runs during `BuildAsync`, before the engine reads the teardown-hook list, so the hook lands.

**Laziness is preserved:** the browser still launches only on first Dynamic-rung use, and disposal is a no-op when it never launched (an HTTP-only scrape that never reached the browser rung). This mirrors the ADR-0058 registration `WithCloakBrowser` already does for its subprocess.

## Verification

- New `IntegrationTests` fact asserts the transport registers itself for teardown (build-only, no browser, runs in CI).
- The existing `Cdp_transport_renders_js_then_extracts` browser test now leaves **no orphaned Chrome** after engine disposal (verified locally: 0 leaked `webreaper-cdp-` processes post-run).
- 555 unit tests green; full solution builds.

Adds an internal `TeardownHookCountForTests` seam (mirrors the existing `*ForTests` internals).

## Notes

- Version bump / `PackageReleaseNotes` left to the owner (release-driven).
- Once this lands, [WebReaper#217](https://github.com/pavlovtech/WebReaper/pull/217)'s `LazyBrowserRung` workaround can collapse back to the doc-exact `.WithCdpPageLoader(new CdpLaunchOptions{...})`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)