### PR TITLE
feat(mcp): WebReaper.Mcp.AspNetCore Streamable HTTP transport (#240-#246)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ env:
     WebReaper.Extraction.Attributes
     WebReaper.Extraction.Generators
     WebReaper.Mcp
+    WebReaper.Mcp.AspNetCore
     WebReaper.Cdp
     WebReaper.Playwright
     WebReaper.Stealth.CloakBrowser
@@ -647,3 +648,41 @@ jobs:
           fi
           git commit -m "WebReaper ${VERSION}"
           git push
+
+  # ADR-0086: publish the WebReaper.Mcp.AspNetCore container image to GHCR.
+  # GHCR is the default registry: GitHub-native, authenticated with the
+  # built-in GITHUB_TOKEN (no extra secret), image under the repo owner. Runs
+  # only when the AspNetCore package is in the released set (lockstep version
+  # match) and never on a dry run; gated behind the NuGet release like the CLI
+  # binaries. The container smoke (docker run -> /health + a tools/call) is the
+  # acceptance check this job's published image is verified against post-release.
+  image-publish:
+    name: Publish container image (GHCR)
+    needs: [pack, release]
+    if: ${{ (github.event_name != 'workflow_dispatch' || inputs.dry_run == false) && contains(needs.pack.outputs.packages, 'WebReaper.Mcp.AspNetCore') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push the MCP HTTP server image
+        uses: docker/build-push-action@v6
+        with:
+          # Context = repo root: the host references the library projects.
+          context: .
+          file: WebReaper.Mcp.AspNetCore/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/webreaper-mcp-http:${{ needs.pack.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/webreaper-mcp-http:latest

--- a/WebReaper.Mcp.AspNetCore/BearerAuth.cs
+++ b/WebReaper.Mcp.AspNetCore/BearerAuth.cs
@@ -1,0 +1,29 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace WebReaper.Mcp.AspNetCore;
+
+// ADR-0086: the pure bearer-token decision the auth middleware calls. No
+// configured token means auth is disabled (loopback dev; the McpHttpOptions
+// bind guard prevents this off-loopback). Otherwise the request must carry
+// "Authorization: Bearer <token>" matching in fixed time.
+internal static class BearerAuth
+{
+    public static bool IsAuthorized(string? configuredToken, string? authorizationHeader)
+    {
+        if (string.IsNullOrEmpty(configuredToken)) return true;
+        if (string.IsNullOrEmpty(authorizationHeader)) return false;
+
+        const string prefix = "Bearer ";
+        if (!authorizationHeader.StartsWith(prefix, StringComparison.Ordinal)) return false;
+
+        var presented = authorizationHeader[prefix.Length..];
+        return FixedTimeEquals(presented, configuredToken);
+    }
+
+    // Constant-time within equal lengths; differing lengths short-circuit
+    // (leaking only length, which is not the secret).
+    private static bool FixedTimeEquals(string a, string b) =>
+        CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(a), Encoding.UTF8.GetBytes(b));
+}

--- a/WebReaper.Mcp.AspNetCore/Dockerfile
+++ b/WebReaper.Mcp.AspNetCore/Dockerfile
@@ -1,0 +1,62 @@
+# ADR-0086: the Streamable HTTP MCP server image, with a headless vanilla
+# Chromium baked in so browser=true works out of the box. Leaner than the
+# playground Tier-B image: headless (no Xvfb), no stealth fork, no egress
+# firewall, no proxy. For an external browser pool set WEBREAPER_CDP_URL and
+# the baked Chromium goes unused.
+#
+# Build context = the REPO ROOT (the host references the library projects):
+#
+#   docker build -f WebReaper.Mcp.AspNetCore/Dockerfile -t webreaper-mcp-http .
+
+# --- build the app (SDK tag matches global.json) ---
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+# Restore as its own layer: shared build props + the csproj graph only
+# (AspNetCore -> Mcp -> WebReaper / Cdp / AI / AI.Http), so a source-only change
+# does not re-run restore.
+COPY global.json Directory.Build.props ./
+COPY WebReaper/WebReaper.csproj WebReaper/
+COPY WebReaper.Cdp/WebReaper.Cdp.csproj WebReaper.Cdp/
+COPY WebReaper.AI/WebReaper.AI.csproj WebReaper.AI/
+COPY WebReaper.AI.Http/WebReaper.AI.Http.csproj WebReaper.AI.Http/
+COPY WebReaper.Mcp/WebReaper.Mcp.csproj WebReaper.Mcp/
+COPY WebReaper.Mcp.AspNetCore/WebReaper.Mcp.AspNetCore.csproj WebReaper.Mcp.AspNetCore/
+RUN dotnet restore WebReaper.Mcp.AspNetCore/WebReaper.Mcp.AspNetCore.csproj
+# Sources, then publish (framework-dependent; the runtime base carries ASP.NET).
+COPY WebReaper/ WebReaper/
+COPY WebReaper.Cdp/ WebReaper.Cdp/
+COPY WebReaper.AI/ WebReaper.AI/
+COPY WebReaper.AI.Http/ WebReaper.AI.Http/
+COPY WebReaper.Mcp/ WebReaper.Mcp/
+COPY WebReaper.Mcp.AspNetCore/ WebReaper.Mcp.AspNetCore/
+RUN dotnet publish WebReaper.Mcp.AspNetCore/WebReaper.Mcp.AspNetCore.csproj \
+    -c Release -o /app --no-restore
+
+# --- runtime: Debian + ASP.NET 10 runtime + headless vanilla Chromium ---
+# Debian (not the .NET aspnet image): .NET 10 ships Ubuntu-only base images, and
+# Ubuntu's `chromium` apt package is a container-hostile snap stub. Debian's
+# `chromium` is a real .deb that runs headless in a container. WebReaper.Cdp's
+# PATH search finds /usr/bin/chromium, so CdpLaunchOptions() launches it with no
+# extra config. The ASP.NET Core 10 runtime is installed via the official script.
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        chromium fonts-liberation fonts-noto-core fonts-noto-color-emoji fonts-freefont-ttf \
+        libicu72 ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && bash /tmp/dotnet-install.sh --channel 10.0 --runtime aspnetcore --install-dir /usr/share/dotnet \
+    && ln -sf /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm /tmp/dotnet-install.sh
+WORKDIR /app
+COPY --from=build /app ./
+
+# Bind all interfaces inside the container. The McpHttpOptions bind guard then
+# REQUIRES WEBREAPER_MCP_TOKEN at startup (a non-loopback bind without a token is
+# refused), so the image is secure by default: `docker run` without a token
+# fails actionably. The vanilla Chromium launches with the host's default flags.
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s \
+    CMD curl -fsS http://localhost:8080/health || exit 1
+ENTRYPOINT ["dotnet", "WebReaper.Mcp.AspNetCore.dll"]

--- a/WebReaper.Mcp.AspNetCore/McpHttpOptions.cs
+++ b/WebReaper.Mcp.AspNetCore/McpHttpOptions.cs
@@ -1,0 +1,69 @@
+using System.Net;
+
+namespace WebReaper.Mcp.AspNetCore;
+
+// ADR-0086: pure config parse + validate for the HTTP host. No IO: the caller
+// passes the token and the configured bind URLs, so this is a closed truth
+// table under test (prior art: WebReaper.Cli's EscalationPlan / ScrapeContext).
+internal sealed record McpHttpOptions(string? BearerToken, bool RequireAuth)
+{
+    public const string TokenEnvVar = "WEBREAPER_MCP_TOKEN";
+
+    /// <summary>
+    /// Validate the (token, bind-urls) pair into options. Throws an actionable
+    /// <see cref="InvalidOperationException"/> when a non-loopback interface is
+    /// bound without a token: an unauthenticated, network-reachable scraper is
+    /// an SSRF amplifier. Loopback with no token is allowed (local dev).
+    /// </summary>
+    public static McpHttpOptions Validate(string? bearerToken, IEnumerable<string>? bindUrls)
+    {
+        var token = string.IsNullOrWhiteSpace(bearerToken) ? null : bearerToken.Trim();
+        var bindsNonLoopback = (bindUrls ?? []).Any(u => !IsLoopback(u));
+
+        if (token is null && bindsNonLoopback)
+            throw new InvalidOperationException(
+                "Refusing to bind a non-loopback interface without authentication. " +
+                $"Set the {TokenEnvVar} environment variable to a bearer token, or bind a " +
+                "loopback address (localhost / 127.0.0.1) for local development.");
+
+        return new McpHttpOptions(token, RequireAuth: token is not null);
+    }
+
+    /// <summary>
+    /// A bind URL is loopback when its host is localhost / a loopback IP / ::1.
+    /// Kestrel wildcards (0.0.0.0, [::], +, *) and any real host are not.
+    /// </summary>
+    internal static bool IsLoopback(string url)
+    {
+        var host = ExtractHost(url);
+        if (host is null) return false;
+        if (host is "+" or "*" or "0.0.0.0" or "::" or "[::]") return false;
+        if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase)) return true;
+        var bare = host.Trim('[', ']');
+        return IPAddress.TryParse(bare, out var ip) && IPAddress.IsLoopback(ip);
+    }
+
+    // Pull the host out of [scheme://]host[:port][/path], tolerating IPv6
+    // [::1]:port and bare host:port forms.
+    private static string? ExtractHost(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return null;
+        var s = url.Trim();
+
+        var scheme = s.IndexOf("://", StringComparison.Ordinal);
+        if (scheme >= 0) s = s[(scheme + 3)..];
+
+        var slash = s.IndexOf('/');
+        if (slash >= 0) s = s[..slash];
+
+        if (s.StartsWith('['))
+        {
+            var close = s.IndexOf(']');
+            return close >= 0 ? s[..(close + 1)] : s;
+        }
+
+        var colon = s.IndexOf(':');
+        if (colon >= 0) s = s[..colon];
+        return s.Length == 0 ? null : s;
+    }
+}

--- a/WebReaper.Mcp.AspNetCore/McpHttpServer.cs
+++ b/WebReaper.Mcp.AspNetCore/McpHttpServer.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using WebReaper.Mcp;
+
+namespace WebReaper.Mcp.AspNetCore;
+
+// ADR-0086: the Streamable HTTP MCP host. Sibling to the stdio Program in
+// WebReaper.Mcp; both wire the same WebReaperTools class. Factored as a
+// builder method so the host smoke test can start the same app on a random
+// loopback port without spawning a subprocess.
+//
+// Slice 1 (the spine): transport + tools + MapMcp + /health, loopback only,
+// no auth. Auth, config validation, and the bind guard land in slice 2.
+public static class McpHttpServer
+{
+    public static WebApplication Build(string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.Services
+            .AddMcpServer()
+            // Stateless: WebReaper's tools are single-shot and make no
+            // server-to-client requests, so the SDK's scalable mode fits.
+            .WithHttpTransport(o => o.Stateless = true)
+            // Reuse the stdio satellite's tools. WebReaperTools is a static
+            // class (cannot be a generic type arg), so scan its assembly, the
+            // same way the stdio host does with WithToolsFromAssembly.
+            .WithToolsFromAssembly(typeof(WebReaperTools).Assembly);
+
+        var app = builder.Build();
+
+        // Streamable HTTP MCP endpoint at the application root.
+        app.MapMcp();
+
+        // Liveness probe for container orchestration.
+        app.MapGet("/health", () => Results.Ok(new { status = "ok" }));
+
+        return app;
+    }
+
+    // Test seam: start the app on a random loopback port and report the bound
+    // base address, so the host smoke test can drive a real HTTP MCP handshake
+    // without a subprocess or a hard-coded port. Internal, visible to the test
+    // projects only.
+    internal static async Task<(WebApplication App, Uri BaseAddress)> StartForTestAsync(string[] args)
+    {
+        var app = Build(args);
+        app.Urls.Clear();
+        app.Urls.Add("http://127.0.0.1:0");
+        await app.StartAsync();
+        var address = app.Services.GetRequiredService<IServer>()
+            .Features.Get<IServerAddressesFeature>()!
+            .Addresses.First();
+        return (app, new Uri(address));
+    }
+}

--- a/WebReaper.Mcp.AspNetCore/McpHttpServer.cs
+++ b/WebReaper.Mcp.AspNetCore/McpHttpServer.cs
@@ -2,35 +2,71 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using WebReaper.Mcp;
 
 namespace WebReaper.Mcp.AspNetCore;
 
 // ADR-0086: the Streamable HTTP MCP host. Sibling to the stdio Program in
-// WebReaper.Mcp; both wire the same WebReaperTools class. Factored as a
-// builder method so the host smoke test can start the same app on a random
-// loopback port without spawning a subprocess.
-//
-// Slice 1 (the spine): transport + tools + MapMcp + /health, loopback only,
-// no auth. Auth, config validation, and the bind guard land in slice 2.
+// WebReaper.Mcp; both wire the same WebReaperTools class. Factored as builder
+// methods so the host smoke test can start the same app on a random loopback
+// port without spawning a subprocess.
 public static class McpHttpServer
 {
     public static WebApplication Build(string[] args)
     {
-        var builder = WebApplication.CreateBuilder(args);
+        var builder = CreateBuilder(args);
+        // Token from env; bind URLs from ASP.NET configuration (--urls /
+        // ASPNETCORE_URLS aggregate into config["urls"]). Validate throws an
+        // actionable error on an unsafe non-loopback-without-token bind.
+        var options = McpHttpOptions.Validate(
+            Environment.GetEnvironmentVariable(McpHttpOptions.TokenEnvVar),
+            ResolveBindUrls(builder.Configuration));
+        return Assemble(builder, options);
+    }
 
+    private static WebApplicationBuilder CreateBuilder(string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
         builder.Services
             .AddMcpServer()
             // Stateless: WebReaper's tools are single-shot and make no
             // server-to-client requests, so the SDK's scalable mode fits.
             .WithHttpTransport(o => o.Stateless = true)
-            // Reuse the stdio satellite's tools. WebReaperTools is a static
-            // class (cannot be a generic type arg), so scan its assembly, the
-            // same way the stdio host does with WithToolsFromAssembly.
+            // Reuse the stdio satellite's tools (WebReaperTools is a static
+            // class, so scan its assembly rather than name the type).
             .WithToolsFromAssembly(typeof(WebReaperTools).Assembly);
+        return builder;
+    }
 
+    private static WebApplication Assemble(WebApplicationBuilder builder, McpHttpOptions options)
+    {
         var app = builder.Build();
+
+        // Bearer-token gate (only when a token is configured). /health stays
+        // open so orchestrators can probe without the token.
+        if (options.RequireAuth)
+        {
+            app.Use(async (context, next) =>
+            {
+                if (context.Request.Path.Equals("/health", StringComparison.OrdinalIgnoreCase))
+                {
+                    await next();
+                    return;
+                }
+
+                var header = context.Request.Headers.Authorization.ToString();
+                if (!BearerAuth.IsAuthorized(options.BearerToken, header))
+                {
+                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    await context.Response.WriteAsync("Unauthorized: missing or invalid bearer token.");
+                    return;
+                }
+
+                await next();
+            });
+        }
 
         // Streamable HTTP MCP endpoint at the application root.
         app.MapMcp();
@@ -41,16 +77,32 @@ public static class McpHttpServer
         return app;
     }
 
+    // ASP.NET aggregates --urls / ASPNETCORE_URLS / DOTNET_URLS into
+    // config["urls"]. Absent => Kestrel's loopback default.
+    private static IEnumerable<string> ResolveBindUrls(IConfiguration config)
+    {
+        var urls = config["urls"];
+        return string.IsNullOrWhiteSpace(urls)
+            ? ["http://localhost:5000"]
+            : urls.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
     // Test seam: start the app on a random loopback port and report the bound
     // base address, so the host smoke test can drive a real HTTP MCP handshake
-    // without a subprocess or a hard-coded port. Internal, visible to the test
-    // projects only.
-    internal static async Task<(WebApplication App, Uri BaseAddress)> StartForTestAsync(string[] args)
+    // without a subprocess or a hard-coded port. An optional token exercises
+    // the auth path without mutating process-global environment state.
+    internal static async Task<(WebApplication App, Uri BaseAddress)> StartForTestAsync(
+        string[] args, string? token = null)
     {
-        var app = Build(args);
+        var builder = CreateBuilder(args);
+        // Loopback bind, so a token is allowed but not required by the guard.
+        var options = McpHttpOptions.Validate(token, ["http://127.0.0.1:0"]);
+        var app = Assemble(builder, options);
+
         app.Urls.Clear();
         app.Urls.Add("http://127.0.0.1:0");
         await app.StartAsync();
+
         var address = app.Services.GetRequiredService<IServer>()
             .Features.Get<IServerAddressesFeature>()!
             .Addresses.First();

--- a/WebReaper.Mcp.AspNetCore/Program.cs
+++ b/WebReaper.Mcp.AspNetCore/Program.cs
@@ -1,0 +1,14 @@
+// ADR-0086: WebReaper.Mcp.AspNetCore entry point. The Streamable HTTP MCP
+// server a remote client (n8n, hosted agent) points a URL at. Tools live in
+// WebReaper.Mcp's WebReaperTools; the host wiring is in McpHttpServer.
+//
+// Slice 1: loopback-only, no auth. Run it and point a Streamable-HTTP MCP
+// client at the printed URL.
+
+using WebReaper.Mcp.AspNetCore;
+
+var app = McpHttpServer.Build(args);
+await app.RunAsync();
+
+// Exposed so the host smoke test can reference the entry assembly.
+public partial class Program;

--- a/WebReaper.Mcp.AspNetCore/README.md
+++ b/WebReaper.Mcp.AspNetCore/README.md
@@ -17,11 +17,13 @@ dotnet run --project WebReaper.Mcp.AspNetCore
 # then point a Streamable-HTTP MCP client at the printed URL
 ```
 
-The container image (Chromium baked in) is the recommended way to self-host:
+The container image (Chromium baked in) is the recommended way to self-host.
+Each release publishes it to GHCR as `ghcr.io/pavlovtech/webreaper-mcp-http`:
 
 ```bash
-docker build -f WebReaper.Mcp.AspNetCore/Dockerfile -t webreaper-mcp-http .
-docker run --rm -p 8080:8080 -e WEBREAPER_MCP_TOKEN=change-me webreaper-mcp-http
+docker run --rm -p 8080:8080 -e WEBREAPER_MCP_TOKEN=change-me \
+  ghcr.io/pavlovtech/webreaper-mcp-http:latest
+# or build it: docker build -f WebReaper.Mcp.AspNetCore/Dockerfile -t webreaper-mcp-http .
 ```
 
 See [docs/mcp-http-quickstart.md](../docs/mcp-http-quickstart.md) for the n8n

--- a/WebReaper.Mcp.AspNetCore/README.md
+++ b/WebReaper.Mcp.AspNetCore/README.md
@@ -17,8 +17,15 @@ dotnet run --project WebReaper.Mcp.AspNetCore
 # then point a Streamable-HTTP MCP client at the printed URL
 ```
 
-The container image (Chromium baked in) is the recommended way to self-host;
-see the repo's deployment docs.
+The container image (Chromium baked in) is the recommended way to self-host:
+
+```bash
+docker build -f WebReaper.Mcp.AspNetCore/Dockerfile -t webreaper-mcp-http .
+docker run --rm -p 8080:8080 -e WEBREAPER_MCP_TOKEN=change-me webreaper-mcp-http
+```
+
+See [docs/mcp-http-quickstart.md](../docs/mcp-http-quickstart.md) for the n8n
+wiring and a `docker-compose.example.yml` (server + optional browser sidecar).
 
 ## Configuration (environment)
 

--- a/WebReaper.Mcp.AspNetCore/README.md
+++ b/WebReaper.Mcp.AspNetCore/README.md
@@ -1,0 +1,34 @@
+# WebReaper.Mcp.AspNetCore
+
+A **Streamable HTTP** [MCP](https://modelcontextprotocol.io) server host for
+[WebReaper](https://github.com/pavlovtech/WebReaper). It exposes WebReaper's
+scraping tools over HTTP so URL-based MCP clients (n8n, hosted agents) can
+reach them. Sibling to the stdio `WebReaper.Mcp` satellite; both expose the
+same tools (`scrape`, `map`, `extract`, `extract_with_prompt`, `crawl`).
+
+Use the stdio `WebReaper.Mcp` for local agents that spawn a process (Cursor,
+Claude Desktop). Use this package when the client connects over a URL. See
+ADR-0086.
+
+## Run
+
+```bash
+dotnet run --project WebReaper.Mcp.AspNetCore
+# then point a Streamable-HTTP MCP client at the printed URL
+```
+
+The container image (Chromium baked in) is the recommended way to self-host;
+see the repo's deployment docs.
+
+## Configuration (environment)
+
+| Variable | Purpose |
+|---|---|
+| `WEBREAPER_MCP_TOKEN` | Bearer token required on every request. Mandatory when binding a non-loopback interface. |
+| `WEBREAPER_CDP_URL` | Connect `browser=true` calls to this CDP endpoint (a shared Chromium / browserless sidecar) instead of launching. |
+| `WEBREAPER_MCP_MAX_CONCURRENT_BROWSERS` | Cap on concurrent managed-Chromium launches. |
+| `WEBREAPER_LLM_MODEL` / `WEBREAPER_LLM_BASE_URL` / `WEBREAPER_LLM_API_KEY` | OpenAI-compatible endpoint for `extract_with_prompt`. The key is read from the environment only. |
+
+## License
+
+MIT.

--- a/WebReaper.Mcp.AspNetCore/WebReaper.Mcp.AspNetCore.csproj
+++ b/WebReaper.Mcp.AspNetCore/WebReaper.Mcp.AspNetCore.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>WebReaper.Mcp.AspNetCore</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <PackageId>WebReaper.Mcp.AspNetCore</PackageId>
+    <Title>WebReaper.Mcp.AspNetCore</Title>
+    <Description>Streamable HTTP MCP (Model Context Protocol) server host for WebReaper. Exposes scrape / map / extract / extract_with_prompt / crawl as MCP tools over HTTP, so URL-based MCP clients (n8n, hosted agents) can reach WebReaper. Sibling to the stdio WebReaper.Mcp satellite, reusing its tools. Self-run, single-tenant, bearer-token auth. ADR-0086.</Description>
+    <!-- ADR-0017: MIT, same as the rest of the funnel. -->
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>scraper, crawler, mcp, model-context-protocol, agent, http, n8n</PackageTags>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- ADR-0086: Streamable HTTP transport. Pinned in lockstep with the
+         ModelContextProtocol version the stdio satellite (WebReaper.Mcp) uses;
+         this package transitively brings ModelContextProtocol at the same pin. -->
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.6.0-preview.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- ADR-0086: reuse the WebReaperTools class and the shared decision
+         modules (BrowserTransport, CrawlBounds) from the stdio satellite.
+         WebReaper.Mcp already bakes WebReaper.Cdp + WebReaper.AI(.Http). -->
+    <ProjectReference Include="..\WebReaper.Mcp\WebReaper.Mcp.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\WebReaper\logo.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="WebReaper.Mcp.AspNetCore.Tests" />
+    <InternalsVisibleTo Include="WebReaper.IntegrationTests" />
+  </ItemGroup>
+
+</Project>

--- a/WebReaper.Mcp.AspNetCore/docker-compose.example.yml
+++ b/WebReaper.Mcp.AspNetCore/docker-compose.example.yml
@@ -1,0 +1,41 @@
+# ADR-0086: run the WebReaper Streamable HTTP MCP server next to n8n.
+# Build the image first (context = repo root):
+#   docker build -f WebReaper.Mcp.AspNetCore/Dockerfile -t webreaper-mcp-http .
+# Then: docker compose -f WebReaper.Mcp.AspNetCore/docker-compose.example.yml up
+
+services:
+  webreaper-mcp:
+    image: webreaper-mcp-http
+    environment:
+      # REQUIRED off-loopback: the bind guard refuses to start without it.
+      WEBREAPER_MCP_TOKEN: "change-me-to-a-long-random-secret"
+      # Optional: LLM endpoint for extract_with_prompt. The key lives here,
+      # never as a tool argument.
+      # WEBREAPER_LLM_MODEL: "gpt-4o-mini"
+      # WEBREAPER_LLM_BASE_URL: "https://api.openai.com/v1"
+      # WEBREAPER_LLM_API_KEY: "sk-..."
+      # Optional: cap concurrent managed-Chromium launches (default 4).
+      # WEBREAPER_MCP_MAX_CONCURRENT_BROWSERS: "4"
+      # Optional: connect browser=true calls to the sidecar below instead of
+      # launching the baked Chromium. One shared pool for all requests.
+      # WEBREAPER_CDP_URL: "http://browser:9222"
+    ports:
+      # n8n on the same network reaches it at http://webreaper-mcp:8080 (no
+      # published port needed for that); this exposes it to the host too.
+      - "8080:8080"
+    restart: unless-stopped
+
+  # Optional shared browser pool. Uncomment and set WEBREAPER_CDP_URL above to
+  # use it instead of the Chromium baked into the image.
+  # browser:
+  #   image: ghcr.io/browserless/chromium
+  #   restart: unless-stopped
+
+  # Your n8n (sketch). In the workflow add an MCP Client Tool node:
+  #   Server Transport = HTTP Streamable
+  #   MCP Endpoint URL  = http://webreaper-mcp:8080
+  #   Authentication    = Bearer, value = the WEBREAPER_MCP_TOKEN above
+  # n8n:
+  #   image: docker.n8n.io/n8nio/n8n
+  #   ports: ["5678:5678"]
+  #   restart: unless-stopped

--- a/WebReaper.Mcp/BrowserTransport.cs
+++ b/WebReaper.Mcp/BrowserTransport.cs
@@ -1,0 +1,63 @@
+using WebReaper.Builders;
+using WebReaper.Cdp;
+
+namespace WebReaper.Mcp;
+
+// ADR-0086: how a browser=true tool gets a browser. Lives in the shared
+// satellite (not the HTTP host) so both the stdio and HTTP hosts honor
+// WEBREAPER_CDP_URL: connect to a shared Chromium / browserless sidecar when
+// set, otherwise launch managed Chromium. The selection is a pure decision
+// (a closed truth table under test); the apply + launch gate are the impure
+// edges.
+
+public enum BrowserLaunchMode { None, Launch, Connect }
+
+public readonly record struct BrowserTransportPlan(BrowserLaunchMode Mode, string? CdpUrl);
+
+public static class BrowserTransport
+{
+    public const string CdpUrlEnvVar = "WEBREAPER_CDP_URL";
+    public const string MaxConcurrentBrowsersEnvVar = "WEBREAPER_MCP_MAX_CONCURRENT_BROWSERS";
+    public const int DefaultMaxConcurrentBrowsers = 4;
+
+    /// <summary>Pure: launch vs connect from the browser flag and an optional CDP url.</summary>
+    public static BrowserTransportPlan Select(bool browser, string? cdpUrl)
+    {
+        if (!browser) return new BrowserTransportPlan(BrowserLaunchMode.None, null);
+        var trimmed = string.IsNullOrWhiteSpace(cdpUrl) ? null : cdpUrl.Trim();
+        return trimmed is null
+            ? new BrowserTransportPlan(BrowserLaunchMode.Launch, null)
+            : new BrowserTransportPlan(BrowserLaunchMode.Connect, trimmed);
+    }
+
+    /// <summary>Pure: a positive integer cap, else the default. Tolerates null / garbage.</summary>
+    public static int ResolveMaxConcurrentBrowsers(string? raw) =>
+        int.TryParse(raw, out var n) && n > 0 ? n : DefaultMaxConcurrentBrowsers;
+
+    // Apply the plan to a builder. Connect uses the CDP-url overload (no
+    // process spawn); Launch spawns managed Chromium; None leaves HTTP.
+    internal static ScraperEngineBuilder ApplyBrowser(this ScraperEngineBuilder builder, BrowserTransportPlan plan) =>
+        plan.Mode switch
+        {
+            BrowserLaunchMode.Connect => builder.WithCdpPageLoader(plan.CdpUrl!),
+            BrowserLaunchMode.Launch => builder.WithCdpPageLoader(new CdpLaunchOptions()),
+            _ => builder,
+        };
+}
+
+// Caps concurrent managed-Chromium launches across tool calls (parallel HTTP
+// requests would otherwise spawn unbounded browsers). Connect-mode calls do
+// not launch, so they never take a permit. The semaphore is sized once from
+// the environment on first use.
+internal static class BrowserLaunchGate
+{
+    private static readonly Lazy<SemaphoreSlim> Gate = new(() =>
+    {
+        var max = BrowserTransport.ResolveMaxConcurrentBrowsers(
+            Environment.GetEnvironmentVariable(BrowserTransport.MaxConcurrentBrowsersEnvVar));
+        return new SemaphoreSlim(max, max);
+    });
+
+    public static Task WaitAsync() => Gate.Value.WaitAsync();
+    public static void Release() => Gate.Value.Release();
+}

--- a/WebReaper.Mcp/CrawlBounds.cs
+++ b/WebReaper.Mcp/CrawlBounds.cs
@@ -1,0 +1,20 @@
+namespace WebReaper.Mcp;
+
+// ADR-0086: bound the crawl tool's page count. MCP has no streaming, so an
+// unbounded sweep would be one long blocking call that runs past a client's
+// node timeout. Small default, hard cap, non-positive rejected.
+public static class CrawlBounds
+{
+    public const int DefaultMaxPages = 50;
+    public const int MaxAllowed = 1000;
+
+    /// <summary>Clamp a requested page cap to the allowed range; reject non-positive.</summary>
+    public static int Validate(int maxPages)
+    {
+        if (maxPages <= 0)
+            throw new ArgumentException(
+                $"max_pages must be positive (default {DefaultMaxPages}, hard cap {MaxAllowed}).",
+                nameof(maxPages));
+        return Math.Min(maxPages, MaxAllowed);
+    }
+}

--- a/WebReaper.Mcp/LlmConfig.cs
+++ b/WebReaper.Mcp/LlmConfig.cs
@@ -1,0 +1,32 @@
+namespace WebReaper.Mcp;
+
+// ADR-0086 / ADR-0084: the LLM config for extract_with_prompt. The API key is
+// environment-only (never a tool parameter); the model may be overridden per
+// call. Resolution + validation is pure (a closed truth table under test); the
+// env reads happen at the call site.
+public sealed record LlmConfig(string Model, string BaseUrl, string? ApiKey)
+{
+    public const string ModelEnvVar = "WEBREAPER_LLM_MODEL";
+    public const string BaseUrlEnvVar = "WEBREAPER_LLM_BASE_URL";
+
+    /// <summary>
+    /// Resolve the effective config: a per-call model override wins over the
+    /// environment model. Throws an actionable <see cref="InvalidOperationException"/>
+    /// when the model or the base URL is missing.
+    /// </summary>
+    public static LlmConfig Resolve(string? modelOverride, string? envModel, string? baseUrl, string? apiKey)
+    {
+        var model = FirstNonBlank(modelOverride, envModel);
+        if (model is null)
+            throw new InvalidOperationException(
+                $"extract_with_prompt needs an LLM model: pass the 'model' parameter or set {ModelEnvVar}.");
+        if (string.IsNullOrWhiteSpace(baseUrl))
+            throw new InvalidOperationException(
+                $"extract_with_prompt needs an LLM endpoint: set {BaseUrlEnvVar} (e.g. https://api.openai.com/v1).");
+
+        return new LlmConfig(model, baseUrl.Trim(), string.IsNullOrWhiteSpace(apiKey) ? null : apiKey);
+    }
+
+    private static string? FirstNonBlank(params string?[] values) =>
+        values.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v))?.Trim();
+}

--- a/WebReaper.Mcp/WebReaperTools.cs
+++ b/WebReaper.Mcp/WebReaperTools.cs
@@ -154,6 +154,41 @@ public static class WebReaperTools
         return string.Join("\n", records.Select(r => r.Data.ToJsonString()));
     }
 
+    [McpServerTool(Name = "crawl"), Description(
+        "Crawl a whole site: recursively follow on-domain links from the start URL "
+        + "and return one Markdown record per page as JSON Lines. WARNING: this is a "
+        + "single long BLOCKING call with NO progress feedback, bounded by max_pages "
+        + "(default 50, hard cap 1000). For a large site prefer 'map' to list URLs, "
+        + "then 'scrape' each URL, so every call stays short and you keep per-URL control.")]
+    public static async Task<string> Crawl(
+        [Description("The site root URL to crawl.")] string url,
+        [Description("Maximum pages to sweep. Default 50, hard cap 1000.")] int maxPages = CrawlBounds.DefaultMaxPages,
+        [Description("Use the headless browser for each page (JS-rendered sites). Default false.")] bool browser = false)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            throw new ArgumentException("URL is required.", nameof(url));
+
+        var cap = CrawlBounds.Validate(maxPages);
+
+        var seed = browser
+            ? ScraperEngineBuilder.CrawlWithBrowser(url)
+            : ScraperEngineBuilder.Crawl(url);
+
+        // ADR-0081 site sweep, bounded. The crawl loop is parallel (ADR-0022),
+        // so sink emits are concurrent; guard the collection.
+        var records = new List<ParsedData>();
+        var builder = seed.AsMarkdown()
+            .Sweep(new SweepOptions())
+            .PageCrawlLimit(cap)
+            .Subscribe(r => { lock (records) records.Add(r); })
+            .StopWhenAllLinksProcessed();
+
+        await RunBrowserAwareAsync(builder, browser);
+
+        // JSON Lines: one record per swept page.
+        return string.Join("\n", records.Select(r => r.Data.ToJsonString()));
+    }
+
     // ADR-0086: resolve the browser plan (launch vs connect-to-CDP-url), apply
     // it, and run the engine. Managed-Chromium launches pass through a
     // concurrency gate; connect / HTTP calls do not. `await using` tears the

--- a/WebReaper.Mcp/WebReaperTools.cs
+++ b/WebReaper.Mcp/WebReaperTools.cs
@@ -5,7 +5,6 @@ using ModelContextProtocol.Server;
 using WebReaper.AI;
 using WebReaper.AI.Http;
 using WebReaper.Builders;
-using WebReaper.Cdp;
 using WebReaper.Core.Mapping;
 using WebReaper.Domain.Parsing;
 using WebReaper.Sinks.Models;
@@ -40,16 +39,9 @@ public static class WebReaperTools
             .Subscribe(records.Add)
             .StopWhenAllLinksProcessed();
 
-        // ADR-0073: wire WebReaper.Cdp launch-and-connect on browser=true.
-        // The Cdp loader's PATH search finds google-chrome / chromium /
-        // chrome / microsoft-edge / msedge; fails actionable when none
-        // present. `await using` the engine so the spawned-Chromium
-        // process tears down with the call (ADR-0058 chain).
-        if (browser)
-            builder = builder.WithCdpPageLoader(new CdpLaunchOptions());
-
-        await using var engine = await builder.BuildAsync();
-        await engine.RunAsync();
+        // ADR-0073 / ADR-0086: browser=true launches managed Chromium, or
+        // connects to WEBREAPER_CDP_URL (a shared browser sidecar) when set.
+        await RunBrowserAwareAsync(builder, browser);
 
         var output = new StringBuilder();
         foreach (var record in records)
@@ -119,12 +111,8 @@ public static class WebReaperTools
             .Subscribe(records.Add)
             .StopWhenAllLinksProcessed();
 
-        // ADR-0073: see Scrape() above for the wiring rationale.
-        if (browser)
-            builder = builder.WithCdpPageLoader(new CdpLaunchOptions());
-
-        await using var engine = await builder.BuildAsync();
-        await engine.RunAsync();
+        // ADR-0086: see Scrape() for the browser-wiring rationale.
+        await RunBrowserAwareAsync(builder, browser);
 
         // JSON Lines: one record per line.
         return string.Join("\n", records.Select(r => r.Data.ToJsonString()));
@@ -160,13 +148,33 @@ public static class WebReaperTools
             .Subscribe(records.Add)
             .StopWhenAllLinksProcessed();
 
-        if (browser)
-            builder = builder.WithCdpPageLoader(new CdpLaunchOptions());
-
-        await using var engine = await builder.BuildAsync();
-        await engine.RunAsync();
+        // ADR-0086: see Scrape() for the browser-wiring rationale.
+        await RunBrowserAwareAsync(builder, browser);
 
         return string.Join("\n", records.Select(r => r.Data.ToJsonString()));
+    }
+
+    // ADR-0086: resolve the browser plan (launch vs connect-to-CDP-url), apply
+    // it, and run the engine. Managed-Chromium launches pass through a
+    // concurrency gate; connect / HTTP calls do not. `await using` tears the
+    // engine (and any spawned Chromium) down on completion (ADR-0058).
+    private static async Task RunBrowserAwareAsync(ScraperEngineBuilder builder, bool browser)
+    {
+        var plan = BrowserTransport.Select(
+            browser, Environment.GetEnvironmentVariable(BrowserTransport.CdpUrlEnvVar));
+        builder = builder.ApplyBrowser(plan);
+
+        var gated = plan.Mode == BrowserLaunchMode.Launch;
+        if (gated) await BrowserLaunchGate.WaitAsync();
+        try
+        {
+            await using var engine = await builder.BuildAsync();
+            await engine.RunAsync();
+        }
+        finally
+        {
+            if (gated) BrowserLaunchGate.Release();
+        }
     }
 
     // ADR-0084: build the OpenAI-compatible chat client from environment config.

--- a/WebReaper.Mcp/WebReaperTools.cs
+++ b/WebReaper.Mcp/WebReaperTools.cs
@@ -124,18 +124,20 @@ public static class WebReaperTools
         "Returns the extracted record(s) as JSON Lines. Requires an OpenAI-compatible LLM " +
         "endpoint configured on the MCP host: set WEBREAPER_LLM_MODEL and WEBREAPER_LLM_BASE_URL " +
         "(e.g. https://api.openai.com/v1 or http://localhost:11434/v1), with the API key in " +
-        "WEBREAPER_LLM_API_KEY (or OPENAI_API_KEY). Costs one LLM call.")]
+        "WEBREAPER_LLM_API_KEY (or OPENAI_API_KEY). The optional model parameter overrides " +
+        "WEBREAPER_LLM_MODEL for this call. Costs one LLM call.")]
     public static async Task<string> ExtractWithPrompt(
         [Description("The URL to extract from.")] string url,
         [Description("Natural-language description of the data to extract.")] string prompt,
-        [Description("Use the headless browser (for JS-rendered pages). Auto-spawns a system Chrome / Chromium / Edge via WebReaper.Cdp. Default false.")] bool browser = false)
+        [Description("Use the headless browser (for JS-rendered pages). Auto-spawns a system Chrome / Chromium / Edge via WebReaper.Cdp. Default false.")] bool browser = false,
+        [Description("Optional model id, overriding WEBREAPER_LLM_MODEL for this call (e.g. gpt-4o-mini). The API key is never a parameter; it stays in the environment.")] string? model = null)
     {
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("URL is required.", nameof(url));
         if (string.IsNullOrWhiteSpace(prompt))
             throw new ArgumentException("Prompt is required.", nameof(prompt));
 
-        using var chatClient = CreateChatClient();
+        using var chatClient = CreateChatClient(model);
 
         var seed = browser
             ? ScraperEngineBuilder.CrawlWithBrowser(url)
@@ -212,25 +214,20 @@ public static class WebReaperTools
         }
     }
 
-    // ADR-0084: build the OpenAI-compatible chat client from environment config.
-    // The same explicit-config contract as the CLI: model + base URL are
-    // required; the API key is read from the environment only, never a param.
-    internal static OpenAiCompatibleChatClient CreateChatClient()
+    // ADR-0084 / ADR-0086: build the OpenAI-compatible chat client. Model +
+    // base URL are required (LlmConfig.Resolve throws actionably if missing);
+    // a per-call modelOverride wins over WEBREAPER_LLM_MODEL; the API key is
+    // read from the environment only, never a parameter.
+    internal static OpenAiCompatibleChatClient CreateChatClient(string? modelOverride = null)
     {
-        var model = Environment.GetEnvironmentVariable("WEBREAPER_LLM_MODEL");
-        var baseUrl = Environment.GetEnvironmentVariable("WEBREAPER_LLM_BASE_URL");
-        var apiKey = Environment.GetEnvironmentVariable("WEBREAPER_LLM_API_KEY")
-                  ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        var config = LlmConfig.Resolve(
+            modelOverride,
+            Environment.GetEnvironmentVariable(LlmConfig.ModelEnvVar),
+            Environment.GetEnvironmentVariable(LlmConfig.BaseUrlEnvVar),
+            Environment.GetEnvironmentVariable("WEBREAPER_LLM_API_KEY")
+                ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
 
-        if (string.IsNullOrWhiteSpace(model))
-            throw new InvalidOperationException(
-                "extract_with_prompt needs an LLM model: set the WEBREAPER_LLM_MODEL environment variable.");
-        if (string.IsNullOrWhiteSpace(baseUrl))
-            throw new InvalidOperationException(
-                "extract_with_prompt needs an LLM endpoint: set WEBREAPER_LLM_BASE_URL "
-                + "(e.g. https://api.openai.com/v1).");
-
-        return new OpenAiCompatibleChatClient(baseUrl, model, apiKey);
+        return new OpenAiCompatibleChatClient(config.BaseUrl, config.Model, config.ApiKey);
     }
 
     // Tiny JSON → Schema parser (same shape the CLI accepts, ADR-0043).

--- a/WebReaper.Tests/WebReaper.IntegrationTests/McpHttpServerTests.cs
+++ b/WebReaper.Tests/WebReaper.IntegrationTests/McpHttpServerTests.cs
@@ -70,6 +70,39 @@ public sealed class McpHttpServerTests
     }
 
     [Fact]
+    public async Task Bearer_token_gates_the_mcp_endpoint()
+    {
+        var (app, baseAddress) = await McpHttpServer.StartForTestAsync([], token: "secret");
+        await using (app)
+        {
+            // With the token: the handshake and tools/list succeed.
+            var authorized = new HttpClientTransport(new HttpClientTransportOptions
+            {
+                Endpoint = baseAddress,
+                TransportMode = HttpTransportMode.StreamableHttp,
+                AdditionalHeaders = new Dictionary<string, string> { ["Authorization"] = "Bearer secret" },
+            });
+            await using (var client = await McpClient.CreateAsync(authorized))
+            {
+                var names = (await client.ListToolsAsync()).Select(t => t.Name).ToHashSet();
+                Assert.Contains("scrape", names);
+            }
+
+            // Without the token: the handshake / first call is rejected.
+            var anonymous = new HttpClientTransport(new HttpClientTransportOptions
+            {
+                Endpoint = baseAddress,
+                TransportMode = HttpTransportMode.StreamableHttp,
+            });
+            await Assert.ThrowsAnyAsync<Exception>(async () =>
+            {
+                await using var client = await McpClient.CreateAsync(anonymous);
+                await client.ListToolsAsync();
+            });
+        }
+    }
+
+    [Fact]
     public async Task Health_endpoint_responds()
     {
         var (app, baseAddress) = await McpHttpServer.StartForTestAsync([]);

--- a/WebReaper.Tests/WebReaper.IntegrationTests/McpHttpServerTests.cs
+++ b/WebReaper.Tests/WebReaper.IntegrationTests/McpHttpServerTests.cs
@@ -1,0 +1,83 @@
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using WebReaper.IntegrationTests.Fixtures;
+using WebReaper.Mcp.AspNetCore;
+using WebReaper.TestServer;
+using Xunit;
+
+namespace WebReaper.IntegrationTests;
+
+/// <summary>
+/// ADR-0086: end-to-end coverage of the Streamable HTTP MCP host
+/// (WebReaper.Mcp.AspNetCore). The real host is started on a random loopback
+/// port and driven with the official MCP SDK client over Streamable HTTP, a
+/// true initialize -> tools/list -> tools/call handshake. The HTTP analog of
+/// McpServerTests (which does the same over stdio). Tools run against the
+/// deterministic local site. Tagged Mcp so the fast gate skips it (real HTTP
+/// stack + protocol startup per test).
+/// </summary>
+[Collection("LocalSite")]
+[Trait("Category", "Mcp")]
+public sealed class McpHttpServerTests
+{
+    private readonly LocalTestSite _site;
+
+    public McpHttpServerTests(LocalSiteFixture fixture) => _site = fixture.Site;
+
+    private static async Task<(McpClient Client, IAsyncDisposable App)> StartAsync()
+    {
+        var (app, baseAddress) = await McpHttpServer.StartForTestAsync([]);
+        var transport = new HttpClientTransport(new HttpClientTransportOptions
+        {
+            Endpoint = baseAddress,
+            TransportMode = HttpTransportMode.StreamableHttp,
+        });
+        var client = await McpClient.CreateAsync(transport);
+        return (client, app);
+    }
+
+    private static string FirstText(CallToolResult result) =>
+        result.Content.OfType<TextContentBlock>().First().Text;
+
+    [Fact]
+    public async Task Server_lists_the_tools_over_http()
+    {
+        var (client, app) = await StartAsync();
+        await using (app)
+        await using (client)
+        {
+            var names = (await client.ListToolsAsync()).Select(t => t.Name).ToHashSet();
+            Assert.Contains("scrape", names);
+            Assert.Contains("map", names);
+            Assert.Contains("extract", names);
+        }
+    }
+
+    [Fact]
+    public async Task Scrape_tool_returns_markdown_over_http()
+    {
+        var (client, app) = await StartAsync();
+        await using (app)
+        await using (client)
+        {
+            var result = await client.CallToolAsync(
+                "scrape",
+                new Dictionary<string, object?> { ["url"] = _site.Url("/static") },
+                cancellationToken: CancellationToken.None);
+
+            Assert.Contains("Widget Pro 3000", FirstText(result));
+        }
+    }
+
+    [Fact]
+    public async Task Health_endpoint_responds()
+    {
+        var (app, baseAddress) = await McpHttpServer.StartForTestAsync([]);
+        await using (app)
+        {
+            using var http = new HttpClient();
+            var response = await http.GetAsync(new Uri(baseAddress, "/health"));
+            Assert.True(response.IsSuccessStatusCode);
+        }
+    }
+}

--- a/WebReaper.Tests/WebReaper.IntegrationTests/McpHttpServerTests.cs
+++ b/WebReaper.Tests/WebReaper.IntegrationTests/McpHttpServerTests.cs
@@ -70,6 +70,28 @@ public sealed class McpHttpServerTests
     }
 
     [Fact]
+    public async Task Crawl_tool_returns_markdown_records_over_http()
+    {
+        var (client, app) = await StartAsync();
+        await using (app)
+        await using (client)
+        {
+            var names = (await client.ListToolsAsync()).Select(t => t.Name).ToHashSet();
+            Assert.Contains("crawl", names);
+
+            var result = await client.CallToolAsync(
+                "crawl",
+                new Dictionary<string, object?> { ["url"] = _site.BaseUrl, ["maxPages"] = 10 },
+                cancellationToken: CancellationToken.None);
+
+            var jsonl = FirstText(result);
+            Assert.False(string.IsNullOrWhiteSpace(jsonl));
+            // Markdown records carry a "markdown" field; JSON Lines = one per page.
+            Assert.Contains("markdown", jsonl);
+        }
+    }
+
+    [Fact]
     public async Task Bearer_token_gates_the_mcp_endpoint()
     {
         var (app, baseAddress) = await McpHttpServer.StartForTestAsync([], token: "secret");

--- a/WebReaper.Tests/WebReaper.IntegrationTests/WebReaper.IntegrationTests.csproj
+++ b/WebReaper.Tests/WebReaper.IntegrationTests/WebReaper.IntegrationTests.csproj
@@ -44,5 +44,6 @@
     <ProjectReference Include="..\..\WebReaper.Mongo\WebReaper.Mongo.csproj" />
     <ProjectReference Include="..\..\WebReaper.AI\WebReaper.AI.csproj" />
     <ProjectReference Include="..\..\WebReaper.Mcp\WebReaper.Mcp.csproj" />
+    <ProjectReference Include="..\..\WebReaper.Mcp.AspNetCore\WebReaper.Mcp.AspNetCore.csproj" />
   </ItemGroup>
 </Project>

--- a/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/BearerAuthTests.cs
+++ b/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/BearerAuthTests.cs
@@ -1,0 +1,34 @@
+using WebReaper.Mcp.AspNetCore;
+using Xunit;
+
+namespace WebReaper.Mcp.AspNetCore.Tests;
+
+// ADR-0086: the bearer-auth decision as a truth table.
+public class BearerAuthTests
+{
+    [Fact]
+    public void No_configured_token_authorizes_everything()
+    {
+        Assert.True(BearerAuth.IsAuthorized(null, null));
+        Assert.True(BearerAuth.IsAuthorized(null, "Bearer anything"));
+        Assert.True(BearerAuth.IsAuthorized("", "whatever"));
+    }
+
+    [Fact]
+    public void Matching_bearer_token_is_authorized()
+    {
+        Assert.True(BearerAuth.IsAuthorized("secret", "Bearer secret"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("secret")]              // missing the Bearer scheme
+    [InlineData("Bearer wrong")]        // wrong token
+    [InlineData("bearer secret")]       // scheme is case-sensitive
+    [InlineData("Basic secret")]        // wrong scheme
+    public void Missing_or_wrong_credentials_are_rejected(string? header)
+    {
+        Assert.False(BearerAuth.IsAuthorized("secret", header));
+    }
+}

--- a/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/BrowserTransportTests.cs
+++ b/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/BrowserTransportTests.cs
@@ -1,0 +1,56 @@
+using WebReaper.Mcp;
+using Xunit;
+
+namespace WebReaper.Mcp.AspNetCore.Tests;
+
+// ADR-0086: browser-transport selection is a closed truth table.
+public class BrowserTransportTests
+{
+    [Fact]
+    public void Browser_false_is_none()
+    {
+        var plan = BrowserTransport.Select(browser: false, cdpUrl: null);
+        Assert.Equal(BrowserLaunchMode.None, plan.Mode);
+        Assert.Null(plan.CdpUrl);
+    }
+
+    [Fact]
+    public void Browser_true_without_cdp_url_launches()
+    {
+        var plan = BrowserTransport.Select(browser: true, cdpUrl: null);
+        Assert.Equal(BrowserLaunchMode.Launch, plan.Mode);
+        Assert.Null(plan.CdpUrl);
+    }
+
+    [Fact]
+    public void Browser_true_with_cdp_url_connects()
+    {
+        var plan = BrowserTransport.Select(browser: true, cdpUrl: "  http://chrome:9222  ");
+        Assert.Equal(BrowserLaunchMode.Connect, plan.Mode);
+        Assert.Equal("http://chrome:9222", plan.CdpUrl);
+    }
+
+    [Fact]
+    public void Cdp_url_is_ignored_when_browser_is_false()
+    {
+        var plan = BrowserTransport.Select(browser: false, cdpUrl: "http://chrome:9222");
+        Assert.Equal(BrowserLaunchMode.None, plan.Mode);
+    }
+
+    [Fact]
+    public void Whitespace_cdp_url_falls_back_to_launch()
+    {
+        Assert.Equal(BrowserLaunchMode.Launch, BrowserTransport.Select(true, "   ").Mode);
+    }
+
+    [Theory]
+    [InlineData(null, 4)]
+    [InlineData("", 4)]
+    [InlineData("garbage", 4)]
+    [InlineData("0", 4)]
+    [InlineData("-2", 4)]
+    [InlineData("1", 1)]
+    [InlineData("16", 16)]
+    public void ResolveMaxConcurrentBrowsers_parses_a_positive_int_or_defaults(string? raw, int expected) =>
+        Assert.Equal(expected, BrowserTransport.ResolveMaxConcurrentBrowsers(raw));
+}

--- a/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/CrawlBoundsTests.cs
+++ b/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/CrawlBoundsTests.cs
@@ -1,0 +1,31 @@
+using WebReaper.Mcp;
+using Xunit;
+
+namespace WebReaper.Mcp.AspNetCore.Tests;
+
+// ADR-0086: the crawl page-cap guard.
+public class CrawlBoundsTests
+{
+    [Fact]
+    public void Default_value_passes_through() =>
+        Assert.Equal(50, CrawlBounds.Validate(CrawlBounds.DefaultMaxPages));
+
+    [Fact]
+    public void Within_range_is_unchanged() =>
+        Assert.Equal(200, CrawlBounds.Validate(200));
+
+    [Fact]
+    public void Above_the_hard_cap_is_clamped() =>
+        Assert.Equal(CrawlBounds.MaxAllowed, CrawlBounds.Validate(5000));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void Non_positive_is_rejected(int n) =>
+        Assert.Throws<ArgumentException>(() => CrawlBounds.Validate(n));
+
+    [Fact]
+    public void Default_is_small_relative_to_the_cap() =>
+        Assert.True(CrawlBounds.DefaultMaxPages < CrawlBounds.MaxAllowed);
+}

--- a/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/LlmConfigTests.cs
+++ b/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/LlmConfigTests.cs
@@ -1,0 +1,58 @@
+using WebReaper.Mcp;
+using Xunit;
+
+namespace WebReaper.Mcp.AspNetCore.Tests;
+
+// ADR-0086: LLM config resolution (per-call model override + env) and the
+// actionable-error validation, as a truth table. No env reads here.
+public class LlmConfigTests
+{
+    [Fact]
+    public void Per_call_model_wins_over_env()
+    {
+        var c = LlmConfig.Resolve("gpt-4o-mini", "env-model", "https://api.openai.com/v1", "key");
+        Assert.Equal("gpt-4o-mini", c.Model);
+    }
+
+    [Fact]
+    public void Env_model_used_when_no_override()
+    {
+        var c = LlmConfig.Resolve(null, "env-model", "https://host/v1", null);
+        Assert.Equal("env-model", c.Model);
+        Assert.Null(c.ApiKey);
+    }
+
+    [Fact]
+    public void Blank_override_falls_back_to_env_model()
+    {
+        Assert.Equal("env-model", LlmConfig.Resolve("   ", "env-model", "https://host", "k").Model);
+    }
+
+    [Fact]
+    public void Missing_model_throws_actionably()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => LlmConfig.Resolve(null, null, "https://host", "k"));
+        Assert.Contains(LlmConfig.ModelEnvVar, ex.Message);
+    }
+
+    [Fact]
+    public void Missing_base_url_throws_actionably()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => LlmConfig.Resolve("model", null, null, "k"));
+        Assert.Contains(LlmConfig.BaseUrlEnvVar, ex.Message);
+    }
+
+    [Fact]
+    public void Blank_api_key_becomes_null()
+    {
+        Assert.Null(LlmConfig.Resolve("model", null, "https://host", "   ").ApiKey);
+    }
+
+    [Fact]
+    public void Base_url_is_trimmed()
+    {
+        Assert.Equal("https://host", LlmConfig.Resolve("model", null, "  https://host  ", null).BaseUrl);
+    }
+}

--- a/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/McpHttpOptionsTests.cs
+++ b/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/McpHttpOptionsTests.cs
@@ -1,0 +1,68 @@
+using WebReaper.Mcp.AspNetCore;
+using Xunit;
+
+namespace WebReaper.Mcp.AspNetCore.Tests;
+
+// ADR-0086: the config validator is a closed truth table (no IO). The
+// load-bearing rule is "refuse a non-loopback bind without a token".
+public class McpHttpOptionsTests
+{
+    [Fact]
+    public void Loopback_without_token_is_allowed_and_auth_is_off()
+    {
+        var options = McpHttpOptions.Validate(null, ["http://localhost:5000"]);
+        Assert.Null(options.BearerToken);
+        Assert.False(options.RequireAuth);
+    }
+
+    [Fact]
+    public void Loopback_with_token_enables_auth()
+    {
+        var options = McpHttpOptions.Validate("secret", ["http://127.0.0.1:8080"]);
+        Assert.Equal("secret", options.BearerToken);
+        Assert.True(options.RequireAuth);
+    }
+
+    [Fact]
+    public void Non_loopback_without_token_is_refused()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => McpHttpOptions.Validate(null, ["http://0.0.0.0:8080"]));
+        Assert.Contains(McpHttpOptions.TokenEnvVar, ex.Message);
+    }
+
+    [Fact]
+    public void Non_loopback_with_token_is_allowed()
+    {
+        var options = McpHttpOptions.Validate("secret", ["http://0.0.0.0:8080"]);
+        Assert.True(options.RequireAuth);
+    }
+
+    [Fact]
+    public void Whitespace_token_is_treated_as_no_token()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => McpHttpOptions.Validate("   ", ["http://example.com"]));
+        Assert.False(McpHttpOptions.Validate("  ", ["http://localhost"]).RequireAuth);
+    }
+
+    [Theory]
+    [InlineData("http://localhost:5000", true)]
+    [InlineData("http://127.0.0.1:8080", true)]
+    [InlineData("http://[::1]:8080", true)]
+    [InlineData("https://localhost", true)]
+    [InlineData("http://0.0.0.0:8080", false)]
+    [InlineData("http://+:80", false)]
+    [InlineData("http://*:80", false)]
+    [InlineData("http://example.com", false)]
+    [InlineData("http://192.168.1.10:8080", false)]
+    public void IsLoopback_classifies_bind_urls(string url, bool expected) =>
+        Assert.Equal(expected, McpHttpOptions.IsLoopback(url));
+
+    [Fact]
+    public void Mixed_binds_require_a_token_if_any_is_non_loopback()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => McpHttpOptions.Validate(null, ["http://localhost:5000", "http://0.0.0.0:8080"]));
+    }
+}

--- a/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/WebReaper.Mcp.AspNetCore.Tests.csproj
+++ b/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/WebReaper.Mcp.AspNetCore.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!-- The host references the ASP.NET shared framework; load it so the
+       host assembly resolves at runtime even though the pure modules under
+       test touch no ASP.NET types. -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\WebReaper.Mcp.AspNetCore\WebReaper.Mcp.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\WebReaper.Mcp\WebReaper.Mcp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/WebReaper.sln
+++ b/WebReaper.sln
@@ -92,6 +92,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.AI.Http", "WebRea
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.AI.Http.Tests", "WebReaper.Tests\WebReaper.AI.Http.Tests\WebReaper.AI.Http.Tests.csproj", "{E6147E28-04BA-4BB2-A22E-19BC185C94DB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.Mcp.AspNetCore", "WebReaper.Mcp.AspNetCore\WebReaper.Mcp.AspNetCore.csproj", "{D058AB6E-9124-444E-8633-4B8110522B79}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -558,6 +560,18 @@ Global
 		{E6147E28-04BA-4BB2-A22E-19BC185C94DB}.Release|x64.Build.0 = Release|Any CPU
 		{E6147E28-04BA-4BB2-A22E-19BC185C94DB}.Release|x86.ActiveCfg = Release|Any CPU
 		{E6147E28-04BA-4BB2-A22E-19BC185C94DB}.Release|x86.Build.0 = Release|Any CPU
+		{D058AB6E-9124-444E-8633-4B8110522B79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D058AB6E-9124-444E-8633-4B8110522B79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D058AB6E-9124-444E-8633-4B8110522B79}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D058AB6E-9124-444E-8633-4B8110522B79}.Debug|x64.Build.0 = Debug|Any CPU
+		{D058AB6E-9124-444E-8633-4B8110522B79}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D058AB6E-9124-444E-8633-4B8110522B79}.Debug|x86.Build.0 = Debug|Any CPU
+		{D058AB6E-9124-444E-8633-4B8110522B79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D058AB6E-9124-444E-8633-4B8110522B79}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D058AB6E-9124-444E-8633-4B8110522B79}.Release|x64.ActiveCfg = Release|Any CPU
+		{D058AB6E-9124-444E-8633-4B8110522B79}.Release|x64.Build.0 = Release|Any CPU
+		{D058AB6E-9124-444E-8633-4B8110522B79}.Release|x86.ActiveCfg = Release|Any CPU
+		{D058AB6E-9124-444E-8633-4B8110522B79}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WebReaper.sln
+++ b/WebReaper.sln
@@ -94,6 +94,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.AI.Http.Tests", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.Mcp.AspNetCore", "WebReaper.Mcp.AspNetCore\WebReaper.Mcp.AspNetCore.csproj", "{D058AB6E-9124-444E-8633-4B8110522B79}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebReaper.Mcp.AspNetCore.Tests", "WebReaper.Tests\WebReaper.Mcp.AspNetCore.Tests\WebReaper.Mcp.AspNetCore.Tests.csproj", "{0BC53D71-8D5B-4055-9D26-A60A44448B0C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -572,6 +574,18 @@ Global
 		{D058AB6E-9124-444E-8633-4B8110522B79}.Release|x64.Build.0 = Release|Any CPU
 		{D058AB6E-9124-444E-8633-4B8110522B79}.Release|x86.ActiveCfg = Release|Any CPU
 		{D058AB6E-9124-444E-8633-4B8110522B79}.Release|x86.Build.0 = Release|Any CPU
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C}.Debug|x64.Build.0 = Debug|Any CPU
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C}.Debug|x86.Build.0 = Debug|Any CPU
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C}.Release|x64.ActiveCfg = Release|Any CPU
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C}.Release|x64.Build.0 = Release|Any CPU
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C}.Release|x86.ActiveCfg = Release|Any CPU
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -599,6 +613,7 @@ Global
 		{363D15C8-D7B3-4783-8F0B-C0ABD6456F84} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
 		{3F16CBE7-DFA7-44B3-89C2-F7E3B75FEA46} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
 		{E6147E28-04BA-4BB2-A22E-19BC185C94DB} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
+		{0BC53D71-8D5B-4055-9D26-A60A44448B0C} = {13348F52-7CE2-02CA-9AD9-07ADD8A5D840}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8413198B-8D26-4E30-A5E2-E0FBC4DCEA59}

--- a/docs/mcp-http-quickstart.md
+++ b/docs/mcp-http-quickstart.md
@@ -1,0 +1,67 @@
+# WebReaper MCP over HTTP (n8n quickstart)
+
+`WebReaper.Mcp.AspNetCore` (ADR-0086) serves WebReaper's scraping tools over
+**Streamable HTTP**, so URL-based MCP clients like **n8n** can reach them. The
+stdio `WebReaper.Mcp` satellite stays the choice for local process-spawning
+agents (Cursor, Claude Desktop); use this when the client connects to a URL.
+
+## Tools
+
+`scrape`, `map`, `extract`, `extract_with_prompt`, and `crawl`. Same tools as the
+stdio satellite (one shared `WebReaperTools`).
+
+- `crawl` is a single long **blocking** call with no progress feedback, bounded
+  by `maxPages` (default 50, hard cap 1000). For a large site prefer `map` to
+  list URLs, then `scrape` each, so every call stays short.
+
+## Run it (Docker)
+
+The image bakes a headless Chromium, so `browser=true` works out of the box.
+
+```bash
+docker build -f WebReaper.Mcp.AspNetCore/Dockerfile -t webreaper-mcp-http .
+
+docker run --rm -p 8080:8080 \
+  -e WEBREAPER_MCP_TOKEN=change-me-to-a-long-random-secret \
+  webreaper-mcp-http
+```
+
+`WEBREAPER_MCP_TOKEN` is **required** here: the server binds all interfaces in
+the container, and the bind guard refuses a non-loopback bind without a token
+(an unauthenticated network-reachable scraper is an SSRF amplifier). For local
+development without Docker you can bind loopback and omit the token:
+
+```bash
+dotnet run --project WebReaper.Mcp.AspNetCore   # http://localhost:5000, no token
+```
+
+A `docker-compose.example.yml` next to the Dockerfile runs it alongside n8n,
+with an optional browser sidecar.
+
+## Wire it into n8n
+
+In your workflow add an **MCP Client Tool** node:
+
+| Field | Value |
+|---|---|
+| Server Transport | HTTP Streamable |
+| MCP Endpoint URL | `http://webreaper-mcp:8080` (same Docker network) or your server URL |
+| Authentication | Bearer, value = your `WEBREAPER_MCP_TOKEN` |
+
+n8n fetches the tool list automatically. Attach the node to an AI Agent, or call
+a tool directly, then iterate over results with n8n's own nodes (e.g. `map` then
+a Loop/Split that `scrape`s each URL).
+
+## Configuration (environment)
+
+| Variable | Purpose |
+|---|---|
+| `WEBREAPER_MCP_TOKEN` | Bearer token. Mandatory off-loopback. |
+| `WEBREAPER_CDP_URL` | Connect `browser=true` to a shared CDP / browserless sidecar instead of launching Chromium. |
+| `WEBREAPER_MCP_MAX_CONCURRENT_BROWSERS` | Cap on concurrent managed-Chromium launches (default 4). |
+| `WEBREAPER_LLM_MODEL` / `WEBREAPER_LLM_BASE_URL` / `WEBREAPER_LLM_API_KEY` | OpenAI-compatible endpoint for `extract_with_prompt`. The key is environment-only; `extract_with_prompt` takes an optional per-call `model` override. |
+
+## Scope
+
+Single-tenant, self-run. Multi-tenant hosting, per-tenant LLM/browser, and
+progress streaming are out of scope (see ADR-0086).

--- a/docs/mcp-http-quickstart.md
+++ b/docs/mcp-http-quickstart.md
@@ -17,13 +17,20 @@ stdio satellite (one shared `WebReaperTools`).
 ## Run it (Docker)
 
 The image bakes a headless Chromium, so `browser=true` works out of the box.
+Each release publishes it to GHCR as
+`ghcr.io/pavlovtech/webreaper-mcp-http:<version>` (and `:latest`):
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e WEBREAPER_MCP_TOKEN=change-me-to-a-long-random-secret \
+  ghcr.io/pavlovtech/webreaper-mcp-http:latest
+```
+
+Or build it yourself (context = repo root):
 
 ```bash
 docker build -f WebReaper.Mcp.AspNetCore/Dockerfile -t webreaper-mcp-http .
-
-docker run --rm -p 8080:8080 \
-  -e WEBREAPER_MCP_TOKEN=change-me-to-a-long-random-secret \
-  webreaper-mcp-http
+docker run --rm -p 8080:8080 -e WEBREAPER_MCP_TOKEN=change-me webreaper-mcp-http
 ```
 
 `WEBREAPER_MCP_TOKEN` is **required** here: the server binds all interfaces in


### PR DESCRIPTION
Implements **ADR-0086** (design PR #238) and PRD #239: a Streamable HTTP MCP host so URL-based clients (the driver: **n8n**) can reach WebReaper, since the stdio satellite is unreachable from n8n's URL-only MCP client.

Seven tracer-bullet slices, each committed separately with its own tests:

| Slice | What |
|---|---|
| #240 | New `WebReaper.Mcp.AspNetCore` host: Streamable HTTP (stateless) + `MapMcp` + `/health`, reusing `WebReaperTools` |
| #241 | Bearer auth (`WEBREAPER_MCP_TOKEN`) + non-loopback-without-token bind guard |
| #243 | `WEBREAPER_CDP_URL` browser-transport selection (shared in `WebReaper.Mcp`, so stdio gains it too) + launch concurrency cap |
| #242 | Bounded `crawl` tool (default 50, hard cap 1000, loud no-progress caveat) |
| #244 | Per-call `model` override on `extract_with_prompt` + `LlmConfig` validation |
| #245 | Chromium-baked Dockerfile + `docker-compose.example.yml` + n8n quickstart |
| #246 | Release: `CANDIDATES` + GHCR image-publish job |

## Tests
- **49 unit tests** (pure truth tables): `McpHttpOptions`, `BearerAuth`, `BrowserTransport`, `CrawlBounds`, `LlmConfig`.
- **9 MCP integration tests**: 5 new HTTP-host (`McpHttpServerTests`: tools/list, scrape, crawl, auth gate, `/health`) + the 4 existing stdio (`McpServerTests`, still green after the shared `WebReaperTools` refactor).
- Full-solution Release build: 0 errors.

## Decisions worth a look
- **GHCR** is the registry default for #246 (GitHub-native, `GITHUB_TOKEN` auth, no new secret). This was the slice's HITL call; change the registry in `release.yml` if you want Docker Hub instead.
- The `WEBREAPER_CDP_URL` logic lives in the **shared** `WebReaper.Mcp` (the ADR-0086 amendment in PR #238), so the stdio host also gained CDP-sidecar support.
- The container image binds all interfaces, so the bind guard **requires** `WEBREAPER_MCP_TOKEN`: `docker run` without one fails actionably (secure by default).

## Not verified here
- The **container smoke** (`docker build` + `docker run` -> `/health` + a tools/call) could not run in this environment (no Docker). `dotnet publish` of the host (the build path the image runs) is green; the image job will exercise the rest on the first release.

Closes #240
Closes #241
Closes #242
Closes #243
Closes #244
Closes #245
Closes #246

Parent PRD: #239. Design: #238 (ADR-0086).

🤖 Generated with [Claude Code](https://claude.com/claude-code)