### PR TITLE
docs: README + website MCP docs for the HTTP server (n8n)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,19 @@ Writes a polished `SKILL.md` to `.claude/skills/webreaper/`. Claude Code loads i
 
 ### MCP server
 
-The [`WebReaper.Mcp`](https://www.nuget.org/packages/WebReaper.Mcp) satellite (ADR-0049) exposes `scrape`, `map`, `extract` as MCP tools over stdio, for clients that can't reach the CLI directly (Cursor, Claude Desktop, Copilot Studio). It's a thin facade over the library API; primary agent surface remains the CLI.
+Two MCP servers expose the same tools (`scrape`, `map`, `extract`, `extract_with_prompt`, `crawl`) for clients that speak the Model Context Protocol:
+
+- **[`WebReaper.Mcp`](https://www.nuget.org/packages/WebReaper.Mcp)** (ADR-0049) speaks **stdio**, for local clients that spawn a process: Cursor, Claude Desktop, Copilot Studio.
+- **[`WebReaper.Mcp.AspNetCore`](https://www.nuget.org/packages/WebReaper.Mcp.AspNetCore)** (ADR-0086) speaks **Streamable HTTP**, for clients that connect to a URL. The headline case is **n8n**, whose MCP Client node is URL-only and cannot reach a stdio server. Run the Chromium-baked image, point n8n's MCP Client node at the URL with a bearer token, and call the tools from a workflow:
+
+  ```bash
+  docker run -p 8080:8080 -e WEBREAPER_MCP_TOKEN=your-secret \
+    ghcr.io/pavlovtech/webreaper-mcp-http:latest
+  ```
+
+  See the [n8n quickstart](docs/mcp-http-quickstart.md).
+
+Both are thin facades over the library API; the primary agent surface remains the CLI.
 
 ### CLI inside any agent harness
 
@@ -283,7 +295,7 @@ dotnet run --project Examples/WebReaper.AiNativeShowcase -- changetrack
 
 ## Packages
 
-The release ships thirteen packages (one core, twelve satellites), all versioned in lockstep at `11.0.0`. The core stays dependency-light and Native-AOT-publishable with zero warnings; satellites bring their own SDK dependencies and quarantine them off the core graph (ADR-0009).
+The release ships fifteen packages (one core, fourteen satellites), all versioned in lockstep. The core stays dependency-light and Native-AOT-publishable with zero warnings; satellites bring their own SDK dependencies and quarantine them off the core graph (ADR-0009).
 
 | Package | Add it for | Key builder calls |
 |---|---|---|
@@ -292,9 +304,11 @@ The release ships thirteen packages (one core, twelve satellites), all versioned
 | **WebReaper.Playwright** | Microsoft.Playwright-backed transport (ADR-0053). Multi-browser (Chromium default; Firefox / WebKit opt-in). All ten `PageAction` arms supported. Use for modern multi-browser needs; pair with `WebReaper.Cdp` for AOT or stealth. | `.WithPlaywrightPageLoader()` |
 | **WebReaper.Stealth.CloakBrowser** | First stealth-backend satellite (ADR-0054). Auto-downloads CloakBrowser on first use; composes on `WebReaper.Cdp`. Disposable via the ADR-0058 engine teardown chain. | `.WithCloakBrowser()` |
 | **WebReaper.AI** | LLM extraction, LLM action resolver, LLM brain, LLM self-healing, LLM schema inferrer (ADR-0044 / 0050 / 0051 / 0067). Built on `Microsoft.Extensions.AI`; bring your own `IChatClient`. | `.WithLlmFallback` `.WithLlmSelfHealing` `.WithLlmExtractor` `.WithLlmAgentBrain` `.WithLlmActionResolver` `.WithLlmSchemaInferrer` `.UseAi(client)` |
+| **WebReaper.AI.Http** | AOT-safe OpenAI-compatible `IChatClient` (ADR-0084): raw `HttpClient` plus System.Text.Json source-gen, no provider SDK. The bring-your-own client the AOT CLI and the MCP servers use for prompt extraction. | `new OpenAiCompatibleChatClient(baseUrl, model, apiKey)` |
 | **WebReaper.Extraction.Attributes** | The `[ScrapeSchema]` / `[ScrapeField]` marker types. Standalone, no runtime cost. | `[ScrapeSchema]` `[ScrapeField("selector")]` |
 | **WebReaper.Extraction.Generators** | Roslyn source generator that emits `static Schema` plus reflection-free `static Materialize(JsonObject)` (ADR-0045). `DevelopmentDependency=true`; does not propagate at runtime. | compile-time only |
-| **WebReaper.Mcp** | MCP server `Exe` exposing scrape / map / extract as MCP tools over stdio (ADR-0049). Interop adapter for MCP-only clients. | the package _is_ the executable |
+| **WebReaper.Mcp** | MCP server `Exe` exposing scrape / map / extract / extract_with_prompt / crawl as MCP tools over **stdio** (ADR-0049). Interop adapter for local MCP clients (Cursor, Claude Desktop). | the package _is_ the executable |
+| **WebReaper.Mcp.AspNetCore** | MCP server over **Streamable HTTP** (ADR-0086) for URL-based clients like n8n; same tools as `WebReaper.Mcp`, plus bearer-token auth and a `WEBREAPER_CDP_URL` browser sidecar. Also ships as a Chromium-baked container image. | the package _is_ the executable; or `docker run ghcr.io/pavlovtech/webreaper-mcp-http` |
 | **WebReaper.Mongo** | MongoDB result sink and MongoDB-backed config / cookie storage. | `.WriteToMongoDb(...)` `.WithMongoDbConfigStorage(...)` `.WithMongoDbCookieStorage(...)` |
 | **WebReaper.Redis** | Redis scheduler, visited-link tracker, result sink, config / cookie storage. | `.WithRedisScheduler(...)` `.TrackVisitedLinksInRedis(...)` `.WriteToRedis(...)` `.WithRedisConfigStorage(...)` `.WithRedisCookieStorage(...)` |
 | **WebReaper.AzureServiceBus** | Distributed scheduler over an Azure Service Bus queue. | `.WithAzureServiceBusScheduler(...)` |

--- a/website/content/docs/mcp-server.mdx
+++ b/website/content/docs/mcp-server.mdx
@@ -1,47 +1,87 @@
 ---
 title: MCP server
-description: Expose WebReaper as MCP tools for Cursor, Claude Desktop, and Copilot Studio.
+description: Expose WebReaper as MCP tools over stdio or Streamable HTTP, for Cursor, Claude Desktop, Copilot Studio, and n8n.
 category: Integrations
 order: 1
 ---
 
 For agent clients that speak the Model Context Protocol, WebReaper ships an MCP
 server. It surfaces the same scraping capabilities as tools, so an MCP-only
-client can scrape, map, and extract without shelling out to the CLI itself.
+client can scrape, map, crawl, and extract without shelling out to the CLI itself.
+
+There are two servers, same tools, different transports:
+
+- **`WebReaper.Mcp`** speaks **stdio**, the transport local clients use when they
+  spawn the server as a child process (Cursor, Claude Desktop, Copilot Studio).
+- **`WebReaper.Mcp.AspNetCore`** speaks **Streamable HTTP**, for clients that
+  connect to a URL instead. The headline case is **n8n**, whose MCP Client node
+  is URL-only and cannot reach a stdio server.
 
 ## What it provides
 
-The `WebReaper.Mcp` satellite exposes WebReaper's core operations as MCP tools:
+Both servers expose WebReaper's core operations as MCP tools:
 
-- scrape a page to clean Markdown
-- map a site to discover its URLs
-- extract structured data with a JSON schema
-- extract structured data by a natural-language prompt, with an LLM (`extract_with_prompt`)
-
-Any MCP-capable client can call these, including:
-
-- Cursor
-- Claude Desktop
-- Copilot Studio
+- `scrape` a page to clean Markdown
+- `map` a site to discover its URLs
+- `extract` structured data with a JSON schema
+- `extract_with_prompt` structured data by a natural-language prompt, with an LLM
+- `crawl` a whole site: a bounded on-domain sweep returning one Markdown record per page
 
 The `extract_with_prompt` tool calls an LLM, so it needs an OpenAI-compatible
 endpoint configured on the MCP host: set `WEBREAPER_LLM_MODEL` and
 `WEBREAPER_LLM_BASE_URL` (for example `https://api.openai.com/v1`, or
 `http://localhost:11434/v1` for a local Ollama), with the API key in
-`WEBREAPER_LLM_API_KEY` (or `OPENAI_API_KEY`). The other tools need no setup.
+`WEBREAPER_LLM_API_KEY` (or `OPENAI_API_KEY`). It also takes an optional per-call
+`model` parameter that overrides `WEBREAPER_LLM_MODEL` for that one call. The
+other tools need no setup.
+
+`crawl` is a single long **blocking** call with no progress feedback, bounded by
+`maxPages` (default 50, hard cap 1000). For a large site, prefer `map` to list
+the URLs and then `scrape` each, so every call stays short.
+
+## Use it with n8n
+
+Run the HTTP server. The container image bakes a headless Chromium, so
+`browser=true` works out of the box:
+
+```bash
+docker run -p 8080:8080 -e WEBREAPER_MCP_TOKEN=your-secret \
+  ghcr.io/pavlovtech/webreaper-mcp-http:latest
+```
+
+`WEBREAPER_MCP_TOKEN` is required here: the server binds all interfaces in the
+container, and it refuses to start on a non-loopback interface without a token,
+so an unauthenticated public scraper is structurally prevented.
+
+Then add an **MCP Client Tool** node in your n8n workflow:
+
+- Server Transport: **HTTP Streamable** (not the deprecated SSE)
+- MCP Endpoint URL: the server URL (for example `http://webreaper-mcp:8080` when
+  both run on the same Docker network, or `http://host.docker.internal:8080`)
+- Authentication: **Bearer**, value = your `WEBREAPER_MCP_TOKEN`
+
+n8n fetches the tool list automatically. Attach the node to an AI Agent, or call
+a tool directly and iterate over results with n8n's own nodes (for example `map`,
+then a loop that `scrape`s each URL).
+
+To share one browser pool instead of launching Chromium per call, set
+`WEBREAPER_CDP_URL` to an external CDP endpoint (a browserless sidecar);
+`WEBREAPER_MCP_MAX_CONCURRENT_BROWSERS` caps concurrent launches otherwise.
 
 ## When to reach for it
 
 If you are using Claude Code, the bundled [Claude Code skill](/docs/claude-code-skill)
 is the simpler path: it routes plain-language requests to the CLI directly. The
-MCP server is the right adapter for clients that do not run shell commands and
-talk to tools over MCP instead.
+MCP servers are the right adapter for clients that talk to tools over MCP, the
+stdio one for local process-spawning clients and the HTTP one for URL-based
+clients like n8n. The scope is single-tenant, self-run; a hosted multi-tenant
+endpoint is future work.
 
 ## Version pinning
 
-The MCP satellite is built on the preview `ModelContextProtocol` SDK. Because it
-is a preview dependency, pin the package version explicitly when you ship, so a
-later preview release does not change behavior under you:
+The MCP satellites are built on the preview `ModelContextProtocol` SDK. Because
+it is a preview dependency, pin the package version explicitly when you ship, so
+a later preview release does not change behavior under you:
 
 ```bash
 dotnet add package WebReaper.Mcp --version <pinned-version>


### PR DESCRIPTION
Documents the v11.2.0 MCP-over-HTTP work (ADR-0086).

**README**
- Rewrote the **MCP server** section: two servers (stdio `WebReaper.Mcp` + Streamable HTTP `WebReaper.Mcp.AspNetCore`), the n8n case, and a `docker run` line.
- Updated the `WebReaper.Mcp` row to the current **5-tool** surface (`scrape`, `map`, `extract`, `extract_with_prompt`, `crawl`) and added a **`WebReaper.Mcp.AspNetCore`** row.
- Corrected the stale Packages intro ("thirteen packages ... at `11.0.0`", and the table was missing `WebReaper.AI.Http`) to **fifteen packages, version-agnostic**, and added the missing `WebReaper.AI.Http` row.

**Website** (`website/content/docs/mcp-server.mdx`)
- Rewrote for both transports, the five tools, the per-call `model` override, and an **n8n quickstart** (Chromium-baked image, bearer token, Streamable HTTP node config, `WEBREAPER_CDP_URL` sidecar).

Docs nav is auto-derived from Velite frontmatter (unchanged page, same category), so no nav edit. The **Vercel preview check on this PR builds the site and validates the MDX** (I didn't install deps in the worktree for a local build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)