### PR TITLE
fix(cloud): stop Tier B vanilla browser double-launch on cold Fly Machines

### DIFF
--- a/cloud/WebReaper.PlaygroundApi/Scraping/SingleAttemptRetryPolicy.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/SingleAttemptRetryPolicy.cs
@@ -1,0 +1,22 @@
+using WebReaper.Infra.Abstract;
+
+namespace WebReaper.PlaygroundApi.Scraping;
+
+/// <summary>
+/// A no-retry <see cref="IRetryPolicy"/>: runs the action exactly once and lets
+/// every exception (cancellation included) propagate. The Tier B playground
+/// scrapes a single URL whose <c>EscalatingPageLoader</c> already climbs
+/// HTTP -&gt; vanilla -&gt; stealth internally on each block, so the core default's
+/// whole-crawl retry (four attempts) replays the entire multi-minute browser
+/// climb from the lifted host floor on any transient transport throw -- the
+/// duplicate <c>attempt(browser)</c> observed in the live climb. One attempt is
+/// the right bound here; the climb's per-rung waits are the resilience.
+/// </summary>
+public sealed class SingleAttemptRetryPolicy : IRetryPolicy
+{
+    public Task<T> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return action(cancellationToken);
+    }
+}

--- a/cloud/WebReaper.PlaygroundApi/Scraping/TierBScraper.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/TierBScraper.cs
@@ -147,6 +147,13 @@ public sealed class TierBScraper
             await using var engine = await builder
                 .WithClimbObserver(observer)
                 .AddSink(sink)
+                // The climb already escalates HTTP -> vanilla -> stealth internally
+                // on each block; the core default's four-attempt whole-crawl retry
+                // would replay the entire multi-minute browser climb from the lifted
+                // host floor on a transient transport throw (the duplicate
+                // attempt(browser)). One attempt is the right bound for a single-URL
+                // scrape.
+                .WithRetryPolicy(new SingleAttemptRetryPolicy())
                 .StopWhenAllLinksProcessed()
                 .BuildAsync();
 
@@ -185,7 +192,11 @@ public sealed class TierBScraper
             new CdpLaunchSpec(
                 executable,
                 ["--headless=new", "--no-sandbox", "--disable-dev-shm-usage"],
-                StartupTimeout: TimeSpan.FromSeconds(20)),
+                // The first browser launch on a scale-to-zero Fly Machine is a cold
+                // start: the Chromium binary + shared libs page in from disk, which
+                // exceeded the old 20s cap and threw a launch TimeoutException. 60s
+                // gives cold-start headroom; a warm relaunch still returns in seconds.
+                StartupTimeout: TimeSpan.FromSeconds(60)),
             cancellationToken);
     }
 
@@ -197,7 +208,8 @@ public sealed class TierBScraper
     {
         var args = new List<string>(CloakBrowserLauncher.RecommendedArgs) { "--no-sandbox", "--headless=new" };
         return CdpLaunchHelpers.LaunchAsync(
-            new CdpLaunchSpec(_cloakBrowserPath!, args, StartupTimeout: TimeSpan.FromSeconds(30)),
+            // 60s cold-start headroom, matching the vanilla rung (see LaunchVanillaAsync).
+            new CdpLaunchSpec(_cloakBrowserPath!, args, StartupTimeout: TimeSpan.FromSeconds(60)),
             cancellationToken);
     }
 


### PR DESCRIPTION
## Problem

Against a Cloudflare target the Tier B climb emitted `attempt(browser)` twice, ~20s apart. Root cause, confirmed live on `webreaper-playground-tierb`:

1. The first vanilla Chromium launch on a scale-to-zero Fly Machine is a cold start (the binary and shared libs page in from disk) that ran past the 20s `StartupTimeout` in `LaunchVanillaAsync` and threw a launch `TimeoutException` (`CdpLaunchHelpers.LaunchAsync` kills the process and throws on a startup timeout).
2. The engine's default `FixedAttemptsRetryPolicy` (four attempts, ADR-0026) caught it and re-ran the whole `Spider` crawl. Because the HTTP 403 had lifted the per-host `HostTierFloor` to the vanilla browser rung, the retry restarted the climb there, launching and running vanilla a second time. The browser rung returns no HTTP status, so its body-marker block is low-confidence and never lifts the floor to stealth, which is why only `attempt(browser)` doubled, not `attempt(http)`.

## Fix

- Raise the vanilla and stealth `StartupTimeout` to 60s for cold-start headroom on Fly. A warm relaunch still returns in a few seconds.
- Give the single-URL playground engine a `SingleAttemptRetryPolicy` (no retry). The `EscalatingPageLoader` already escalates HTTP to vanilla to stealth internally on each block, so a transient transport throw should surface rather than replay a multi-minute browser climb from the lifted floor.

## Validation

Live on `webreaper-playground-tierb` against `scrapingcourse.com/cloudflare-challenge`: a single `attempt(browser)`, no retry amplification (was two). Climb runs clean to its outcome (~115s).

## Scope note (problem A, not in this PR)

The related "post-challenge origin capture" investigation concluded that CloakBrowser headless from Fly's datacenter IP does not clear Cloudflare's managed challenge at all: a reload test (3 reloads) never advanced past the interstitial and origin content was never served, vs ~6s to origin from a residential IP. The "Verification successful" text in the captured markdown is a hidden CF template element (present at t=2s), not a real pass. That is a datacenter-IP / headless block (needs a residential proxy + headed mode per CloakBrowser's README), not a capture-logic bug, so it is out of scope here and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
