### PR TITLE
feat(cloud): lean no-stealth public Tier B image + warm pool

### DIFF
--- a/cloud/WebReaper.PlaygroundApi/Dockerfile.tierb.lean
+++ b/cloud/WebReaper.PlaygroundApi/Dockerfile.tierb.lean
@@ -1,0 +1,73 @@
+# Tier B PUBLIC playground image: the lean, no-stealth climb. Where
+# Dockerfile.tierb bakes the CloakBrowser stealth fork for the secret-gated /
+# future real-GPU path, this image ships ONLY the HTTP rung + a headed vanilla
+# Chromium rung (Apache/BSD-only, ~216 MB smaller, no CloakBrowser binary and so
+# no OEM/SaaS licensing surface on a public-serving app). The vanilla rung runs
+# headed under Xvfb and routes through PLAYGROUND_RESIDENTIAL_PROXY, which is what
+# clears Cloudflare / DataDome JS challenges at the vanilla rung; the ~37s stealth
+# rung is intentionally absent so a hard-CF target cannot climb past one browser
+# rung and exceed the playground edge's 60s maxDuration.
+#
+# Build context = the REPO ROOT (the app references the library projects):
+#
+#   docker build -f cloud/WebReaper.PlaygroundApi/Dockerfile.tierb.lean -t webreaper-playground-tierb .
+
+# --- build the app (SDK tag matches global.json) ---
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+# Restore as its own layer: copy the shared build props + the csprojs only (the
+# whole project graph: WebReaper -> Cdp -> Stealth.CloakBrowser -> the API), so a
+# source-only change does not re-run restore. (Stealth.CloakBrowser is still a
+# compile-time ref for the recipe code; only the binary is omitted at runtime.)
+COPY global.json Directory.Build.props ./
+COPY WebReaper/WebReaper.csproj WebReaper/
+COPY WebReaper.Cdp/WebReaper.Cdp.csproj WebReaper.Cdp/
+COPY WebReaper.Stealth.CloakBrowser/WebReaper.Stealth.CloakBrowser.csproj WebReaper.Stealth.CloakBrowser/
+COPY cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj cloud/WebReaper.PlaygroundApi/
+RUN dotnet restore cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj
+# Sources, then publish (framework-dependent; the aspnet base carries the runtime).
+COPY WebReaper/ WebReaper/
+COPY WebReaper.Cdp/ WebReaper.Cdp/
+COPY WebReaper.Stealth.CloakBrowser/ WebReaper.Stealth.CloakBrowser/
+COPY cloud/WebReaper.PlaygroundApi/ cloud/WebReaper.PlaygroundApi/
+RUN dotnet publish cloud/WebReaper.PlaygroundApi/WebReaper.PlaygroundApi.csproj \
+    -c Release -o /app --no-restore
+
+# --- runtime: Debian + ASP.NET 10 runtime + vanilla Chromium (no CloakBrowser) ---
+# Debian (not the .NET aspnet image): .NET 10 ships Ubuntu-only base images, and
+# Ubuntu's `chromium` apt package is a container-hostile snap stub. Debian's
+# `chromium` is a real .deb that runs headless/headed in a container. The Noto +
+# freefont + emoji fonts keep headed rendering sane across locales; xvfb provides
+# the virtual display the headed vanilla rung needs. The ASP.NET Core 10 runtime
+# is installed via the official script (distro-independent).
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        chromium fonts-liberation fonts-noto-core fonts-noto-color-emoji fonts-freefont-ttf \
+        libicu72 ca-certificates curl nftables xvfb \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && bash /tmp/dotnet-install.sh --channel 10.0 --runtime aspnetcore --install-dir /usr/share/dotnet \
+    && ln -sf /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm /tmp/dotnet-install.sh
+WORKDIR /app
+COPY --from=build /app ./
+# The in-VM egress SSRF firewall (decision 4) + the entrypoint that applies it
+# before the app starts (nftables is installed above).
+COPY cloud/WebReaper.PlaygroundApi/egress-firewall.nft /app/egress-firewall.nft
+COPY cloud/WebReaper.PlaygroundApi/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+# The vanilla browser launches with --no-sandbox (the Firecracker VM is the trust
+# boundary, decision 5), so the container runs as root. PLAYGROUND_CHROMIUM_PATH
+# names the baked vanilla Chromium; PLAYGROUND_CLOAKBROWSER_PATH is deliberately
+# UNSET so TierBScraper builds no stealth rung (HTTP + headed vanilla only).
+# PLAYGROUND_HEADED=1 runs the vanilla rung headed under Xvfb (entrypoint starts
+# it); pair with PLAYGROUND_RESIDENTIAL_PROXY (a Fly secret) for the residential
+# exit IP that clears CF/DataDome at the vanilla rung.
+ENV ASPNETCORE_URLS=http://+:8080 \
+    PLAYGROUND_CHROMIUM_PATH=/usr/bin/chromium \
+    PLAYGROUND_HEADED=1
+EXPOSE 8080
+# The entrypoint applies the egress firewall (per PLAYGROUND_EGRESS_FIREWALL),
+# then execs the .NET host.
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/cloud/WebReaper.PlaygroundApi/fly.tierb.toml
+++ b/cloud/WebReaper.PlaygroundApi/fly.tierb.toml
@@ -17,17 +17,23 @@ app = "webreaper-playground-tierb"
 primary_region = "iad"
 
 [build]
-  # Resolved relative to THIS file's directory (not the build context): the
-  # browser-baked image. The build context stays the repo root you deploy from.
-  dockerfile = "Dockerfile.tierb"
+  # Resolved relative to THIS file's directory (not the build context): the LEAN
+  # public image (HTTP + headed vanilla Chromium, no CloakBrowser stealth rung).
+  # The stealth-capable Dockerfile.tierb stays in-tree for a future dedicated
+  # stealth / real-GPU app; the public path runs lean so a hard-CF target cannot
+  # climb to the ~37s stealth rung and exceed the playground edge's 60s
+  # maxDuration. The build context stays the repo root you deploy from.
+  dockerfile = "Dockerfile.tierb.lean"
 
 [http_service]
   internal_port = 8080
   force_https = true
-  # Scale to zero between demos; the climb animation masks the cold boot.
+  # Keep one Machine warm so the first climb skips the ~9s VM cold-boot (the live
+  # climb must fit the playground edge's 60s maxDuration). Extra Machines still
+  # auto-stop between demos; auto_start brings them back under load.
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   # One hostile browser job per Machine (decision 3). soft_limit routes the 2nd
   # concurrent request to a 2nd Machine (auto-start) instead of sharing the VM;
@@ -46,8 +52,8 @@ primary_region = "iad"
     grace_period = "10s"
 
 [[vm]]
-  # ~2 GB for headless Chromium + the CloakBrowser fork (decision 5); 2 shared
-  # vCPUs since browser rendering is CPU-bound.
+  # ~2 GB for a headed vanilla Chromium under Xvfb (decision 5); 2 shared vCPUs
+  # since browser rendering is CPU-bound.
   size = "shared-cpu-2x"
   memory = "2048mb"
 


### PR DESCRIPTION
## What

Makes the public Tier B playground backend run a **lean, no-stealth image**, and keeps one Fly Machine warm. Together with #227 (the CDP wait cuts) this keeps a real live climb under the playground edge's **60s `maxDuration`**.

## Why no stealth on the public path
- On this software-GL infra the CloakBrowser stealth rung is **honest-loss** against a hard Cloudflare managed challenge (the WebGL-pixel wall), so it only adds ~37s of dead climb.
- Running the CloakBrowser binary on a **public-serving** app is precisely the OEM/SaaS "browser-as-a-service" use its `BINARY-LICENSE` restricts. Removing the binary from the public image sidesteps that entirely.
- A hard-CF pick that climbs HTTP → vanilla → stealth can exceed 60s; bounding the public path to one browser rung keeps it under.

## Changes
- **New `Dockerfile.tierb.lean`** — HTTP rung + headed vanilla Chromium only. No CloakBrowser fetch stage, no `PLAYGROUND_CLOAKBROWSER_PATH` (so `TierBScraper` builds no stealth rung), ~216 MB smaller, Apache/BSD-only. Keeps headed mode (Xvfb) + the residential-proxy wiring — which is what actually clears CF/DataDome at the vanilla rung. The stealth-capable `Dockerfile.tierb` stays in-tree for a future dedicated stealth / real-GPU app.
- **`fly.tierb.toml`** — point the public app at the lean image; `min_machines_running = 1` (warm pool) so the first climb skips the ~9s VM cold-boot.

## Verification
CI's `build` job excludes `cloud/`, so the real gate is the **Fly remote build** during deploy. This PR is deployed + re-measured before merge; numbers in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
