### PR TITLE
feat(website): Tier B edge gate: email capture + browser-minutes budget (step 5)

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -59,3 +59,19 @@ RESEND_API_KEY=
 # PLAYGROUND_IP_PER_MIN=5
 # PLAYGROUND_IP_PER_DAY=25
 # PLAYGROUND_GLOBAL_PER_DAY=5000
+
+# --- Tier B gate (browser + stealth climb; see app/api/playground/tier-b/scrape) ---
+# Tier B is the gated, metered tier: it reuses Turnstile + the rate limits above,
+# adds an email-capture gate and a daily browser-time budget, and proxies to a
+# SEPARATE Fly app (dedicated org; cloud/WebReaper.PlaygroundApi/fly.tierb.toml).
+# Leads are stored in the Upstash set pg:playground:leads (or logged if unset).
+
+# The private Tier B Fly app URL + its own shared secret (a different app/secret
+# from Tier A above). Defaults to the local backend dev port.
+# PLAYGROUND_TIERB_BACKEND_URL=https://webreaper-playground-tierb.fly.dev
+# PLAYGROUND_TIERB_BACKEND_SECRET=
+
+# Daily browser-time budget kill switch. Each run is metered at its 45s worst
+# case; past this many browser-seconds/day the playground shows "at capacity,
+# sign up". Default 10800 (3 browser-hours).
+# PLAYGROUND_TIERB_DAILY_BROWSER_SECONDS=10800

--- a/website/app/api/playground/scrape/route.ts
+++ b/website/app/api/playground/scrape/route.ts
@@ -2,6 +2,7 @@ import {
   SSE_HEADERS,
   checkRateLimits,
   clientIp,
+  safeHttpUrl,
   sseError,
   verifyTurnstile,
 } from "@/lib/playground/gate";
@@ -61,18 +62,4 @@ export async function GET(req: Request): Promise<Response> {
 function backendHeaders(): HeadersInit {
   const secret = process.env.PLAYGROUND_BACKEND_SECRET;
   return secret ? { "x-playground-secret": secret } : {};
-}
-
-// Light pre-check only; the backend's SSRF-guarded handler is the authoritative
-// address policy (DNS-pinned, redirect re-validated). This just rejects obvious
-// junk and non-http schemes before opening an upstream connection.
-function safeHttpUrl(raw: string | null): URL | null {
-  if (!raw) return null;
-  let url: URL;
-  try {
-    url = new URL(raw);
-  } catch {
-    return null;
-  }
-  return url.protocol === "http:" || url.protocol === "https:" ? url : null;
 }

--- a/website/app/api/playground/tier-b/scrape/route.ts
+++ b/website/app/api/playground/tier-b/scrape/route.ts
@@ -1,0 +1,74 @@
+import {
+  SSE_HEADERS,
+  captureEmail,
+  checkRateLimits,
+  checkTierBBudget,
+  clientIp,
+  safeHttpUrl,
+  sseError,
+  verifyTurnstile,
+} from "@/lib/playground/gate";
+
+// SSE must never be cached, and the handler runs as long as the climb streams.
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// The Tier B Fly app is SEPARATE from the Tier A backend (its own dedicated org;
+// see cloud/WebReaper.PlaygroundApi/fly.tierb.toml). NEXT_PUBLIC is deliberately
+// absent: the browser never learns the backend URL.
+const BACKEND_URL = process.env.PLAYGROUND_TIERB_BACKEND_URL ?? "http://localhost:5179";
+
+/**
+ * Tier B playground gate. GET (so the client EventSource can consume it):
+ *   /api/playground/tier-b/scrape?url=<encoded>&cf=<turnstile>&email=<address>
+ * The gated, metered tier: verify Turnstile, apply the per-IP / global rate
+ * limits, capture the email (lead funnel), then meter the daily browser-time
+ * budget before spending a browser Machine. On success it streams the Tier B
+ * backend /tier-b/scrape/stream SSE through, injecting the shared secret.
+ */
+export async function GET(req: Request): Promise<Response> {
+  const params = new URL(req.url).searchParams;
+  const target = safeHttpUrl(params.get("url"));
+  if (!target) return sseError("Enter a valid http(s) URL to scrape.");
+
+  const ip = clientIp(req);
+
+  const turnstile = await verifyTurnstile(params.get("cf"), ip);
+  if (!turnstile.ok) return sseError(turnstile.reason);
+
+  const limit = await checkRateLimits(ip);
+  if (!limit.ok) return sseError(limit.reason);
+
+  // Capture the lead before metering, so an at-capacity visitor is still on the
+  // list when shown the "sign up" message.
+  const email = await captureEmail(params.get("email"), ip);
+  if (!email.ok) return sseError(email.reason);
+
+  const budget = await checkTierBBudget();
+  if (!budget.ok) return sseError(budget.reason);
+
+  const upstreamUrl = `${BACKEND_URL}/tier-b/scrape/stream?url=${encodeURIComponent(target.href)}`;
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl, {
+      headers: backendHeaders(),
+      // Propagate client disconnect so the backend kills the browser when the
+      // EventSource closes.
+      signal: req.signal,
+    });
+  } catch (err) {
+    console.error("[playground] tier-b backend unreachable:", err);
+    return sseError("The scrape service is unavailable right now. Please try again.");
+  }
+
+  if (!upstream.ok || !upstream.body) {
+    return sseError("The scrape service returned an error. Please try again.");
+  }
+
+  return new Response(upstream.body, { status: 200, headers: SSE_HEADERS });
+}
+
+function backendHeaders(): HeadersInit {
+  const secret = process.env.PLAYGROUND_TIERB_BACKEND_SECRET;
+  return secret ? { "x-playground-secret": secret } : {};
+}

--- a/website/lib/playground/gate.ts
+++ b/website/lib/playground/gate.ts
@@ -155,28 +155,153 @@ export async function checkRateLimits(ip: string): Promise<GateVerdict> {
   return { ok: true };
 }
 
-async function incrWithExpire(
+type RedisResult = { result?: unknown; error?: string };
+
+// Run a pipeline of Redis commands atomically via the Upstash REST /multi-exec
+// endpoint. Throws on a transport / HTTP error; callers treat that as fail-open.
+async function redisMultiExec(
   baseUrl: string,
   token: string,
-  key: string,
-  ttlSec: number,
-): Promise<number> {
+  commands: string[][],
+): Promise<RedisResult[]> {
   const res = await fetch(`${baseUrl}/multi-exec`, {
     method: "POST",
     headers: {
       authorization: `Bearer ${token}`,
       "content-type": "application/json",
     },
-    body: JSON.stringify([
-      ["INCR", key],
-      ["EXPIRE", key, String(ttlSec)],
-    ]),
+    body: JSON.stringify(commands),
   });
   if (!res.ok) throw new Error(`Upstash HTTP ${res.status}`);
-  const results = (await res.json()) as Array<{ result?: number; error?: string }>;
-  const incr = results[0];
-  if (!incr || typeof incr.result !== "number") {
-    throw new Error(incr?.error ?? "unexpected INCR result");
+  return (await res.json()) as RedisResult[];
+}
+
+function firstCount(results: RedisResult[], op: string): number {
+  const r = results[0];
+  if (!r || typeof r.result !== "number") {
+    throw new Error(typeof r?.error === "string" ? r.error : `unexpected ${op} result`);
   }
-  return incr.result;
+  return r.result;
+}
+
+async function incrWithExpire(
+  baseUrl: string,
+  token: string,
+  key: string,
+  ttlSec: number,
+): Promise<number> {
+  const results = await redisMultiExec(baseUrl, token, [
+    ["INCR", key],
+    ["EXPIRE", key, String(ttlSec)],
+  ]);
+  return firstCount(results, "INCR");
+}
+
+async function incrByWithExpire(
+  baseUrl: string,
+  token: string,
+  key: string,
+  amount: number,
+  ttlSec: number,
+): Promise<number> {
+  const results = await redisMultiExec(baseUrl, token, [
+    ["INCRBY", key, String(amount)],
+    ["EXPIRE", key, String(ttlSec)],
+  ]);
+  return firstCount(results, "INCRBY");
+}
+
+/**
+ * Light pre-check shared by both tiers: reject obvious junk and non-http(s)
+ * schemes before opening an upstream connection. The backend's SSRF-guarded
+ * handler (and, for Tier B, the in-VM egress firewall) are the authoritative
+ * address policy.
+ */
+export function safeHttpUrl(raw: string | null): URL | null {
+  if (!raw) return null;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+}
+
+// Pragmatic email shape check for the gate: one @, a dot in the domain, no
+// whitespace. Not RFC-perfect; it only has to reject junk.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Tier B email-capture gate (the 2026-05-30 decision: the live climb is gated by
+ * an email that feeds the Stripe-ready waitlist). Validates the address and
+ * records it best-effort to the lead store, then allows. A missing or malformed
+ * email is the only block; a store outage never blocks, since the lead is already
+ * in hand.
+ */
+export async function captureEmail(email: string | null, ip: string): Promise<GateVerdict> {
+  const value = email?.trim().toLowerCase() ?? "";
+  if (!value || value.length > 254 || !EMAIL_RE.test(value)) {
+    return { ok: false, reason: "Enter your email to run the full browser climb." };
+  }
+  await recordLead(value, ip);
+  return { ok: true };
+}
+
+// Best-effort lead capture into a deduplicated Upstash set. Unconfigured => log
+// the lead so it is recoverable (a missing store must not silently drop the
+// funnel, matching lib/billing.ts's waitlist behaviour). Never throws.
+async function recordLead(email: string, ip: string): Promise<void> {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    console.warn(
+      `[playground] lead captured but Upstash is unset, so it was NOT stored. ` +
+        `Recover from this log: email=${email} ip=${ip}.`,
+    );
+    return;
+  }
+  try {
+    await redisMultiExec(url, token, [["SADD", "pg:playground:leads", email]]);
+  } catch (err) {
+    console.error("[playground] lead store error (the run is still allowed):", err);
+  }
+}
+
+// The per-job browser-time ceiling the backend enforces (its ~45s kill). The
+// budget meters every Tier B run at this worst case.
+const TIERB_JOB_SECONDS = 45;
+
+/**
+ * Tier B daily browser-time budget kill switch (the cost ceiling, decision 6).
+ * Meters each run at its 45s worst case into a daily counter; once it passes
+ * PLAYGROUND_TIERB_DAILY_BROWSER_SECONDS (default 3 browser-hours) the playground
+ * shows "at capacity, sign up" instead of spending another browser Machine.
+ * Unconfigured / store outage => allow: a cost ceiling must not take the demo
+ * down on a Redis blip, and the backend's own per-job kill plus Fly scale-to-zero
+ * are the harder cost guards.
+ */
+export async function checkTierBBudget(): Promise<GateVerdict> {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    console.warn("[playground] Upstash not configured; Tier B budget disabled (dev mode).");
+    return { ok: true };
+  }
+
+  const cap = intEnv("PLAYGROUND_TIERB_DAILY_BROWSER_SECONDS", 10_800);
+  const day = Math.floor(Date.now() / 86_400_000);
+  try {
+    const spent = await incrByWithExpire(url, token, `pg:tierb:secs:d:${day}`, TIERB_JOB_SECONDS, 86_400);
+    if (spent > cap) {
+      return {
+        ok: false,
+        reason: "The live browser demo is at capacity for today. Sign up for Cloud to keep going.",
+      };
+    }
+  } catch (err) {
+    console.error("[playground] Tier B budget store error:", err);
+    return { ok: true };
+  }
+  return { ok: true };
 }


### PR DESCRIPTION
Build-order **step 5** of the Phase 2 doc: the gated, metered edge route for Tier B.

## What's here

New route **`/api/playground/tier-b/scrape`** — it reuses the Phase 1 Turnstile + per-IP/global rate limits, then adds the two Tier B guards:

- **Email-capture gate** — validate the address, record it best-effort to a deduplicated Upstash set (`pg:playground:leads`), or log it recoverably when Upstash is unset (matching `billing.ts`'s waitlist behaviour, no per-run owner spam). A missing/malformed email is the only hard block.
- **Daily browser-time budget kill switch** (decision 6) — meter each run at its 45s worst case into a daily counter; past `PLAYGROUND_TIERB_DAILY_BROWSER_SECONDS` (default 3 browser-hours) the playground shows "at capacity, sign up" instead of spending another browser Machine.

It proxies to the **separate** Tier B Fly app (`PLAYGROUND_TIERB_BACKEND_URL` / `_SECRET`). `gate.ts` gains `captureEmail` + `checkTierBBudget`; the Upstash plumbing is refactored onto a shared `redisMultiExec` + `incrByWithExpire` (Tier A's rate limit unchanged), and `safeHttpUrl` moves to the shared module. `.env.example` documents the new vars.

## Fail-soft + dormant

Unset env = dev mode (Turnstile / Upstash skipped; the email is the active gate) — same pattern as Phase 1. The route is **dormant** until the playground client routes through it and the Tier B backend deploys. Wiring the client (an email field + the Tier B `EventSource`) is the activation follow-up, kept out of this change like the Phase 1 activation note.

## Verified

- `tsc --noEmit` clean across the whole project (after `velite`).
- `next build` compiles and registers `ƒ /api/playground/tier-b/scrape`.
- Functional smoke via `next start`: no/invalid email → blocked ("Enter your email…"); valid email → passes the gate to the backend proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)