### PR TITLE
chore(release): v11.1.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,7 @@
   -->
 
   <PropertyGroup>
-    <Version>11.1.1</Version>
+    <Version>11.1.2</Version>
 
     <Authors>Alex Pavlov</Authors>
     <Company>Alex Pavlov</Company>


### PR DESCRIPTION
Cuts **v11.1.2**, a small additive release. Bumps the lockstep package version `11.1.1 -> 11.1.2` in `Directory.Build.props`; the CHANGELOG section already landed in #229.

Contents (all packaged, since v11.1.1):
- Faster CDP browser rung: page-load wait capped 30s->12s, interstitial poll 20s->8s (#227)
- ADR-0085 `IClimbObserver` climb-progress seam on the escalating loader (#215)
- CDP launch-and-connect teardown fix (#218)
- `WebReaper.Stealth.CloakBrowser` installer fix (#220)

All 14 packages ship at 11.1.2. After merge, tag `v11.1.2` triggers the release pipeline (pack -> approval gate -> publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)