### PR TITLE
docs: surface .Subscribe + dedup playground TryNormalizeUrl (closes #234, #235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ The release ships thirteen packages (one core, twelve satellites), all versioned
 
 | Package | Add it for | Key builder calls |
 |---|---|---|
-| **WebReaper** | Core. HTTP crawl and parse, in-memory and file scheduler / visited-link tracker / cookie and config storage, Console / CSV / JSON-Lines sinks, Markdown extractor, schema fold. Dependency-light, Native-AOT-ready, Newtonsoft-free. | `Crawl` `Extract` `AsMarkdown` `Follow` `Paginate` `Sweep` `WriteToJsonFile` `WriteToCsvFile` `WriteToConsole` |
+| **WebReaper** | Core. HTTP crawl and parse, in-memory and file scheduler / visited-link tracker / cookie and config storage, Console / CSV / JSON-Lines sinks, Markdown extractor, schema fold. Dependency-light, Native-AOT-ready, Newtonsoft-free. | `Crawl` `Extract` `AsMarkdown` `Follow` `Paginate` `Sweep` `WriteToJsonFile` `WriteToCsvFile` `WriteToConsole` `Subscribe` |
 | **WebReaper.Cdp** | Raw CDP `IPageLoadTransport` (ADR-0052). AOT-clean (no PuppeteerSharp / Playwright dependency); System.Net.WebSockets plus System.Text.Json source-gen. Bedrock for the stealth pattern. | `.WithCdpPageLoader(cdpUrl)` (BYO) or `.WithCdpPageLoader(CdpLaunchOptions)` (launch managed Chromium) |
 | **WebReaper.Playwright** | Microsoft.Playwright-backed transport (ADR-0053). Multi-browser (Chromium default; Firefox / WebKit opt-in). All ten `PageAction` arms supported. Use for modern multi-browser needs; pair with `WebReaper.Cdp` for AOT or stealth. | `.WithPlaywrightPageLoader()` |
 | **WebReaper.Stealth.CloakBrowser** | First stealth-backend satellite (ADR-0054). Auto-downloads CloakBrowser on first use; composes on `WebReaper.Cdp`. Disposable via the ADR-0058 engine teardown chain. | `.WithCloakBrowser()` |
@@ -348,6 +348,31 @@ await engine.RunAsync();
 ```
 
 Each `new("field", "css-selector")` is a leaf; nest schemas for objects, set `IsList = true` for arrays, set `Attr = "href"` to read an HTML attribute instead of inner text.
+
+### Collect records in-process
+
+Get the scraped records back in your own process, no file and no custom sink. Pass `Subscribe` (ADR-0038) the `Add` of a thread-safe collection, then read them after the run:
+
+```csharp
+using System.Collections.Concurrent;
+using WebReaper.Builders;
+using WebReaper.Sinks.Models;
+
+var records = new ConcurrentBag<ParsedData>();
+
+var engine = await ScraperEngineBuilder
+    .Crawl("https://news.ycombinator.com")
+    .AsMarkdown()
+    .Subscribe(records.Add)            // called concurrently; collect into a thread-safe type
+    .BuildAsync();
+
+await engine.RunAsync();
+
+foreach (var record in records)
+    Console.WriteLine($"{record.Url}: {record.Data["markdown"]?.GetValue<string>()?.Length ?? 0} chars");
+```
+
+The Crawl driver fans out to sinks concurrently, so a `ConcurrentBag` is the right collector, not a bare `List`. For structured fields, read your schema keys out of `record.Data` instead of `"markdown"`.
 
 ### Parsing dynamic pages (SPA)
 

--- a/WebReaper/Builders/ScraperEngineBuilder.cs
+++ b/WebReaper/Builders/ScraperEngineBuilder.cs
@@ -573,11 +573,29 @@ public class ScraperEngineBuilder
     /// <summary>
     /// Invoke <paramref name="scrapingResultHandler"/> for every scraped
     /// record. ADR-0038: sugar for registering a delegate
-    /// <see cref="IScraperSink"/> — an in-process delegate destination, not a
+    /// <see cref="IScraperSink"/>, an in-process delegate destination, not a
     /// separate notification seam; it composes with the other sinks and
     /// receives its own clone of the record, like any sink. To react to a page
-    /// <em>before</em> it reaches the sinks (enrich / filter / repair), use
+    /// <em>before</em> it reaches the sinks (enrich, filter, repair), use
     /// <see cref="Process(IPageProcessor)"/> instead.
+    /// <para>
+    /// This is the idiomatic way to collect records in-process without a custom
+    /// sink: the handler is called concurrently (the Crawl driver fans records
+    /// out to sinks under <c>Parallel.ForEachAsync</c>; see
+    /// <see cref="IScraperSink.EmitAsync"/>), so collect into a thread-safe type
+    /// such as <c>ConcurrentBag&lt;ParsedData&gt;</c>.
+    /// </para>
+    /// <example>
+    /// <code>
+    /// var records = new ConcurrentBag&lt;ParsedData&gt;();
+    /// await using var engine = await ScraperEngineBuilder
+    ///     .Crawl("https://example.com").AsMarkdown()
+    ///     .Subscribe(records.Add)
+    ///     .BuildAsync();
+    /// await engine.RunAsync();
+    /// // records now holds every scraped ParsedData
+    /// </code>
+    /// </example>
     /// </summary>
     public ScraperEngineBuilder Subscribe(Action<ParsedData> scrapingResultHandler)
     {

--- a/cloud/WebReaper.PlaygroundApi.Tests/RequestUrlTests.cs
+++ b/cloud/WebReaper.PlaygroundApi.Tests/RequestUrlTests.cs
@@ -1,0 +1,45 @@
+using WebReaper.PlaygroundApi.Ssrf;
+using Xunit;
+
+namespace WebReaper.PlaygroundApi.Tests;
+
+// Mirrors SsrfPolicyTests' Theory/InlineData style. RequestUrl.TryNormalizeUrl
+// is the request-URL shape guard shared by the Tier A and Tier B scrapers,
+// deduped from two byte-identical private copies. SsrfPolicy guards the
+// resolved address; RequestUrl guards the URL shape.
+public class RequestUrlTests
+{
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("http://example.com")]
+    [InlineData("https://example.com/path?q=1#frag")]
+    [InlineData("  https://example.com  ")] // surrounding whitespace is trimmed
+    [InlineData("HTTPS://EXAMPLE.COM")]      // scheme compared case-insensitively
+    public void Accepts_absolute_http_and_https(string url)
+    {
+        Assert.True(RequestUrl.TryNormalizeUrl(url, out var uri));
+        Assert.True(uri.IsAbsoluteUri);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("example.com")]          // no scheme, not absolute
+    [InlineData("/path/only")]           // relative
+    [InlineData("ftp://example.com")]    // non-http(s) scheme
+    [InlineData("file:///etc/passwd")]   // non-http(s) scheme
+    [InlineData("javascript:alert(1)")]  // non-http(s) scheme
+    public void Rejects_empty_relative_and_non_http_schemes(string? url)
+    {
+        Assert.False(RequestUrl.TryNormalizeUrl(url, out var uri));
+        Assert.Null(uri);
+    }
+
+    [Fact]
+    public void Trims_whitespace_before_parsing()
+    {
+        Assert.True(RequestUrl.TryNormalizeUrl("\t https://example.com/x \n", out var uri));
+        Assert.Equal("https://example.com/x", uri.ToString());
+    }
+}

--- a/cloud/WebReaper.PlaygroundApi/Scraping/TierAScraper.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/TierAScraper.cs
@@ -24,7 +24,7 @@ public sealed class TierAScraper
         string url,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        if (!TryNormalizeUrl(url, out var uri))
+        if (!RequestUrl.TryNormalizeUrl(url, out var uri))
         {
             yield return ClimbEvents.Error("Enter a valid http(s) URL.");
             yield break;
@@ -38,19 +38,6 @@ public sealed class TierAScraper
         // try/catch), returning the events to emit for its outcome.
         foreach (var climbEvent in await FetchAsync(uri, cancellationToken))
             yield return climbEvent;
-    }
-
-    private static bool TryNormalizeUrl(string? url, out Uri uri)
-    {
-        uri = null!;
-        if (string.IsNullOrWhiteSpace(url))
-            return false;
-        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var parsed))
-            return false;
-        if (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps)
-            return false;
-        uri = parsed;
-        return true;
     }
 
     private static async Task<IReadOnlyList<object>> FetchAsync(Uri uri, CancellationToken cancellationToken)

--- a/cloud/WebReaper.PlaygroundApi/Scraping/TierBScraper.cs
+++ b/cloud/WebReaper.PlaygroundApi/Scraping/TierBScraper.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using WebReaper.Builders;
 using WebReaper.Cdp;
+using WebReaper.PlaygroundApi.Ssrf;
 using WebReaper.Proxy.Abstract;
 using WebReaper.Stealth.CloakBrowser;
 
@@ -124,7 +125,7 @@ public sealed class TierBScraper
         string url,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        if (!TryNormalizeUrl(url, out var uri))
+        if (!RequestUrl.TryNormalizeUrl(url, out var uri))
         {
             yield return ClimbEvents.Error("Enter a valid http(s) URL.");
             yield break;
@@ -335,19 +336,6 @@ public sealed class TierBScraper
         TimeoutException => "The browser did not start in time.",
         _ => "The climb failed before it could finish.",
     };
-
-    private static bool TryNormalizeUrl(string? url, out Uri uri)
-    {
-        uri = null!;
-        if (string.IsNullOrWhiteSpace(url))
-            return false;
-        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var parsed))
-            return false;
-        if (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps)
-            return false;
-        uri = parsed;
-        return true;
-    }
 
     /// <summary>
     /// One browser rung whose CDP process is launched lazily (on the first load

--- a/cloud/WebReaper.PlaygroundApi/Ssrf/RequestUrl.cs
+++ b/cloud/WebReaper.PlaygroundApi/Ssrf/RequestUrl.cs
@@ -1,0 +1,31 @@
+namespace WebReaper.PlaygroundApi.Ssrf;
+
+/// <summary>
+/// Validates and normalises an inbound scrape URL before it is fetched: it must
+/// be a non-empty, absolute http(s) URL (trimmed first). Shared by the Tier A
+/// and Tier B scrapers so the request-URL guard lives in one place, not two
+/// byte-identical copies. Pairs with <see cref="SsrfPolicy"/>: that guards the
+/// resolved address, this guards the URL shape. Public to mirror
+/// <see cref="SsrfPolicy"/> and stay directly unit-testable; this app is not a
+/// packaged library, so it adds nothing to the WebReaper public surface.
+/// </summary>
+public static class RequestUrl
+{
+    /// <summary>
+    /// True when <paramref name="url"/> is a non-empty, absolute http(s) URL; on
+    /// success <paramref name="uri"/> is the parsed (trimmed) <see cref="Uri"/>,
+    /// otherwise it is null.
+    /// </summary>
+    public static bool TryNormalizeUrl(string? url, out Uri uri)
+    {
+        uri = null!;
+        if (string.IsNullOrWhiteSpace(url))
+            return false;
+        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var parsed))
+            return false;
+        if (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps)
+            return false;
+        uri = parsed;
+        return true;
+    }
+}


### PR DESCRIPTION
Implements the two `ready-for-agent` slices of PRD #233. Both are docs or playground-internal with zero new public WebReaper library surface, per the grill that produced #233.

## #234 — surface `.Subscribe` as the in-process collection idiom (docs only)

`.Subscribe(Action<ParsedData>)` (ADR-0038) already lets a consumer collect records in-process, but it was undiscoverable, so a real consumer (the lead-discovery harness) hand-rolled a custom `IScraperSink`.

- README: new "Collect records in-process" recipe under API overview (`ConcurrentBag<ParsedData>` + `.Subscribe(records.Add)` + post-run projection).
- README: `Subscribe` added to the WebReaper method-chip list in the Packages table.
- `Subscribe` xml-doc: a thread-safe-collection `<example>` plus a note that the handler is called concurrently, cross-referencing `IScraperSink.EmitAsync`.

No new public API; the capability already existed. The exact pattern in the README example is the one the lead-discovery harness compiles and runs.

## #235 — dedup `TryNormalizeUrl` (playground internal)

`TierAScraper` and `TierBScraper` carried byte-identical private `TryNormalizeUrl` copies. Extracted to one `RequestUrl.TryNormalizeUrl` in the `Ssrf` namespace, beside `SsrfPolicy` (its sibling request-guard). Public to mirror `SsrfPolicy` and stay directly testable; the playground app is not packaged (not in `WebReaper.sln`), so this adds nothing to the WebReaper library surface. No behavior change. New `RequestUrlTests` mirrors `SsrfPolicyTests`' Theory/InlineData style.

## Why not the rejected alternatives

The grill behind #233 rejected a built-in `InMemorySink` / `RunAndCollectAsync` terminal (`.Subscribe` already covers it; collect-all fights the streaming-sink design) and a public `WebReaper.Domain.Url` helper (the two `SameHost` impls are intentional semantic divergence, not a dup; a public normalizer grows surface and invites bikeshed). This PR is the docs-only and internal-dedup residue.

## Verification

- Full-solution build: 0 errors (pre-existing NU1902 / CA1416 warnings only).
- Library unit tests: 555 passed.
- Cloud `WebReaper.PlaygroundApi.Tests`: 73 passed, including the new `RequestUrlTests`.

Closes #234
Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)
