### PR TITLE
docs: 11.1.2 changelog draft + playground launch post + env fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 11.1.2: faster browser rung + a climb-progress seam
+
+A small additive release: browser-mode scrapes return sooner, the escalating loader gains an observability seam, and two transport/installer fixes land. No breaking changes, no API removals.
+
+- **Faster browser rung ([ADR-0083] transport tuning).** The raw-CDP transport (`WebReaper.Cdp`) waited up to 30s for the page load event and polled a JS-challenge interstitial for up to 20s. Both were capture *deadlines*, not targets: the DOM is ready long before the load event settles on an ad-heavy page, and a Cloudflare-style challenge that clears does so in the first few seconds. The load wait is now capped at 12s and the interstitial poll at 8s (1s steps); on timeout the current DOM is captured as before, and a page still showing a challenge is a real block the detector flags. Measured on a real climb: a browser-rung success dropped from ~22s to ~9s, and a blocked rung from ~53s to ~40s. Helps every CDP consumer, including the CLI's `--browser` path; nothing about the result changes, only the dead waiting.
+- **Climb-progress observer seam ([ADR-0085]).** `EscalatingPageLoader` now reports each step of a climb (attempt, blocked, climbing, succeeded, exhausted) through a new `IClimbObserver` seam, with `NullClimbObserver` as the zero-overhead default. Wire one with `ScraperEngineBuilder.WithClimbObserver(...)` to surface live per-rung progress (the live scrape playground streams it over SSE); a no-op for everyone who does not.
+- **CDP launch-and-connect teardown fix ([ADR-0058]).** `.WithCdpPageLoader(CdpLaunchOptions)` now registers its spawned browser for engine teardown, so the launched Chromium is killed on engine disposal instead of leaking on a long-running host. The CLI was unaffected (it exits per scrape); server consumers that build an engine per request were not.
+- **`WebReaper.Stealth.CloakBrowser` installer fix.** The binary auto-download now resolves a real CloakBrowser release (the `chromium-vNNN` tag scheme), verifies the asset against the release `SHA256SUMS`, extracts with the BCL (`System.Formats.Tar`, AOT-clean), and fails fast on an unshipped platform (macOS / linux-arm64 / win-x86 are not published).
+
+All 14 packages ship at 11.1.2 (lockstep).
+
+[ADR-0083]: docs/adr/0083-escalating-page-loader.md
+[ADR-0085]: docs/adr/0085-climb-progress-observer-seam.md
+[ADR-0058]: docs/adr/0058-engine-teardown-disposal.md
+
 ## 11.1.1: AI extraction in the MCP server + discoverability
 
 A small additive release on top of v11.1.0's AI extraction.

--- a/website/.env.example
+++ b/website/.env.example
@@ -31,8 +31,8 @@ RESEND_API_KEY=
 # All optional: with none set, the gate is OPEN and the route proxies straight
 # to a local backend (dev mode, logged loudly). Set these to arm it in prod.
 
-# Show the "Try it live" section on /playground. Set to 1 once the backend is
-# deployed and PLAYGROUND_BACKEND_URL is set; otherwise the section is hidden.
+# Show the Tier A "Try it live" (HTTP-to-Markdown) controls. Set to 1 once the
+# backend is deployed and PLAYGROUND_BACKEND_URL is set; otherwise hidden.
 # NEXT_PUBLIC_PLAYGROUND_LIVE=1
 
 # The private Fly backend URL the edge route proxies to. NOT NEXT_PUBLIC: the
@@ -66,10 +66,21 @@ RESEND_API_KEY=
 # SEPARATE Fly app (dedicated org; cloud/WebReaper.PlaygroundApi/fly.tierb.toml).
 # Leads are stored in the Upstash set pg:playground:leads (or logged if unset).
 
+# Show the live browser climb in the landing-page hero (the "Try it on a real
+# site" control under the recorded climb). Set to 1 once the Tier B backend is
+# deployed; otherwise the hero stays a recorded demo.
+# NEXT_PUBLIC_PLAYGROUND_TIERB_LIVE=1
+
 # The private Tier B Fly app URL + its own shared secret (a different app/secret
-# from Tier A above). Defaults to the local backend dev port.
+# from Tier A above). Defaults to the local backend dev port. The secret MUST
+# match the Fly app's PLAYGROUND_BACKEND_SECRET, or the edge proxy gets a 403.
 # PLAYGROUND_TIERB_BACKEND_URL=https://webreaper-playground-tierb.fly.dev
 # PLAYGROUND_TIERB_BACKEND_SECRET=
+
+# Comma-separated host allowlist for the live browser climb (the SSRF guard while
+# the in-VM egress firewall is off). A leading "." matches subdomains. Must
+# include the hosts the hero's curated targets use. Unset => any public URL.
+# PLAYGROUND_TIERB_ALLOWED_HOSTS=.walmart.com,.rozetka.com.ua,.leboncoin.fr
 
 # Daily browser-time budget kill switch. Each run is metered at its 45s worst
 # case; past this many browser-seconds/day the playground shows "at capacity,

--- a/website/content/blog/watch-the-climb-live.mdx
+++ b/website/content/blog/watch-the-climb-live.mdx
@@ -1,0 +1,93 @@
+---
+title: "Watch the climb, live: a real scrape in the homepage terminal"
+description: The terminal on the WebReaper homepage now runs a real climb against a site you choose, HTTP to a browser, streamed live, not a recording.
+date: 2026-06-01
+author: WebReaper Team
+tags:
+  - announcement
+  - stealth
+---
+
+The terminal on the [WebReaper homepage](https://webreaper.ai) used to play a
+recording. It still opens with one, a known climb against a bot-protected site
+so you can see the shape of the thing. But now there is a second button under
+it: **Try it on a real site**. Click it, type any URL, and the same terminal
+runs an actual scrape and streams each step back as it happens.
+
+No sign-up to watch. One email to run your own.
+
+## What you are watching
+
+WebReaper treats bot protection as a ladder it climbs only as far as a page
+forces it to. The live terminal shows every rung in real time:
+
+- **HTTP.** A plain request goes out first. On a protected site it comes back a
+  403 or a challenge page, and the rung lights up red.
+- **Headless browser.** WebReaper escalates to a real browser, through a
+  residential exit so the request looks like a person. Most Cloudflare and
+  DataDome challenges clear here, and you get the page back as clean Markdown.
+- **Stealth.** The top rung, a hardened stealth browser, for the sites the
+  vanilla browser cannot pass.
+
+The climb stops the moment a rung gets through, so a page that never needed a
+browser is served from the HTTP rung in well under a second, and the higher
+rungs read **not needed**. That is the whole point of escalation: you pay for a
+browser only when the site makes you.
+
+## It tells the truth when it loses
+
+The interesting part of a live demo is what happens when it does not work, and
+this is where most scraping demos quietly cheat. The hardest managed challenges,
+the ones that read your actual GPU pixels rather than just your user agent, are
+not beatable from a commodity cloud host. When WebReaper hits one of those, the
+terminal does not hand you a challenge page dressed up as success. It climbs to
+the top, reports the block, and says so.
+
+You will also see the honest shape of real pages. Point it at a marketing
+homepage and you often get a thin result, because that page is a JavaScript
+shell with no text to extract. Point it at a product page or an article and you
+get the real content. The terminal shows you which you got, rather than padding
+an empty result.
+
+That honesty is deliberate. A scraper that returns a Cloudflare interstitial as
+"the page" is worse than useless in a pipeline, because you do not find out
+until the bad data is three steps downstream.
+
+## The same engine you run locally
+
+There is nothing special about the playground's scraper. It is the same
+`webreaper` you install and run on your own machine, driving the same
+escalating page loader, emitting the same per-rung progress. The live terminal
+just forwards that progress over the wire so you can watch it climb.
+
+Locally it is one command:
+
+```bash
+# A plain scrape auto-climbs to a browser when a page looks blocked
+webreaper scrape https://example.com
+
+# Bot-protected? Add the stealth backend and let it escalate on a challenge
+webreaper scrape https://example.com --browser --auto-stealth
+```
+
+Or in code, the climb is built into the one page loader, so a crawl gets it for
+free:
+
+```csharp
+using WebReaper.Builders;
+
+var engine = await ScraperEngineBuilder
+    .Crawl("https://example.com")
+    .AsMarkdown()
+    .WriteToConsole()
+    .BuildAsync();
+
+await engine.RunAsync();
+```
+
+## Try it
+
+Open [webreaper.ai](https://webreaper.ai), watch the recorded climb, then run a
+real one. Pick one of the suggested bot-protected sites or paste your own URL.
+It is the fastest way to see what WebReaper actually does, on a site you care
+about, in about the time it takes to read this sentence.


### PR DESCRIPTION
## What

Brings three doc surfaces current after the live-playground + climb-speedup work (#225/#226/#227/#228).

### CHANGELOG — draft `## 11.1.2` (unreleased)
A drafted, **not-yet-tagged** section for the library/CLI-facing changes that have landed on master since v11.1.1:
- **Faster browser rung** — the CDP transport's page-load wait (30s→12s) and interstitial poll (20s→8s) caps (#227). A browser-rung success dropped ~22s→~9s, a blocked rung ~53s→~40s. Helps the CLI `--browser` path too.
- **`IClimbObserver` seam** (ADR-0085, #215) on the escalating loader, `NullClimbObserver` default.
- **CDP launch-and-connect teardown fix** (ADR-0058, #218).
- **CloakBrowser installer** release-resolution + SHA256 fix (#220).

The next release cuts this section as-is (the heading number is a placeholder for whatever the next lockstep version is — adjust at release time if needed).

### Blog — "Watch the climb, live"
Announces the homepage terminal's live scrape (the editable command line + curated targets from #226). Honest about the honest-loss tier and thin-SPA results, in the existing blog voice.

### `website/.env.example`
The `NEXT_PUBLIC_PLAYGROUND_LIVE` comment pointed at the deleted `/playground` page; retargeted at the hero. Added the `NEXT_PUBLIC_PLAYGROUND_TIERB_LIVE` + `PLAYGROUND_TIERB_ALLOWED_HOSTS` vars the live hero actually needs, with the "secret must match the Fly app" note (the bug that blocked go-live).

## Verified
`pnpm build` green; velite resolves the new post; `/blog/watch-the-climb-live` route generates. No em-dashes.

## Not included (deliberate)
The Cloud playground infra (`cloud/`, Fly, Dockerfiles) stays undocumented in the library README/docs — it's not part of the library/CLI product, consistent with the quiet-shipped Cloud posture. This PR documents only the user-visible library change (the perf win) and the public-facing launch (the blog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
