### PR TITLE
feat(cloud): Tier B Fly isolation + egress SSRF firewall + deploy runbook (step 4)

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -84,3 +84,104 @@ client changes belong with that work (kept out of this change to avoid touching
 
 Until then the gate is dormant; the backend secret + CORS allowlist still let
 you lock the Fly app down independently.
+
+## Tier B (live browser + stealth climb)
+
+Tier B is the second code path in this same app: `GET /tier-b/scrape/stream`
+builds a real WebReaper engine so the ADR-0083 escalating loader climbs HTTP to a
+vanilla browser to the CloakBrowser stealth rung, streaming the live climb over
+SSE. It needs the browsers baked in, so it ships as a **separate image**
+(`Dockerfile.tierb`) deployed as a **separate Fly app in a dedicated org**
+(decision 4: a browser SSRF / escape must not reach other apps over Fly 6PN). The
+lean Tier A app above is untouched.
+
+### Deploy (owner actions)
+
+```bash
+# 1. A dedicated org, so the blast radius is isolated from `personal`.
+fly orgs create webreaper-tierb           # once; pick your own name
+
+# 2. Launch the app into that org (sets the app name + region; no deploy yet).
+fly launch --no-deploy --org webreaper-tierb \
+  --config cloud/WebReaper.PlaygroundApi/fly.tierb.toml
+
+# 3. The shared gate secret (same value as the Tier A app / the Vercel edge).
+fly secrets set PLAYGROUND_BACKEND_SECRET=$(openssl rand -hex 32) \
+  --config cloud/WebReaper.PlaygroundApi/fly.tierb.toml
+
+# 4. Bring it up with the firewall OFF first, to confirm the app + climb work
+#    before adding the network layer (see "Egress firewall" below).
+fly secrets set PLAYGROUND_EGRESS_FIREWALL=off \
+  --config cloud/WebReaper.PlaygroundApi/fly.tierb.toml
+fly deploy --config cloud/WebReaper.PlaygroundApi/fly.tierb.toml   # from the REPO ROOT
+```
+
+The image bakes Chromium (`/usr/bin/chromium`) and the CloakBrowser fork
+(`/opt/cloakbrowser/chrome`) and names them via `PLAYGROUND_CHROMIUM_PATH` /
+`PLAYGROUND_CLOAKBROWSER_PATH`, so no per-deploy browser config is needed. The
+stealth rung is present only because the binary is baked; keep it reachable only
+through the `X-Playground-Secret` gate (never the public edge route) until the
+CloakHQ OEM license lands.
+
+### Egress firewall (decision 4): validate, then enforce
+
+The browser issues its own OS-level requests, bypassing the app-layer SSRF guard,
+so `egress-firewall.nft` lifts the blocklist to the network layer (nftables,
+applied by `entrypoint.sh` per `PLAYGROUND_EGRESS_FIREWALL`). It is **not a
+verified control until validated on a live Machine**; three things can only be
+checked there:
+
+1. **CAP_NET_ADMIN.** `nft -f` needs it. With the firewall in `warn` mode, the
+   Machine logs whether it applied; if it did not, the Machine likely lacks the
+   capability (raise it with Fly support / a Machine config).
+2. **DNS.** Allowed by port (53), not by host, so resolution should work
+   regardless; confirm a climb still resolves names.
+3. **NAT64.** If Fly reaches the IPv4 internet via `64:ff9b::/96`, outbound v4
+   rides inside IPv6 and the `ip daddr` rules never match it. Confirm an internal
+   v4 target is actually blocked (below); if not, re-express the internal ranges
+   as their `64:ff9b::` embeddings.
+
+Rollout:
+
+```bash
+# After the firewall-off deploy works, turn the firewall on in warn mode:
+fly secrets set PLAYGROUND_EGRESS_FIREWALL=warn --config .../fly.tierb.toml
+fly deploy --config .../fly.tierb.toml
+fly logs --config .../fly.tierb.toml         # expect "egress firewall applied"
+
+# Validate from a gated request (replace SECRET + the app URL):
+#  - public scrape works (DNS + egress OK):
+curl -N -H "X-Playground-Secret: $SECRET" \
+  "https://<app>.fly.dev/tier-b/scrape/stream?url=https://example.com"
+#  - an internal target is BLOCKED (expect an error event, not a result):
+curl -N -H "X-Playground-Secret: $SECRET" \
+  "https://<app>.fly.dev/tier-b/scrape/stream?url=http://169.254.169.254/latest/meta-data/"
+
+# Once both hold, enforce (the Machine refuses to start without the firewall):
+fly secrets set PLAYGROUND_EGRESS_FIREWALL=enforce --config .../fly.tierb.toml
+fly deploy --config .../fly.tierb.toml
+```
+
+### Stealth verification (real IPs)
+
+The full HTTP to vanilla to stealth climb and "beats hardened Cloudflare" cannot
+be checked locally (no macOS CloakBrowser build, and emulation is too slow for the
+45s job budget). On the deployed Machine, curl the gated stealth climb against a
+known Cloudflare-challenge target and watch the events escalate to
+`attempt(stealth)` and then `success` or an honest `exhausted`:
+
+```bash
+curl -N -H "X-Playground-Secret: $SECRET" \
+  "https://<app>.fly.dev/tier-b/scrape/stream?url=https://<a-cloudflare-protected-site>"
+```
+
+CloakBrowser's own docs note headless can still be detected by the hardest sites;
+if a target needs it, headed mode + a residential proxy is the next lever (a
+future option, not wired here).
+
+### Env (Tier B additions)
+
+| Side | Variable | Purpose |
+|---|---|---|
+| Fly (Tier B) | `PLAYGROUND_EGRESS_FIREWALL` | `warn` (default) apply + continue on failure; `enforce` refuse to start without it; `off` skip (bring-up only). |
+| Fly (Tier B, baked) | `PLAYGROUND_CHROMIUM_PATH` / `PLAYGROUND_CLOAKBROWSER_PATH` | The two baked browser binaries. Set in the image; override only to relocate them. |

--- a/cloud/WebReaper.PlaygroundApi/Dockerfile.tierb
+++ b/cloud/WebReaper.PlaygroundApi/Dockerfile.tierb
@@ -57,7 +57,7 @@ RUN dotnet publish cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj 
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        chromium fonts-liberation libicu72 ca-certificates curl \
+        chromium fonts-liberation libicu72 ca-certificates curl nftables \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
     && bash /tmp/dotnet-install.sh --channel 10.0 --runtime aspnetcore --install-dir /usr/share/dotnet \
@@ -66,6 +66,11 @@ RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
 WORKDIR /app
 COPY --from=build /app ./
 COPY --from=cloakbrowser /opt/cloakbrowser /opt/cloakbrowser
+# The in-VM egress SSRF firewall (decision 4) + the entrypoint that applies it
+# before the app starts (nftables is installed above).
+COPY cloud/WebReaper.PlaygroundApi/egress-firewall.nft /app/egress-firewall.nft
+COPY cloud/WebReaper.PlaygroundApi/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 # The browsers launch with --no-sandbox (the Firecracker VM is the trust boundary,
 # decision 5), so the container runs as root, unlike the lean Tier A image.
 # PLAYGROUND_CHROMIUM_PATH / _CLOAKBROWSER_PATH name the two baked binaries.
@@ -73,4 +78,6 @@ ENV ASPNETCORE_URLS=http://+:8080 \
     PLAYGROUND_CHROMIUM_PATH=/usr/bin/chromium \
     PLAYGROUND_CLOAKBROWSER_PATH=/opt/cloakbrowser/chrome
 EXPOSE 8080
-ENTRYPOINT ["dotnet", "WebReaper.PlaygroundApi.dll"]
+# The entrypoint applies the egress firewall (per PLAYGROUND_EGRESS_FIREWALL),
+# then execs the .NET host.
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/cloud/WebReaper.PlaygroundApi/egress-firewall.nft
+++ b/cloud/WebReaper.PlaygroundApi/egress-firewall.nft
@@ -1,0 +1,67 @@
+#!/usr/sbin/nft -f
+#
+# Tier B in-VM egress SSRF firewall (Phase 2 doc, decision 4).
+#
+# Once Chromium drives the page it issues its own OS-level requests (subresources,
+# redirects, fetch / XHR, WebSocket) straight from the kernel, bypassing the app's
+# DNS-pinned HttpClient guard. This lifts the Phase 1 SsrfPolicy blocklist to the
+# network layer, where it covers every rung including the browser: the public
+# internet is allowed; private / loopback / link-local (incl. the 169.254.169.254
+# cloud-metadata address) / CGNAT / Fly 6PN (fdaa::/8) destinations are dropped.
+# DNS and the app <-> launched-browser CDP loopback stay open so scraping works.
+#
+# VALIDATE ON DEPLOY (see cloud/README.md). Three things can only be confirmed on
+# a live Fly Machine, and the firewall is not a verified control until they are:
+#   1. CAP_NET_ADMIN must be present for `nft -f` to apply at all.
+#   2. The resolver address: DNS is allowed by port (53) here, not by host, so it
+#      works regardless, but confirm name resolution still succeeds.
+#   3. NAT64: if Fly reaches the IPv4 internet via NAT64 (64:ff9b::/96), outbound
+#      v4 rides inside IPv6 and the `ip daddr` rules below never match it. In that
+#      case the internal v4 ranges must be re-expressed as their 64:ff9b::
+#      embeddings (e.g. 64:ff9b::a9fe:a9fe for the metadata IP). Left out here
+#      because blocking 64:ff9b::/96 wholesale would also kill public IPv4.
+
+flush ruleset
+
+table inet egress {
+    chain output {
+        type filter hook output priority 0; policy accept;
+
+        # The app talks to its launched browser's CDP endpoint on 127.0.0.1;
+        # never block loopback.
+        oifname "lo" accept
+
+        # Return traffic for connections already allowed out.
+        ct state established,related accept
+
+        # DNS must resolve. Allowing port 53 is safe: a DNS-rebinding answer that
+        # points a public name at an internal IP is still blocked at connect time
+        # by the destination rules below.
+        udp dport 53 accept
+        tcp dport 53 accept
+
+        # IPv4: unspecified, private (RFC1918), CGNAT, loopback, link-local
+        # (incl. cloud metadata 169.254.169.254), multicast, reserved.
+        ip daddr {
+            0.0.0.0/8,
+            10.0.0.0/8,
+            100.64.0.0/10,
+            127.0.0.0/8,
+            169.254.0.0/16,
+            172.16.0.0/12,
+            192.168.0.0/16,
+            224.0.0.0/4,
+            240.0.0.0/4
+        } drop
+
+        # IPv6: loopback, unspecified, ULA (fc00::/7 covers Fly's fdaa::/8 6PN),
+        # link-local, multicast.
+        ip6 daddr {
+            ::1/128,
+            ::/128,
+            fc00::/7,
+            fe80::/10,
+            ff00::/8
+        } drop
+    }
+}

--- a/cloud/WebReaper.PlaygroundApi/entrypoint.sh
+++ b/cloud/WebReaper.PlaygroundApi/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Tier B container entrypoint: apply the in-VM egress SSRF firewall (decision 4)
+# before starting the app, then hand off to the .NET host.
+#
+# PLAYGROUND_EGRESS_FIREWALL:
+#   warn    (default) apply the firewall; if it cannot apply (e.g. the Machine
+#           lacks CAP_NET_ADMIN), log loudly and start anyway.
+#   enforce apply the firewall; refuse to start if it cannot.
+#   off     skip the firewall entirely (initial deploy bring-up only).
+# See cloud/README.md for the validate-then-enforce rollout.
+set -e
+
+MODE="${PLAYGROUND_EGRESS_FIREWALL:-warn}"
+if [ "$MODE" != "off" ]; then
+    if nft -f /app/egress-firewall.nft 2>/tmp/nft.err; then
+        echo "[entrypoint] egress firewall applied (PLAYGROUND_EGRESS_FIREWALL=$MODE)"
+    else
+        echo "[entrypoint] WARNING: egress firewall did NOT apply: $(cat /tmp/nft.err 2>/dev/null)"
+        echo "[entrypoint] this Machine likely lacks CAP_NET_ADMIN; see cloud/README.md"
+        if [ "$MODE" = "enforce" ]; then
+            echo "[entrypoint] PLAYGROUND_EGRESS_FIREWALL=enforce: refusing to start without the firewall."
+            exit 1
+        fi
+    fi
+fi
+
+exec dotnet WebReaper.PlaygroundApi.dll

--- a/cloud/WebReaper.PlaygroundApi/fly.tierb.toml
+++ b/cloud/WebReaper.PlaygroundApi/fly.tierb.toml
@@ -1,0 +1,61 @@
+# Fly config for the Tier B playground backend (Phase 2: the live browser-and-
+# stealth climb). This is a SEPARATE app from the lean Tier A backend, deployed
+# into a DEDICATED Fly org (not `personal`) so a browser SSRF / escape blast
+# radius cannot reach other apps over Fly's 6PN private network (decision 4). The
+# app name + org are chosen at `fly launch` time; see cloud/README.md for the
+# runbook.
+#
+# Deploy from the REPO ROOT (the Docker build context; the Dockerfile copies the
+# library projects from there):
+#
+#   fly deploy --config cloud/WebReaper.PlaygroundApi/fly.tierb.toml
+#
+# PLAYGROUND_BACKEND_SECRET (the X-Playground-Secret the edge injects) is a SECRET
+# set via `fly secrets set`, never committed here.
+
+app = "webreaper-playground-tierb"
+primary_region = "iad"
+
+[build]
+  # Resolved relative to THIS file's directory (not the build context): the
+  # browser-baked image. The build context stays the repo root you deploy from.
+  dockerfile = "Dockerfile.tierb"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  # Scale to zero between demos; the climb animation masks the cold boot.
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  # One hostile browser job per Machine (decision 3). soft_limit routes the 2nd
+  # concurrent request to a 2nd Machine (auto-start) instead of sharing the VM;
+  # hard_limit forbids a VM from ever taking two. Relax hard_limit to 2 if the
+  # health check ever races a long climb (see the runbook).
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 1
+    hard_limit = 1
+
+  [[http_service.checks]]
+    method = "GET"
+    path = "/health"
+    interval = "15s"
+    timeout = "2s"
+    grace_period = "10s"
+
+[[vm]]
+  # ~2 GB for headless Chromium + the CloakBrowser fork (decision 5); 2 shared
+  # vCPUs since browser rendering is CPU-bound.
+  size = "shared-cpu-2x"
+  memory = "2048mb"
+
+[env]
+  PLAYGROUND_ALLOWED_ORIGINS = "https://webreaper.ai"
+  # The in-VM egress SSRF firewall (decision 4). warn: apply it, continue with a
+  # loud log if it cannot (e.g. no CAP_NET_ADMIN); enforce: refuse to start
+  # without it; off: skip it (initial bring-up only). See cloud/README.md before
+  # flipping to enforce; the firewall needs one-time validation on the live
+  # Machine. The stealth rung also stays secret-gated until that is done.
+  PLAYGROUND_EGRESS_FIREWALL = "warn"


### PR DESCRIPTION
Build-order **step 4** of the Phase 2 doc: the deploy surface for Tier B (isolation + the network-layer SSRF firewall) and the runbook to stand it up.

## What's here

- **`fly.tierb.toml`** — a separate Fly app for the browser-baked image (`Dockerfile.tierb`), meant for a **dedicated org** so a browser SSRF/escape blast radius can't reach other apps over Fly 6PN (decision 4). ~2 GB / 2 vCPU, `concurrency soft=hard=1` (one hostile job per Machine, decision 3), scale-to-zero, `/health`.
- **`egress-firewall.nft`** — the browser issues its own OS-level requests, bypassing the app-layer DNS-pinned guard, so this lifts the Phase 1 `SsrfPolicy` blocklist to the network layer (nftables): public internet allowed; private / loopback / link-local (incl. `169.254.169.254`) / CGNAT / Fly 6PN dropped; DNS + the app↔browser CDP loopback kept open.
- **`entrypoint.sh`** — applies the firewall per `PLAYGROUND_EGRESS_FIREWALL` (`warn` apply+continue / `enforce` refuse-to-start / `off` bring-up). `Dockerfile.tierb` installs nftables and runs through it.
- **`cloud/README.md`** — the full Tier B runbook: dedicated org, secrets, the validate-then-enforce firewall rollout, and stealth verification on real IPs.

## Verified locally

- The ruleset **loads into a real kernel** (nft applied it; even coalesced `224/4+240/4`→`224/3`).
- Entrypoint **fail-opens** with a loud log when `CAP_NET_ADMIN` is absent, and **applies** the firewall (7 rules in-kernel) when it's present.
- With the firewall on: the **example.com climb still works** (DNS + public egress), and an **RFC1918 destination is dropped** — `172.17.0.1` times out at 6.0s (exit 28) vs public `1.1.1.1` at 0.09s.

## Owner-gated (can't verify without the live Machine; the runbook covers each)

- Creating the **dedicated Fly org** and the **deploy** itself.
- Three firewall unknowns: **`CAP_NET_ADMIN`** availability on Fly, the **resolver** address, and whether Fly's **NAT64** (`64:ff9b::/96`) routes IPv4 *around* the `ip daddr` rules (in which case the internal ranges need re-expressing as their `64:ff9b::` embeddings).
- The real **stealth-vs-Cloudflare** check on real IPs.

The stealth rung stays behind the `X-Playground-Secret` gate (never the public edge route) until the CloakHQ OEM license lands.

> Note: decision 5's "Playwright base image" was superseded by the Debian + real-`chromium` image from #219 (the .NET 10 images are Ubuntu-only and Ubuntu's chromium is a snap); this PR builds on that verified image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)