### PR TITLE
feat(cloud): Tier B stealth rung (CloakBrowser) + browser-baked image (step 3)

### DIFF
--- a/cloud/WebReaper.PlaygroundApi/Dockerfile.tierb
+++ b/cloud/WebReaper.PlaygroundApi/Dockerfile.tierb
@@ -1,0 +1,76 @@
+# Tier B playground backend image: the same app as the lean Tier A Dockerfile,
+# plus the two browsers the live climb needs baked in. The vanilla Chromium rung
+# is Debian's `chromium` (which also pulls the shared-library closure the
+# CloakBrowser fork links against); the stealth rung is CloakBrowser's
+# source-patched Chromium fork, fetched and checksum-verified from its GitHub
+# release. Tier A keeps its lean browser-less image (this is a separate
+# Dockerfile, deployed to the dedicated Tier B Fly org in step 4).
+#
+# Build context = the REPO ROOT (the app references the library projects):
+#
+#   docker build -f cloud/WebReaper.PlaygroundApi/Dockerfile.tierb -t webreaper-playground-tierb .
+
+# --- fetch + checksum-verify the CloakBrowser stealth binary ---
+FROM debian:bookworm-slim AS cloakbrowser
+# Pin the version + its SHA256 from the release's SHA256SUMS. linux-x64 is the
+# only Linux asset CloakBrowser publishes (no arm64), so the image is amd64.
+ARG CLOAK_VERSION=chromium-v146.0.7680.177.5
+ARG CLOAK_SHA256=4a12bcde95fa1bb1beef2b41ab5e5c27c36be78e3be3d0dac8c64d705216670e
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /opt/cloakbrowser \
+    && curl -fsSL -o /tmp/cloakbrowser.tar.gz \
+        "https://github.com/CloakHQ/CloakBrowser/releases/download/${CLOAK_VERSION}/cloakbrowser-linux-x64.tar.gz" \
+    && echo "${CLOAK_SHA256}  /tmp/cloakbrowser.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/cloakbrowser.tar.gz -C /opt/cloakbrowser \
+    && rm /tmp/cloakbrowser.tar.gz \
+    && test -x /opt/cloakbrowser/chrome
+
+# --- build the app (SDK tag matches global.json) ---
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+# Restore as its own layer: copy the shared build props + the csprojs only (the
+# whole project graph: WebReaper -> Cdp -> Stealth.CloakBrowser -> the API), so a
+# source-only change does not re-run restore.
+COPY global.json Directory.Build.props ./
+COPY WebReaper/WebReaper.csproj WebReaper/
+COPY WebReaper.Cdp/WebReaper.Cdp.csproj WebReaper.Cdp/
+COPY WebReaper.Stealth.CloakBrowser/WebReaper.Stealth.CloakBrowser.csproj WebReaper.Stealth.CloakBrowser/
+COPY cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj cloud/WebReaper.PlaygroundApi/
+RUN dotnet restore cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj
+# Sources, then publish (framework-dependent; the aspnet base carries the runtime).
+COPY WebReaper/ WebReaper/
+COPY WebReaper.Cdp/ WebReaper.Cdp/
+COPY WebReaper.Stealth.CloakBrowser/ WebReaper.Stealth.CloakBrowser/
+COPY cloud/WebReaper.PlaygroundApi/ cloud/WebReaper.PlaygroundApi/
+RUN dotnet publish cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj \
+    -c Release -o /app --no-restore
+
+# --- runtime: Debian + ASP.NET 10 runtime + both browsers ---
+# Debian (not the .NET aspnet image): .NET 10 ships Ubuntu-only base images, and
+# Ubuntu's `chromium` apt package is a container-hostile snap stub. Debian's
+# `chromium` is a real .deb that runs headless in a container AND pulls the
+# shared-library closure the CloakBrowser fork links against; fonts-liberation
+# keeps headless rendering sane. The ASP.NET Core 10 runtime is installed via the
+# official script (distro-independent).
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        chromium fonts-liberation libicu72 ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && bash /tmp/dotnet-install.sh --channel 10.0 --runtime aspnetcore --install-dir /usr/share/dotnet \
+    && ln -sf /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm /tmp/dotnet-install.sh
+WORKDIR /app
+COPY --from=build /app ./
+COPY --from=cloakbrowser /opt/cloakbrowser /opt/cloakbrowser
+# The browsers launch with --no-sandbox (the Firecracker VM is the trust boundary,
+# decision 5), so the container runs as root, unlike the lean Tier A image.
+# PLAYGROUND_CHROMIUM_PATH / _CLOAKBROWSER_PATH name the two baked binaries.
+ENV ASPNETCORE_URLS=http://+:8080 \
+    PLAYGROUND_CHROMIUM_PATH=/usr/bin/chromium \
+    PLAYGROUND_CLOAKBROWSER_PATH=/opt/cloakbrowser/chrome
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "WebReaper.PlaygroundApi.dll"]

--- a/cloud/WebReaper.PlaygroundApi/Program.cs
+++ b/cloud/WebReaper.PlaygroundApi/Program.cs
@@ -32,8 +32,14 @@ var backendSecret = Environment.GetEnvironmentVariable("PLAYGROUND_BACKEND_SECRE
 // the CDP launcher searches PATH (local dev). Fail-soft seam, like the others.
 var chromiumPath = Environment.GetEnvironmentVariable("PLAYGROUND_CHROMIUM_PATH");
 
+// Tier B's stealth rung. When PLAYGROUND_CLOAKBROWSER_PATH names a baked
+// CloakBrowser binary the climb gains a stealth tier above the vanilla browser;
+// unset => HTTP + vanilla only. Stays behind the X-Playground-Secret gate (never
+// the public edge route) until the CloakHQ OEM license lands.
+var cloakBrowserPath = Environment.GetEnvironmentVariable("PLAYGROUND_CLOAKBROWSER_PATH");
+
 builder.Services.AddSingleton<TierAScraper>();
-builder.Services.AddSingleton(new TierBScraper(chromiumPath));
+builder.Services.AddSingleton(new TierBScraper(chromiumPath, cloakBrowserPath));
 
 var app = builder.Build();
 app.UseCors();

--- a/cloud/WebReaper.PlaygroundApi/Scraping/TierBScraper.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/TierBScraper.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using WebReaper.Builders;
 using WebReaper.Cdp;
+using WebReaper.Stealth.CloakBrowser;
 
 namespace WebReaper.PlaygroundApi.Scraping;
 
@@ -9,21 +10,26 @@ namespace WebReaper.PlaygroundApi.Scraping;
 /// Tier B: the gated, live browser climb. Where Tier A is a direct HTTP-to-Markdown
 /// fetch with no climb (<see cref="TierAScraper"/>), Tier B builds a real WebReaper
 /// engine so the ADR-0083 <c>EscalatingPageLoader</c> does the climbing: the start
-/// page enters at the HTTP rung and auto-climbs to the vanilla browser rung on a
-/// block. The live climb streams over the ADR-0085 <c>IClimbObserver</c> seam (not
+/// page enters at the HTTP rung and auto-climbs to the vanilla browser rung, then
+/// (when a CloakBrowser binary is configured) the stealth rung, on each block. The
+/// live climb streams over the ADR-0085 <c>IClimbObserver</c> seam (not
 /// log-scraping); the extracted Markdown arrives on an <c>IScraperSink</c>. Both
 /// feed one bounded channel the SSE endpoint drains, so the same climb-viz the
 /// canned hero uses renders live and user-driven. Emits the shared <c>ClimbEvent</c>
 /// shape.
 /// <para>
-/// This is build-order step 2 (Phase 2 doc): HTTP + vanilla browser only, no
-/// stealth rung yet (legally clean, bakeable). The stealth rung
-/// (<c>WithCloakBrowser</c>) is appended in step 3, behind the secret gate until
-/// the CloakHQ OEM license lands.
+/// The stealth rung is included only when a CloakBrowser binary path is supplied
+/// (the baked binary, named in <c>PLAYGROUND_CLOAKBROWSER_PATH</c>); unset means
+/// HTTP + vanilla browser only. Per the Phase 2 doc it stays behind the
+/// <c>X-Playground-Secret</c> gate (never wired to the public edge route) until the
+/// CloakHQ OEM license lands.
 /// </para>
 /// </summary>
 public sealed class TierBScraper
 {
+    private static readonly string[] ChromiumNames =
+        ["google-chrome", "chromium", "chrome", "microsoft-edge", "msedge"];
+
     // A climb emits a handful of steps and the SSE reader drains immediately, so
     // the channel sits near-empty; the bound just caps it so a stalled reader
     // cannot grow it without limit.
@@ -34,11 +40,19 @@ public sealed class TierBScraper
     private static readonly TimeSpan RunTimeout = TimeSpan.FromSeconds(45);
 
     private readonly string? _chromiumPath;
+    private readonly string? _cloakBrowserPath;
 
     /// <param name="chromiumPath">Absolute path to the baked Chromium binary (the
     /// Docker image's Playwright Chromium). <c>null</c> lets the CDP launcher
     /// search PATH and conventional install locations (the local-dev path).</param>
-    public TierBScraper(string? chromiumPath = null) => _chromiumPath = chromiumPath;
+    /// <param name="cloakBrowserPath">Absolute path to the baked CloakBrowser
+    /// binary. When set, a stealth rung is appended above the vanilla browser rung;
+    /// <c>null</c> means HTTP + vanilla browser only.</param>
+    public TierBScraper(string? chromiumPath = null, string? cloakBrowserPath = null)
+    {
+        _chromiumPath = chromiumPath;
+        _cloakBrowserPath = cloakBrowserPath;
+    }
 
     public async IAsyncEnumerable<object> StreamAsync(
         string url,
@@ -73,7 +87,7 @@ public sealed class TierBScraper
         }
         finally
         {
-            // Observe the background task and let it tear the engine + browser
+            // Observe the background task and let it tear the engine + browsers
             // down (it has finished by the time the channel closes; on an early
             // disconnect the linked token cancels it).
             await climb;
@@ -85,20 +99,21 @@ public sealed class TierBScraper
         // Link the request-abort token with the per-job budget: a client
         // disconnect cancels cancellationToken; the 45s budget cancels via
         // CancelAfter. Either tears the engine down through RunAsync, and the
-        // browser through the await using below.
+        // browsers through the await using below.
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeout.CancelAfter(RunTimeout);
 
-        // We own the vanilla-browser rung's process. The lazy
-        // WithCdpPageLoader(CdpLaunchOptions) overload would defer teardown to
-        // transport disposal, but the engine never disposes page-load transports
-        // (EscalatingPageLoader is not IAsyncDisposable and nothing registers the
-        // transport via OnTeardown), so on a long-running host its spawned Chrome
-        // leaks per request. Instead we launch lazily (only when the climb
-        // actually reaches the browser rung, keeping an HTTP-success scrape
-        // browser-free) and kill the process tree ourselves here, the model-B
-        // per-job recycle (decision 3).
-        await using var browser = new LazyBrowserRung(_chromiumPath);
+        // We own each browser rung's process. The lazy WithCdpPageLoader overloads
+        // would defer teardown to transport disposal, but the engine never disposes
+        // page-load transports (EscalatingPageLoader is not IAsyncDisposable and
+        // nothing registers the transport via OnTeardown), so on a long-running
+        // host a spawned browser leaks per request. Instead each rung launches
+        // lazily (only when the climb actually reaches it, so an HTTP-success scrape
+        // stays browser-free and most scrapes never spawn the stealth browser) and
+        // we kill the process trees ourselves here, the model-B per-job recycle
+        // (decision 3).
+        await using var vanilla = new LazyCdpRung(LaunchVanillaAsync);
+        await using var stealth = _cloakBrowserPath is not null ? new LazyCdpRung(LaunchStealthAsync) : null;
 
         try
         {
@@ -109,14 +124,22 @@ public sealed class TierBScraper
             // so the start page enters at the HTTP rung and the viz shows HTTP
             // challenged before the climb. No link selectors => a single page (the
             // scrape-one-URL non-goal holds). WithLoadTransport is the public seam
-            // WithCdpPageLoader wraps; we use it directly so we can hold the
-            // browser handle and own its teardown.
-            await using var engine = await ScraperEngineBuilder
+            // WithCdpPageLoader wraps; we use it directly so we can hold each browser
+            // handle and own its teardown. Rung order is HTTP (0), vanilla (1),
+            // stealth (2), the index the ChannelClimbObserver maps to a tier name.
+            var builder = ScraperEngineBuilder
                 .Crawl(uri.ToString())
                 .AsMarkdown()
                 .WithLoadTransport((cookies, proxy, logger, actionResolver) =>
-                    new CdpPageLoadTransport(browser.ProvideCdpUrlAsync, disposeUrlProvider: null,
-                        cookies, proxy, logger, actionResolver))
+                    new CdpPageLoadTransport(vanilla.ProvideCdpUrlAsync, disposeUrlProvider: null,
+                        cookies, proxy, logger, actionResolver));
+
+            if (stealth is not null)
+                builder = builder.WithLoadTransport((cookies, proxy, logger, actionResolver) =>
+                    new CdpPageLoadTransport(stealth.ProvideCdpUrlAsync, disposeUrlProvider: null,
+                        cookies, proxy, logger, actionResolver));
+
+            await using var engine = await builder
                 .WithClimbObserver(observer)
                 .AddSink(sink)
                 .StopWhenAllLinksProcessed()
@@ -145,12 +168,40 @@ public sealed class TierBScraper
         }
     }
 
+    // The vanilla browser rung (Apache/BSD Chromium). Launches lazily on the first
+    // browser-rung load.
+    private Task<LaunchedCdpEndpoint> LaunchVanillaAsync(CancellationToken cancellationToken)
+    {
+        var executable = _chromiumPath
+            ?? CdpLaunchHelpers.FindOnPath(ChromiumNames)
+            ?? throw new InvalidOperationException(
+                "No Chromium binary found. Set PLAYGROUND_CHROMIUM_PATH or install Chrome/Chromium.");
+        return CdpLaunchHelpers.LaunchAsync(
+            new CdpLaunchSpec(
+                executable,
+                ["--headless=new", "--no-sandbox", "--disable-dev-shm-usage"],
+                StartupTimeout: TimeSpan.FromSeconds(20)),
+            cancellationToken);
+    }
+
+    // The stealth rung (CloakBrowser, gated on the configured binary). The vendor's
+    // RecommendedArgs are hardened-Chromium sanity flags; the stealth is in the
+    // binary. --no-sandbox is added because the container runs as root (the VM is
+    // the trust boundary, decision 5).
+    private Task<LaunchedCdpEndpoint> LaunchStealthAsync(CancellationToken cancellationToken)
+    {
+        var args = new List<string>(CloakBrowserLauncher.RecommendedArgs) { "--no-sandbox", "--headless=new" };
+        return CdpLaunchHelpers.LaunchAsync(
+            new CdpLaunchSpec(_cloakBrowserPath!, args, StartupTimeout: TimeSpan.FromSeconds(30)),
+            cancellationToken);
+    }
+
     private static string DescribeFailure(Exception ex) => ex switch
     {
-        // No Chromium baked or on PATH, or a bad PLAYGROUND_CHROMIUM_PATH.
+        // No browser binary at the configured path / on PATH.
         InvalidOperationException or FileNotFoundException =>
-            "The browser climb could not start (no Chromium available).",
-        // The browser launched but never published its CDP endpoint in time.
+            "The browser climb could not start (no browser binary available).",
+        // A browser launched but never published its CDP endpoint in time.
         TimeoutException => "The browser did not start in time.",
         _ => "The climb failed before it could finish.",
     };
@@ -169,23 +220,20 @@ public sealed class TierBScraper
     }
 
     /// <summary>
-    /// A single browser rung whose Chromium process is launched lazily (on the
-    /// first browser-rung load) and owned here, so it is killed deterministically
-    /// on disposal regardless of how the run ends. The CDP-URL provider is handed
-    /// to the <see cref="CdpPageLoadTransport"/>; the first call spawns Chromium
-    /// with <c>--remote-debugging-port=0</c> and returns its WebSocket URL,
-    /// subsequent calls reuse it.
+    /// One browser rung whose CDP process is launched lazily (on the first load
+    /// that reaches it) by the supplied launcher and owned here, so it is killed
+    /// deterministically on disposal regardless of how the run ends. The CDP-URL
+    /// provider is handed to the <see cref="CdpPageLoadTransport"/>; the first call
+    /// launches the browser and returns its WebSocket URL, subsequent calls reuse
+    /// it.
     /// </summary>
-    private sealed class LazyBrowserRung : IAsyncDisposable
+    private sealed class LazyCdpRung : IAsyncDisposable
     {
-        private static readonly string[] ChromiumNames =
-            ["google-chrome", "chromium", "chrome", "microsoft-edge", "msedge"];
-
-        private readonly string? _chromiumPath;
+        private readonly Func<CancellationToken, Task<LaunchedCdpEndpoint>> _launch;
         private readonly SemaphoreSlim _launchLock = new(1, 1);
         private LaunchedCdpEndpoint? _endpoint;
 
-        public LazyBrowserRung(string? chromiumPath) => _chromiumPath = chromiumPath;
+        public LazyCdpRung(Func<CancellationToken, Task<LaunchedCdpEndpoint>> launch) => _launch = launch;
 
         public async Task<string> ProvideCdpUrlAsync(CancellationToken cancellationToken)
         {
@@ -194,16 +242,7 @@ public sealed class TierBScraper
             try
             {
                 if (_endpoint is not null) return _endpoint.CdpUrl;
-                var executable = _chromiumPath
-                    ?? CdpLaunchHelpers.FindOnPath(ChromiumNames)
-                    ?? throw new InvalidOperationException(
-                        "No Chromium binary found. Set PLAYGROUND_CHROMIUM_PATH or install Chrome/Chromium.");
-                _endpoint = await CdpLaunchHelpers.LaunchAsync(
-                    new CdpLaunchSpec(
-                        executable,
-                        ["--headless=new", "--no-sandbox", "--disable-dev-shm-usage"],
-                        StartupTimeout: TimeSpan.FromSeconds(20)),
-                    cancellationToken);
+                _endpoint = await _launch(cancellationToken);
                 return _endpoint.CdpUrl;
             }
             finally

--- a/cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj
+++ b/cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj
@@ -13,10 +13,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\WebReaper\WebReaper.csproj" />
     <!-- Tier B's vanilla-browser rung: the raw-CDP transport (WithCdpPageLoader).
-         WebReaper.Cdp is self-contained (no PuppeteerSharp / Microsoft.Playwright),
-         so this one reference covers the HTTP-to-browser climb. The stealth rung
-         (WebReaper.Stealth.CloakBrowser) is added in build-order step 3. -->
+         WebReaper.Cdp is self-contained (no PuppeteerSharp / Microsoft.Playwright). -->
     <ProjectReference Include="..\..\WebReaper.Cdp\WebReaper.Cdp.csproj" />
+    <!-- Tier B's stealth rung: CloakBrowser's recommended launch flags. We launch
+         the binary lazily ourselves (not via the eager WithCloakBrowser) so it
+         only spawns when the climb reaches the stealth tier. -->
+    <ProjectReference Include="..\..\WebReaper.Stealth.CloakBrowser\WebReaper.Stealth.CloakBrowser.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Build-order **step 3** of the Phase 2 doc: adds the stealth (CloakBrowser) rung above the vanilla browser rung, plus the browser-baked Tier B image.

> **Stacked on [#217](https://github.com/pavlovtech/WebReaper/pull/217)** (base = `feat/cloud-tier-b-scraper`). GitHub will retarget to `master` once #217 merges.

## Stealth rung

- Appended above the vanilla rung: HTTP (0) → vanilla browser (1) → stealth (2), the index the climb-viz maps to a tier name.
- **Lazy-owned**, not the satellite's eager `WithCloakBrowser`: CloakBrowser launches only when the climb actually reaches the stealth rung (so an HTTP- or vanilla-success scrape never spawns a ~220 MB browser), and the process tree is killed deterministically on disposal. References `WebReaper.Stealth.CloakBrowser` only for the vendor's recommended launch flags.
- **Gated on `PLAYGROUND_CLOAKBROWSER_PATH`** — unset means HTTP + vanilla only (exact step-2 behavior). Stays behind the `X-Playground-Secret` gate (never the public edge route) until the OEM license lands.

## Image (`Dockerfile.tierb`, separate from the lean Tier A image)

- **Debian base + ASP.NET 10 runtime via the official install script.** The .NET 10 images are Ubuntu-only, and Ubuntu's `chromium` apt package is a **container-hostile snap stub** (caught it in the first build's logs). Debian's real `chromium` .deb is the vanilla rung and pulls the shared-library closure the CloakBrowser fork links against.
- **Real binary, checksum-verified:** `cloakbrowser-linux-x64.tar.gz` @ `chromium-v146.0.7680.177.5`, SHA256 from the release's `SHA256SUMS`, extracted to `/opt/cloakbrowser/chrome` (the fork's exe is named `chrome`).

## Verified

- Image builds (1.58 GB).
- **Both browsers are real and render in-container** (`--dump-dom` → `Example Domain`): vanilla **Chromium 148** (Debian), CloakBrowser **Chromium 146** (the fork).
- App + HTTP-success climb work in-container (correct SSE wire shape, real markdown).

**Deferred to the Fly deploy (step 4):** the full automated HTTP→vanilla→stealth climb timing and a beats-hardened-Cloudflare check. Rosetta amd64 emulation is too slow for the 45s job budget locally, and CloakBrowser's own README notes headless can still be detected by the hardest sites without headed mode + a residential proxy.

## Separate finding: the scaffold installer is broken

`WebReaper.Stealth.CloakBrowser/CloakBrowserInstaller` cannot fetch a real binary: it guesses tag `v0.3.30` (real: `chromium-v146...`), expects the exe at `cloakbrowser` (real: `chrome`), ignores the published `SHA256SUMS`, and there is no macOS asset (only `linux-x64` / `windows-x64`). This PR bypasses it (the Dockerfile bakes the binary directly), but the installer itself needs its own fix. Happy to do that next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)