### PR TITLE
perf(cdp): cap page-load + interstitial waits to speed the browser rung

### DIFF
--- a/WebReaper.Cdp/CdpPageLoadTransport.cs
+++ b/WebReaper.Cdp/CdpPageLoadTransport.cs
@@ -121,17 +121,24 @@ public sealed class CdpPageLoadTransport : IPageLoadTransport, IAsyncDisposable
             // — we swallow per-cookie failures via a try/catch on the batch).
             await ApplyCookiesAsync(browser, sessionId, request.Url, cancellationToken);
 
-            // Navigate. Wait for the load event with a generous timeout.
+            // Navigate, then wait for the page's load event. The cap is a
+            // capture deadline, not a target: `Page.loadEventFired` only fires
+            // once every sub-resource (ads, trackers, fonts) settles, which on a
+            // heavy real-world page runs well past when the DOM — all we extract —
+            // is ready. So we cap the wait modestly and capture the current DOM on
+            // timeout; a JS-challenge page that is still verifying is caught by the
+            // interstitial poll below, not here. (Measured: dropping this from 30s
+            // shaves the bulk off heavy pages whose load event never settles.)
             await browser.SendAsync("Page.navigate",
                 new JsonObject { ["url"] = request.Url }, sessionId, cancellationToken);
             try
             {
                 await browser.WaitForEventAsync("Page.loadEventFired",
-                    sessionId, TimeSpan.FromSeconds(30), cancellationToken);
+                    sessionId, TimeSpan.FromSeconds(12), cancellationToken);
             }
             catch (TimeoutException)
             {
-                _logger.LogWarning("CdpPageLoadTransport: Page.loadEventFired timed out for {Url}; continuing with current DOM.", request.Url);
+                _logger.LogWarning("CdpPageLoadTransport: Page.loadEventFired did not settle within 12s for {Url}; capturing the current DOM.", request.Url);
             }
 
             // Small settle delay — analogous to Puppeteer's Networkidle2 wait.
@@ -156,13 +163,16 @@ public sealed class CdpPageLoadTransport : IPageLoadTransport, IAsyncDisposable
             // until it clears (a stealth browser that passes the check yields the
             // real DOM) or a cap elapses (a browser that cannot pass stays on the
             // interstitial, which the block detector then flags). Real pages capture
-            // immediately: the marker check fails on the first read.
+            // immediately: the marker check fails on the first read. The cap is 8s:
+            // a challenge that clears does so in the first few seconds; one that has
+            // not cleared by 8s is a block (honest-loss), so polling longer only
+            // delays the climb to the next rung and the final blocked verdict.
             var html = await CdpPageActionDispatcher.EvaluateAsync(browser, sessionId,
                 "document.documentElement.outerHTML", cancellationToken);
-            var interstitialDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
+            var interstitialDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(8);
             while (LooksLikeInterstitial(html) && DateTime.UtcNow < interstitialDeadline)
             {
-                await Task.Delay(1500, cancellationToken);
+                await Task.Delay(1000, cancellationToken);
                 html = await CdpPageActionDispatcher.EvaluateAsync(browser, sessionId,
                     "document.documentElement.outerHTML", cancellationToken);
             }


### PR DESCRIPTION
## What

The CDP browser transport waited up to **30s** for `Page.loadEventFired` and polled a JS-challenge interstitial for up to **20s**. Both are *capture deadlines*, not targets:

- The DOM we extract is ready long before the load event settles on a heavy real-world page (ads/trackers/fonts hold the load event open well past first contentful render).
- A Cloudflare-style challenge that *will* clear does so in the first few seconds; one that hasn't cleared by ~8s is a real block.

So the long caps just made every browser-rung load drag. This cuts the load-event wait **30s → 12s** and the interstitial poll **20s/1.5s → 8s/1s**. On timeout we still capture the current DOM (unchanged behaviour); a page still showing a challenge at 8s is a real block the detector flags and the loader climbs past, so nothing correct is lost — only the dead waiting.

## Measured (live Tier B playground backend on Fly, same image)

| Path | Before | After |
|---|---|---|
| HTTP-only (example.com, HN) | ~1s | ~1s (unchanged) |
| Real-content extraction (HN) | full markdown | full markdown (23,311 chars, intact) |
| **Browser-rung success (indeed)** | **22.3s** | **9.3s** |
| Blocked browser rung (CF "Just a moment") | ~53s | ~40s |
| Blocked stealth rung | ~51s | ~37s |

CDP unit tests: **17/17 pass**. Build clean.

## Scope / what this does NOT fix

- The remaining bulk of a *blocked* or *cold* browser rung is **Chromium cold-start** (binary + shared libs paging in on a scale-to-zero VM, ~20s), which a timeout cut can't touch — that's a warm-pool / image concern, separate from this PR.
- This helps **every CDP consumer**, including the `webreaper` CLI, not just the playground.

## Recommendation for the public playground (not in this PR)

A *hard*-Cloudflare target still climbs HTTP → browser → stealth and can land ~37s on the stealth rung; stacked on a cold VM that can exceed the playground edge's 60s `maxDuration`. Recommend the **public Tier B backend run the lean no-stealth image** (HTTP + one browser rung only), so the public path is bounded to ~one browser rung and stays under 60s. The stealth rung stays for the secret-gated path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
