### PR TITLE
fix(mcp): make WebReaper.Mcp.AspNetCore packable (v11.2.0 release fix)

### DIFF
--- a/WebReaper.Mcp.AspNetCore/WebReaper.Mcp.AspNetCore.csproj
+++ b/WebReaper.Mcp.AspNetCore/WebReaper.Mcp.AspNetCore.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- Microsoft.NET.Sdk.Web defaults IsPackable=false; opt in so the host
+         ships as a NuGet package (embeddable via the public McpHttpServer API)
+         in lockstep with the other satellites, alongside the container image. -->
+    <IsPackable>true</IsPackable>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>WebReaper.Mcp.AspNetCore</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
The v11.2.0 release run failed at the **reversible pack stage** (before the NuGet gate, so nothing published): `Verify packed artifacts` reported `expected 15 .nupkg, got 14`.

**Cause:** `Microsoft.NET.Sdk.Web` defaults `IsPackable=false`, so the new `WebReaper.Mcp.AspNetCore` host produced no `.nupkg`.

**Fix:** `<IsPackable>true</IsPackable>`. The host packs cleanly as `WebReaper.Mcp.AspNetCore.11.2.0.nupkg` (verified locally; nuspec version 11.2.0). It is genuinely useful as a package too: `McpHttpServer.Build()` is public, so it can be embedded in another ASP.NET host. The `NU5104` prerelease-dependency warning is identical to the existing `WebReaper.Mcp` package and is not an error.

After merge I'll move the `v11.2.0` tag to the fix commit and re-trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)