### PR TITLE
feat(cloud): configurable Tier B job budget + wait for JS bot-check interstitials

### DIFF
--- a/WebReaper.Cdp/CdpPageLoadTransport.cs
+++ b/WebReaper.Cdp/CdpPageLoadTransport.cs
@@ -131,8 +131,23 @@ public sealed class CdpPageLoadTransport : IPageLoadTransport, IAsyncDisposable
                 }
             }
 
+            // Capture the rendered DOM. JS bot-checks (Cloudflare et al.) serve an
+            // interstitial that loads, runs a challenge, then redirects to the real
+            // content, so a single capture at the load event grabs the "verifying
+            // you are human" page. When the DOM looks like an interstitial, poll
+            // until it clears (a stealth browser that passes the check yields the
+            // real DOM) or a cap elapses (a browser that cannot pass stays on the
+            // interstitial, which the block detector then flags). Real pages capture
+            // immediately: the marker check fails on the first read.
             var html = await CdpPageActionDispatcher.EvaluateAsync(browser, sessionId,
                 "document.documentElement.outerHTML", cancellationToken);
+            var interstitialDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
+            while (LooksLikeInterstitial(html) && DateTime.UtcNow < interstitialDeadline)
+            {
+                await Task.Delay(1500, cancellationToken);
+                html = await CdpPageActionDispatcher.EvaluateAsync(browser, sessionId,
+                    "document.documentElement.outerHTML", cancellationToken);
+            }
             // ADR-0083 slice 1: the CDP transport returns the rendered DOM with a
             // null HttpStatus and no headers. Capturing the main-document status
             // via Network.responseReceived is the ADR-named follow-up; browser-
@@ -153,6 +168,24 @@ public sealed class CdpPageLoadTransport : IPageLoadTransport, IAsyncDisposable
             catch { /* best-effort cleanup */ }
         }
     }
+
+    // The JS-challenge interstitial pages a bot-check serves before redirecting to
+    // the real content. Deliberately narrow: these strings appear on the "verifying
+    // you are human" page, not on real content, so a stealth browser that clears
+    // the challenge no longer matches and its real DOM is captured. Kept local so
+    // the AOT-clean transport does not depend on core's IBlockDetector.
+    private static readonly string[] InterstitialMarkers =
+    [
+        "Just a moment",
+        "Performing security verification",
+        "challenge-platform",
+        "cf-browser-verification",
+        "_cf_chl_opt",
+    ];
+
+    private static bool LooksLikeInterstitial(string? html) =>
+        !string.IsNullOrEmpty(html)
+        && Array.Exists(InterstitialMarkers, m => html.Contains(m, StringComparison.OrdinalIgnoreCase));
 
     // ADR-0035 closed-sum dispatch — delegated to CdpPageActionDispatcher
     // (extracted in ADR-0057 follow-up so the dispatch table is testable

--- a/cloud/WebReaper.PlaygroundApi/Program.cs
+++ b/cloud/WebReaper.PlaygroundApi/Program.cs
@@ -38,8 +38,13 @@ var chromiumPath = Environment.GetEnvironmentVariable("PLAYGROUND_CHROMIUM_PATH"
 // the public edge route) until the CloakHQ OEM license lands.
 var cloakBrowserPath = Environment.GetEnvironmentVariable("PLAYGROUND_CLOAKBROWSER_PATH");
 
+// Per-job wall-clock budget (seconds). The default 45 is fine for HTTP and
+// vanilla climbs; a full stealth climb against a slow Cloudflare challenge needs
+// more (each browser rung can wait up to 30s for the challenge page to load).
+var jobSeconds = int.TryParse(Environment.GetEnvironmentVariable("PLAYGROUND_TIERB_JOB_SECONDS"), out var js) && js > 0 ? js : 45;
+
 builder.Services.AddSingleton<TierAScraper>();
-builder.Services.AddSingleton(new TierBScraper(chromiumPath, cloakBrowserPath));
+builder.Services.AddSingleton(new TierBScraper(chromiumPath, cloakBrowserPath, jobSeconds));
 
 var app = builder.Build();
 app.UseCors();

--- a/cloud/WebReaper.PlaygroundApi/Scraping/TierBScraper.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/TierBScraper.cs
@@ -35,9 +35,11 @@ public sealed class TierBScraper
     // cannot grow it without limit.
     private const int ChannelCapacity = 64;
 
-    // Per-job wall-clock ceiling (Phase 2 doc decision 3: the ~45s kill). Caps a
-    // hostile or pathological page so one job cannot hold a pooled VM open.
-    private static readonly TimeSpan RunTimeout = TimeSpan.FromSeconds(45);
+    // Per-job wall-clock ceiling (decision 3): caps a hostile or pathological page
+    // so one job cannot hold a pooled VM open. Configurable because a full HTTP to
+    // vanilla to stealth climb against a slow bot-check (each browser rung can wait
+    // up to 30s for the challenge page) needs more than the 45s default.
+    private readonly TimeSpan _runTimeout;
 
     private readonly string? _chromiumPath;
     private readonly string? _cloakBrowserPath;
@@ -48,10 +50,13 @@ public sealed class TierBScraper
     /// <param name="cloakBrowserPath">Absolute path to the baked CloakBrowser
     /// binary. When set, a stealth rung is appended above the vanilla browser rung;
     /// <c>null</c> means HTTP + vanilla browser only.</param>
-    public TierBScraper(string? chromiumPath = null, string? cloakBrowserPath = null)
+    /// <param name="jobSeconds">Per-job wall-clock budget in seconds (default 45).
+    /// A full stealth climb against a slow Cloudflare challenge needs more.</param>
+    public TierBScraper(string? chromiumPath = null, string? cloakBrowserPath = null, int jobSeconds = 45)
     {
         _chromiumPath = chromiumPath;
         _cloakBrowserPath = cloakBrowserPath;
+        _runTimeout = TimeSpan.FromSeconds(jobSeconds > 0 ? jobSeconds : 45);
     }
 
     public async IAsyncEnumerable<object> StreamAsync(
@@ -101,7 +106,7 @@ public sealed class TierBScraper
         // CancelAfter. Either tears the engine down through RunAsync, and the
         // browsers through the await using below.
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeout.CancelAfter(RunTimeout);
+        timeout.CancelAfter(_runTimeout);
 
         // We own each browser rung's process. The lazy WithCdpPageLoader overloads
         // would defer teardown to transport disposal, but the engine never disposes


### PR DESCRIPTION
Two changes the live Tier B Cloudflare climb needed (validated on the Fly deployment).

## 1. Wait for JS bot-check interstitials to clear (`WebReaper.Cdp`)
`CdpPageLoadTransport` captured the DOM at the first load event + 200ms. A Cloudflare-style challenge serves an interstitial that loads, runs a JS challenge, then redirects to the real content — so the capture grabbed the "verifying you are human" page. Now, if the DOM looks like an interstitial (`Just a moment...`, `Performing security verification`, `challenge-platform`, …), it polls until that clears (up to 20s) before capturing. A stealth browser that passes the check yields the real DOM; one that can't stays on the interstitial (which the block detector flags). Real pages capture immediately. **Affects all browser scrapes** (the CLI benefits too).

## 2. Configurable per-job budget (`cloud`)
`PLAYGROUND_TIERB_JOB_SECONDS` (default 45). The full HTTP→vanilla→stealth climb against a slow Cloudflare challenge exceeds 45s (each browser rung can wait up to 30s for the challenge page).

## What this proved (live on Fly)
Against a Cloudflare-challenge target, the climb escalates `HTTP(403) → vanilla("Just a moment...") → stealth`, and **CloakBrowser passes the fingerprint check** — the captured page reaches `Verification successful`. The stealth value is demonstrated end to end.

## Honest limitations (first pass)
- **Post-challenge origin capture is still imperfect:** some targets stay on Cloudflare's "verification successful" interstitial within the wait window rather than yielding the origin content. A robust version waits for the post-challenge *navigation* event, not just DOM polling.
- **Timing vs the edge:** the CF climb takes ~2 min (cold browsers + challenge waits + a retry-doubled vanilla rung). The Vercel edge function caps at 60s, so this isn't a public user-facing flow until the climb is optimized (skip the vanilla wait, fix the double-attempt, go straight to stealth on known-CF, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)