### PR TITLE
fix(warnings): CA1416 false positive + AOT-hostile JsonArray.Add

### DIFF
--- a/WebReaper.AI/Tools/AgentDecisionTools.cs
+++ b/WebReaper.AI/Tools/AgentDecisionTools.cs
@@ -82,7 +82,7 @@ internal static class AgentDecisionTools
                         ["description"] = "Why this is the right next step.",
                     },
                 },
-                ["required"] = new JsonArray { "schema", "reason" },
+                ["required"] = new JsonArray { (JsonNode)"schema", (JsonNode)"reason" },
             });
 
         /// <summary>Construct the arm from a tool call's argument JSON plus
@@ -156,7 +156,7 @@ internal static class AgentDecisionTools
                         ["description"] = "Why this URL is the right next step.",
                     },
                 },
-                ["required"] = new JsonArray { "url", "reason" },
+                ["required"] = new JsonArray { (JsonNode)"url", (JsonNode)"reason" },
             });
 
         public static ToolCallResult<AgentDecision.Follow> FromArguments(JsonElement args, string reason)
@@ -190,7 +190,7 @@ internal static class AgentDecisionTools
                         ["description"] = "Why the run is stopping — goal satisfied, dead-end, etc.",
                     },
                 },
-                ["required"] = new JsonArray { "reason" },
+                ["required"] = new JsonArray { (JsonNode)"reason" },
             });
 
         /// <summary>Always succeeds — Stop has no required arguments beyond

--- a/WebReaper.AI/Tools/PageActionTools.cs
+++ b/WebReaper.AI/Tools/PageActionTools.cs
@@ -75,7 +75,7 @@ internal static class PageActionTools
                         ["description"] = "Why this click is the right next step. (Brain only — resolver ignores.)",
                     },
                 },
-                ["required"] = new JsonArray { "selector" },
+                ["required"] = new JsonArray { (JsonNode)"selector" },
             });
 
         /// <summary>Construct the arm from a tool call's argument JSON, or
@@ -117,7 +117,7 @@ internal static class PageActionTools
                         ["description"] = "Why this wait is the right next step. (Brain only — resolver ignores.)",
                     },
                 },
-                ["required"] = new JsonArray { "ms" },
+                ["required"] = new JsonArray { (JsonNode)"ms" },
             });
 
         /// <summary>Always succeeds — missing or malformed <c>ms</c> defaults
@@ -161,7 +161,7 @@ internal static class PageActionTools
                         ["description"] = "Why this wait is the right next step. (Brain only — resolver ignores.)",
                     },
                 },
-                ["required"] = new JsonArray { "selector" },
+                ["required"] = new JsonArray { (JsonNode)"selector" },
             });
 
         public static ToolCallResult<PageAction.WaitForSelector> FromArguments(JsonElement args)
@@ -265,7 +265,7 @@ internal static class PageActionTools
                         ["description"] = "Why this evaluation is the right next step. (Brain only — resolver ignores.)",
                     },
                 },
-                ["required"] = new JsonArray { "expression" },
+                ["required"] = new JsonArray { (JsonNode)"expression" },
             });
 
         public static ToolCallResult<PageAction.EvaluateExpression> FromArguments(JsonElement args)
@@ -310,7 +310,7 @@ internal static class PageActionTools
                         ["description"] = "Why this key press is the right next step. (Brain only; resolver ignores.)",
                     },
                 },
-                ["required"] = new JsonArray { "key" },
+                ["required"] = new JsonArray { (JsonNode)"key" },
             });
 
         /// <summary>Construct the arm from a tool call's argument JSON, or
@@ -354,7 +354,7 @@ internal static class PageActionTools
                         ["description"] = "Why this scroll is the right next step. (Brain only; resolver ignores.)",
                     },
                 },
-                ["required"] = new JsonArray { "selector" },
+                ["required"] = new JsonArray { (JsonNode)"selector" },
             });
 
         public static ToolCallResult<PageAction.ScrollIntoView> FromArguments(JsonElement args)
@@ -402,7 +402,7 @@ internal static class PageActionTools
                         ["description"] = "Why this fill is the right next step. (Brain only; resolver ignores.)",
                     },
                 },
-                ["required"] = new JsonArray { "selector", "value" },
+                ["required"] = new JsonArray { (JsonNode)"selector", (JsonNode)"value" },
             });
 
         public static ToolCallResult<PageAction.Fill> FromArguments(JsonElement args)
@@ -451,7 +451,7 @@ internal static class PageActionTools
                         ["description"] = "Why this intent is the right next step.",
                     },
                 },
-                ["required"] = new JsonArray { "intent" },
+                ["required"] = new JsonArray { (JsonNode)"intent" },
             });
 
         public static ToolCallResult<PageAction.SemanticAct> FromArguments(JsonElement args)

--- a/WebReaper.Stealth.CloakBrowser/CloakBrowserInstaller.cs
+++ b/WebReaper.Stealth.CloakBrowser/CloakBrowserInstaller.cs
@@ -1,6 +1,7 @@
 using System.Formats.Tar;
 using System.IO.Compression;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using Microsoft.Extensions.Logging;
 using WebReaper.Cdp;
@@ -211,6 +212,9 @@ public static class CloakBrowserInstaller
         await TarFile.ExtractToDirectoryAsync(gz, destDir, overwriteFiles: true, ct);
     }
 
+    // The Unix file-mode APIs throw on Windows; the only caller is guarded by
+    // `if (!OperatingSystem.IsWindows())`, which this attribute lets CA1416 see.
+    [UnsupportedOSPlatform("windows")]
     private static void EnsureExecutable(string path)
     {
         var mode = File.GetUnixFileMode(path);


### PR DESCRIPTION
Clears the release-build annotations the v11.1.2 run surfaced. No behavior change.

**CA1416 (false positive).** `CloakBrowserInstaller.EnsureExecutable` calls `File.Get/SetUnixFileMode`, which the analyzer flagged as "unsupported on windows" even though its only caller is guarded by `if (!OperatingSystem.IsWindows())`. Annotated the method `[UnsupportedOSPlatform("windows")]` so CA1416 understands the contract. The chmod was never reachable on Windows; nothing functional changes.

**AOT-hostile `JsonArray.Add<T>(T)` (IL2026/IL3050).** The `new JsonArray { "x", ... }` initializers in the agent/page-action tool registries bound to the generic `Add<T>(T)` (RequiresDynamicCode/RequiresUnreferencedCode), which surfaced in the CLI AOT publish. Cast each string element to `(JsonNode)` so they bind to the AOT-safe `Add(JsonNode?)` overload (the same pattern the cookie code already uses).

**Verified locally:**
- `WebReaper.Stealth.CloakBrowser` builds CA1416-clean.
- `WebReaper.AI` with `-p:IsAotCompatible=true` builds AOT-clean: **0** IL2026/IL3050 (was 20).

Ships in the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)