### PR TITLE
feat(mcp): progress notifications + extract_inferred tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Writes a polished `SKILL.md` to `.claude/skills/webreaper/`. Claude Code loads i
 
 ### MCP server
 
-Two MCP servers expose the same tools (`scrape`, `map`, `extract`, `extract_with_prompt`, `crawl`) for clients that speak the Model Context Protocol:
+Two MCP servers expose the same tools (`scrape`, `map`, `extract`, `extract_with_prompt`, `extract_inferred`, `crawl`) for clients that speak the Model Context Protocol:
 
 - **[`WebReaper.Mcp`](https://www.nuget.org/packages/WebReaper.Mcp)** (ADR-0049) speaks **stdio**, for local clients that spawn a process: Cursor, Claude Desktop, Copilot Studio.
 - **[`WebReaper.Mcp.AspNetCore`](https://www.nuget.org/packages/WebReaper.Mcp.AspNetCore)** (ADR-0086) speaks **Streamable HTTP**, for clients that connect to a URL. The headline case is **n8n**, whose MCP Client node is URL-only and cannot reach a stdio server. Run the Chromium-baked image, point n8n's MCP Client node at the URL with a bearer token, and call the tools from a workflow:
@@ -307,7 +307,7 @@ The release ships fifteen packages (one core, fourteen satellites), all versione
 | **WebReaper.AI.Http** | AOT-safe OpenAI-compatible `IChatClient` (ADR-0084): raw `HttpClient` plus System.Text.Json source-gen, no provider SDK. The bring-your-own client the AOT CLI and the MCP servers use for prompt extraction. | `new OpenAiCompatibleChatClient(baseUrl, model, apiKey)` |
 | **WebReaper.Extraction.Attributes** | The `[ScrapeSchema]` / `[ScrapeField]` marker types. Standalone, no runtime cost. | `[ScrapeSchema]` `[ScrapeField("selector")]` |
 | **WebReaper.Extraction.Generators** | Roslyn source generator that emits `static Schema` plus reflection-free `static Materialize(JsonObject)` (ADR-0045). `DevelopmentDependency=true`; does not propagate at runtime. | compile-time only |
-| **WebReaper.Mcp** | MCP server `Exe` exposing scrape / map / extract / extract_with_prompt / crawl as MCP tools over **stdio** (ADR-0049). Interop adapter for local MCP clients (Cursor, Claude Desktop). | the package _is_ the executable |
+| **WebReaper.Mcp** | MCP server `Exe` exposing scrape / map / extract / extract_with_prompt / extract_inferred / crawl as MCP tools over **stdio** (ADR-0049). Interop adapter for local MCP clients (Cursor, Claude Desktop). | the package _is_ the executable |
 | **WebReaper.Mcp.AspNetCore** | MCP server over **Streamable HTTP** (ADR-0086) for URL-based clients like n8n; same tools as `WebReaper.Mcp`, plus bearer-token auth and a `WEBREAPER_CDP_URL` browser sidecar. Also ships as a Chromium-baked container image. | the package _is_ the executable; or `docker run ghcr.io/pavlovtech/webreaper-mcp-http` |
 | **WebReaper.Mongo** | MongoDB result sink and MongoDB-backed config / cookie storage. | `.WriteToMongoDb(...)` `.WithMongoDbConfigStorage(...)` `.WithMongoDbCookieStorage(...)` |
 | **WebReaper.Redis** | Redis scheduler, visited-link tracker, result sink, config / cookie storage. | `.WithRedisScheduler(...)` `.TrackVisitedLinksInRedis(...)` `.WriteToRedis(...)` `.WithRedisConfigStorage(...)` `.WithRedisCookieStorage(...)` |

--- a/WebReaper.Mcp/McpProgressClimbObserver.cs
+++ b/WebReaper.Mcp/McpProgressClimbObserver.cs
@@ -1,0 +1,54 @@
+using ModelContextProtocol;
+using WebReaper.Core.Loaders.Abstract;
+
+namespace WebReaper.Mcp;
+
+// ADR-0085 + ADR-0086: forward EscalatingPageLoader climb steps to MCP progress
+// notifications, so an interactive MCP client (Claude Desktop, Cursor, Inspector)
+// shows live progress during a long crawl or a browser climb. n8n's node is
+// blocking and will not render these; this is for clients that do.
+//
+// OnStep runs on the load hot path and may run concurrently (a sweep loads pages
+// under Parallel.ForEachAsync), so the counter is interlocked and IProgress.Report
+// is the cheap, non-blocking, thread-safe sink the seam requires; it never throws
+// back into the loader.
+internal sealed class McpProgressClimbObserver : IClimbObserver
+{
+    private readonly IProgress<ProgressNotificationValue> _progress;
+    private readonly int? _total;
+    private int _completed;
+
+    public McpProgressClimbObserver(IProgress<ProgressNotificationValue> progress, int? total)
+    {
+        _progress = progress;
+        _total = total;
+    }
+
+    public void OnStep(ClimbStep step)
+    {
+        switch (step.Phase)
+        {
+            case ClimbPhase.Succeeded:
+                Report(Interlocked.Increment(ref _completed), $"loaded {step.Url}");
+                break;
+            case ClimbPhase.Climbing:
+                Report(_completed, $"climbing to a stronger tier for {step.Url}");
+                break;
+            case ClimbPhase.Blocked:
+                Report(_completed, $"blocked at tier {step.TierIndex}; climbing");
+                break;
+            case ClimbPhase.Exhausted:
+                Report(_completed, $"top tier still blocked for {step.Url}");
+                break;
+            // Attempt is too noisy to surface.
+        }
+    }
+
+    private void Report(int done, string message) =>
+        _progress.Report(new ProgressNotificationValue
+        {
+            Progress = done,
+            Total = _total,
+            Message = message,
+        });
+}

--- a/WebReaper.Mcp/WebReaper.Mcp.csproj
+++ b/WebReaper.Mcp/WebReaper.Mcp.csproj
@@ -48,4 +48,10 @@
     <None Include="..\WebReaper\logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- ADR-0086: the progress-observer adapter is internal glue; the unit
+         tests for its climb-step -> MCP-progress translation live next door. -->
+    <InternalsVisibleTo Include="WebReaper.Mcp.AspNetCore.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/WebReaper.Mcp/WebReaperTools.cs
+++ b/WebReaper.Mcp/WebReaperTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text;
 using System.Text.Json.Nodes;
+using ModelContextProtocol;
 using ModelContextProtocol.Server;
 using WebReaper.AI;
 using WebReaper.AI.Http;
@@ -25,7 +26,8 @@ public static class WebReaperTools
         "into context.")]
     public static async Task<string> Scrape(
         [Description("The URL to scrape.")] string url,
-        [Description("Use the headless browser (for JS-rendered pages). Auto-spawns a system Chrome / Chromium / Edge via WebReaper.Cdp; install a Chromium-family browser on the MCP host first. Default false.")] bool browser = false)
+        [Description("Use the headless browser (for JS-rendered pages). Auto-spawns a system Chrome / Chromium / Edge via WebReaper.Cdp; install a Chromium-family browser on the MCP host first. Default false.")] bool browser = false,
+        IProgress<ProgressNotificationValue>? progress = null)
     {
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("URL is required.", nameof(url));
@@ -41,7 +43,8 @@ public static class WebReaperTools
 
         // ADR-0073 / ADR-0086: browser=true launches managed Chromium, or
         // connects to WEBREAPER_CDP_URL (a shared browser sidecar) when set.
-        await RunBrowserAwareAsync(builder, browser);
+        // ADR-0085: surface the load/climb as MCP progress (single page).
+        await RunBrowserAwareAsync(builder, browser, progress, total: 1);
 
         var output = new StringBuilder();
         foreach (var record in records)
@@ -84,7 +87,8 @@ public static class WebReaperTools
     public static async Task<string> Extract(
         [Description("The URL to extract from.")] string url,
         [Description("The extraction schema as JSON. See the WebReaper docs for the shape.")] string schemaJson,
-        [Description("Use the headless browser. Auto-spawns a system Chrome / Chromium / Edge via WebReaper.Cdp; install a Chromium-family browser on the MCP host first. Default false.")] bool browser = false)
+        [Description("Use the headless browser. Auto-spawns a system Chrome / Chromium / Edge via WebReaper.Cdp; install a Chromium-family browser on the MCP host first. Default false.")] bool browser = false,
+        IProgress<ProgressNotificationValue>? progress = null)
     {
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("URL is required.", nameof(url));
@@ -112,7 +116,7 @@ public static class WebReaperTools
             .StopWhenAllLinksProcessed();
 
         // ADR-0086: see Scrape() for the browser-wiring rationale.
-        await RunBrowserAwareAsync(builder, browser);
+        await RunBrowserAwareAsync(builder, browser, progress, total: 1);
 
         // JSON Lines: one record per line.
         return string.Join("\n", records.Select(r => r.Data.ToJsonString()));
@@ -130,7 +134,8 @@ public static class WebReaperTools
         [Description("The URL to extract from.")] string url,
         [Description("Natural-language description of the data to extract.")] string prompt,
         [Description("Use the headless browser (for JS-rendered pages). Auto-spawns a system Chrome / Chromium / Edge via WebReaper.Cdp. Default false.")] bool browser = false,
-        [Description("Optional model id, overriding WEBREAPER_LLM_MODEL for this call (e.g. gpt-4o-mini). The API key is never a parameter; it stays in the environment.")] string? model = null)
+        [Description("Optional model id, overriding WEBREAPER_LLM_MODEL for this call (e.g. gpt-4o-mini). The API key is never a parameter; it stays in the environment.")] string? model = null,
+        IProgress<ProgressNotificationValue>? progress = null)
     {
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("URL is required.", nameof(url));
@@ -151,7 +156,7 @@ public static class WebReaperTools
             .StopWhenAllLinksProcessed();
 
         // ADR-0086: see Scrape() for the browser-wiring rationale.
-        await RunBrowserAwareAsync(builder, browser);
+        await RunBrowserAwareAsync(builder, browser, progress, total: 1);
 
         return string.Join("\n", records.Select(r => r.Data.ToJsonString()));
     }
@@ -159,13 +164,16 @@ public static class WebReaperTools
     [McpServerTool(Name = "crawl"), Description(
         "Crawl a whole site: recursively follow on-domain links from the start URL "
         + "and return one Markdown record per page as JSON Lines. WARNING: this is a "
-        + "single long BLOCKING call with NO progress feedback, bounded by max_pages "
-        + "(default 50, hard cap 1000). For a large site prefer 'map' to list URLs, "
-        + "then 'scrape' each URL, so every call stays short and you keep per-URL control.")]
+        + "single long BLOCKING call, bounded by max_pages (default 50, hard cap 1000). "
+        + "It emits MCP progress notifications per page for clients that render them "
+        + "(e.g. Claude Desktop); blocking clients like n8n just wait for the result. "
+        + "For a large site prefer 'map' to list URLs, then 'scrape' each URL, so every "
+        + "call stays short and you keep per-URL control.")]
     public static async Task<string> Crawl(
         [Description("The site root URL to crawl.")] string url,
         [Description("Maximum pages to sweep. Default 50, hard cap 1000.")] int maxPages = CrawlBounds.DefaultMaxPages,
-        [Description("Use the headless browser for each page (JS-rendered sites). Default false.")] bool browser = false)
+        [Description("Use the headless browser for each page (JS-rendered sites). Default false.")] bool browser = false,
+        IProgress<ProgressNotificationValue>? progress = null)
     {
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("URL is required.", nameof(url));
@@ -185,18 +193,62 @@ public static class WebReaperTools
             .Subscribe(r => { lock (records) records.Add(r); })
             .StopWhenAllLinksProcessed();
 
-        await RunBrowserAwareAsync(builder, browser);
+        // ADR-0085: per-page climb steps become MCP progress (total = the cap).
+        await RunBrowserAwareAsync(builder, browser, progress, total: cap);
 
         // JSON Lines: one record per swept page.
+        return string.Join("\n", records.Select(r => r.Data.ToJsonString()));
+    }
+
+    [McpServerTool(Name = "extract_inferred"), Description(
+        "Extract structured data from a URL WITHOUT writing a schema: an LLM infers the "
+        + "schema from the page (optionally steered by a goal), then WebReaper extracts "
+        + "deterministically. Cheaper and more consistent than extract_with_prompt across "
+        + "similarly shaped pages. Requires an OpenAI-compatible LLM endpoint on the host: "
+        + "WEBREAPER_LLM_MODEL + WEBREAPER_LLM_BASE_URL, key in WEBREAPER_LLM_API_KEY (or "
+        + "OPENAI_API_KEY). Returns the extracted record(s) as JSON Lines.")]
+    public static async Task<string> ExtractInferred(
+        [Description("The URL to extract from.")] string url,
+        [Description("Optional goal to steer the inferred schema (e.g. \"product name and price\").")] string? goal = null,
+        [Description("Use the headless browser (for JS-rendered pages). Default false.")] bool browser = false,
+        [Description("Optional model id, overriding WEBREAPER_LLM_MODEL for this call.")] string? model = null,
+        IProgress<ProgressNotificationValue>? progress = null)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            throw new ArgumentException("URL is required.", nameof(url));
+
+        using var chatClient = CreateChatClient(model);
+
+        var seed = browser
+            ? ScraperEngineBuilder.CrawlWithBrowser(url)
+            : ScraperEngineBuilder.Crawl(url);
+
+        var records = new List<ParsedData>();
+        // ADR-0067: infer a Schema once with the LLM, then run the deterministic fold.
+        var builder = seed.ExtractInferred(goal)
+            .WithLlmSchemaInferrer(chatClient)
+            .Subscribe(records.Add)
+            .StopWhenAllLinksProcessed();
+
+        await RunBrowserAwareAsync(builder, browser, progress, total: 1);
+
         return string.Join("\n", records.Select(r => r.Data.ToJsonString()));
     }
 
     // ADR-0086: resolve the browser plan (launch vs connect-to-CDP-url), apply
     // it, and run the engine. Managed-Chromium launches pass through a
     // concurrency gate; connect / HTTP calls do not. `await using` tears the
-    // engine (and any spawned Chromium) down on completion (ADR-0058).
-    private static async Task RunBrowserAwareAsync(ScraperEngineBuilder builder, bool browser)
+    // engine (and any spawned Chromium) down on completion (ADR-0058). When the
+    // MCP client requested progress (ADR-0085), forward climb steps to it.
+    private static async Task RunBrowserAwareAsync(
+        ScraperEngineBuilder builder,
+        bool browser,
+        IProgress<ProgressNotificationValue>? progress = null,
+        int? total = null)
     {
+        if (progress is not null)
+            builder = builder.WithClimbObserver(new McpProgressClimbObserver(progress, total));
+
         var plan = BrowserTransport.Select(
             browser, Environment.GetEnvironmentVariable(BrowserTransport.CdpUrlEnvVar));
         builder = builder.ApplyBrowser(plan);

--- a/WebReaper.Tests/WebReaper.IntegrationTests/McpHttpServerTests.cs
+++ b/WebReaper.Tests/WebReaper.IntegrationTests/McpHttpServerTests.cs
@@ -50,6 +50,9 @@ public sealed class McpHttpServerTests
             Assert.Contains("scrape", names);
             Assert.Contains("map", names);
             Assert.Contains("extract", names);
+            Assert.Contains("extract_with_prompt", names);
+            Assert.Contains("crawl", names);
+            Assert.Contains("extract_inferred", names);
         }
     }
 

--- a/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/McpProgressClimbObserverTests.cs
+++ b/WebReaper.Tests/WebReaper.Mcp.AspNetCore.Tests/McpProgressClimbObserverTests.cs
@@ -1,0 +1,73 @@
+using ModelContextProtocol;
+using WebReaper.Core.Loaders.Abstract;
+using WebReaper.Domain.Selectors;
+using WebReaper.Mcp;
+using Xunit;
+
+namespace WebReaper.Mcp.AspNetCore.Tests;
+
+// ADR-0085 + ADR-0086: the climb-step -> MCP-progress translation, deterministic
+// (no engine, no network). The full notifications/progress roundtrip is
+// interactive-client behavior the SDK owns; this pins our mapping.
+public class McpProgressClimbObserverTests
+{
+    private sealed class CapturingProgress : IProgress<ProgressNotificationValue>
+    {
+        public List<ProgressNotificationValue> Reports { get; } = [];
+        public void Report(ProgressNotificationValue value) => Reports.Add(value);
+    }
+
+    private static ClimbStep Step(ClimbPhase phase, string url = "https://example.com/p", int tier = 0) =>
+        new(phase, url, tier, PageType.Static, HttpStatus: null, Reason: null);
+
+    [Fact]
+    public void Succeeded_steps_increment_the_page_count()
+    {
+        var captured = new CapturingProgress();
+        var observer = new McpProgressClimbObserver(captured, total: 10);
+
+        observer.OnStep(Step(ClimbPhase.Succeeded, "https://example.com/1"));
+        observer.OnStep(Step(ClimbPhase.Succeeded, "https://example.com/2"));
+
+        Assert.Equal(2, captured.Reports.Count);
+        Assert.Equal(1, (int)captured.Reports[0].Progress);
+        Assert.Equal(2, (int)captured.Reports[1].Progress);
+        Assert.Equal(10, (int)captured.Reports[1].Total!.Value);
+    }
+
+    [Fact]
+    public void Attempt_steps_are_not_reported()
+    {
+        var captured = new CapturingProgress();
+        var observer = new McpProgressClimbObserver(captured, total: null);
+
+        observer.OnStep(Step(ClimbPhase.Attempt));
+
+        Assert.Empty(captured.Reports);
+    }
+
+    [Fact]
+    public void Block_climb_exhaust_report_without_incrementing_the_count()
+    {
+        var captured = new CapturingProgress();
+        var observer = new McpProgressClimbObserver(captured, total: null);
+
+        observer.OnStep(Step(ClimbPhase.Blocked));
+        observer.OnStep(Step(ClimbPhase.Climbing));
+        observer.OnStep(Step(ClimbPhase.Exhausted));
+
+        Assert.Equal(3, captured.Reports.Count);
+        Assert.All(captured.Reports, r => Assert.Equal(0, (int)r.Progress));
+    }
+
+    [Fact]
+    public void Each_report_carries_a_message_with_the_url()
+    {
+        var captured = new CapturingProgress();
+        var observer = new McpProgressClimbObserver(captured, total: 1);
+
+        observer.OnStep(Step(ClimbPhase.Succeeded, "https://example.com/widget"));
+
+        Assert.Contains("example.com/widget", captured.Reports[0].Message);
+    }
+}

--- a/website/content/docs/mcp-server.mdx
+++ b/website/content/docs/mcp-server.mdx
@@ -25,19 +25,22 @@ Both servers expose WebReaper's core operations as MCP tools:
 - `map` a site to discover its URLs
 - `extract` structured data with a JSON schema
 - `extract_with_prompt` structured data by a natural-language prompt, with an LLM
+- `extract_inferred` structured data with no schema: an LLM infers the schema once, then WebReaper extracts deterministically (cheaper and more consistent than a prompt across similarly shaped pages)
 - `crawl` a whole site: a bounded on-domain sweep returning one Markdown record per page
 
-The `extract_with_prompt` tool calls an LLM, so it needs an OpenAI-compatible
-endpoint configured on the MCP host: set `WEBREAPER_LLM_MODEL` and
-`WEBREAPER_LLM_BASE_URL` (for example `https://api.openai.com/v1`, or
+The `extract_with_prompt` and `extract_inferred` tools call an LLM, so they need
+an OpenAI-compatible endpoint configured on the MCP host: set `WEBREAPER_LLM_MODEL`
+and `WEBREAPER_LLM_BASE_URL` (for example `https://api.openai.com/v1`, or
 `http://localhost:11434/v1` for a local Ollama), with the API key in
-`WEBREAPER_LLM_API_KEY` (or `OPENAI_API_KEY`). It also takes an optional per-call
+`WEBREAPER_LLM_API_KEY` (or `OPENAI_API_KEY`). Both take an optional per-call
 `model` parameter that overrides `WEBREAPER_LLM_MODEL` for that one call. The
 other tools need no setup.
 
-`crawl` is a single long **blocking** call with no progress feedback, bounded by
-`maxPages` (default 50, hard cap 1000). For a large site, prefer `map` to list
-the URLs and then `scrape` each, so every call stays short.
+`crawl` is a single long **blocking** call bounded by `maxPages` (default 50,
+hard cap 1000). It emits MCP progress notifications per page for clients that
+render them (Claude Desktop, Cursor); a blocking client like n8n just waits for
+the result. For a large site, prefer `map` to list the URLs and then `scrape`
+each, so every call stays short.
 
 ## Use it with n8n
 


### PR DESCRIPTION
The "check these two" follow-up: implements **progress over MCP** and the **infer-schema tool**.

## Progress over MCP (ADR-0085)
`scrape` / `extract` / `extract_with_prompt` / `crawl` / `extract_inferred` forward `EscalatingPageLoader` climb steps to MCP progress notifications via a new `McpProgressClimbObserver`, wired through the shared run helper. Interactive MCP clients (Claude Desktop, Cursor) render live per-page / per-climb progress.

**Honest caveat (kept in the tool description + docs):** n8n's MCP Client node is a blocking node and does not surface MCP progress, so this helps interactive clients, not n8n. The real n8n long-crawl mitigations (the `maxPages` cap + map-then-scrape) already shipped.

## extract_inferred tool (ADR-0067)
A 6th tool: an LLM infers the schema once, then WebReaper extracts deterministically. Cheaper and more consistent than `extract_with_prompt` across similarly shaped pages. Same env LLM config + optional per-call `model`.

## Tests
- 4 `McpProgressClimbObserver` truth-table units (climb-step -> progress mapping; Succeeded increments, Attempt skipped, block/climb/exhaust report without incrementing).
- The injected `IProgress<ProgressNotificationValue>` param does not alter the tool input schema: the 9 existing MCP integration tests (stdio + HTTP) still pass.
- `tools/list` now asserts all 6 tools incl `extract_inferred`.
- Full-solution Release build clean. README + website MCP docs updated.

Additive; no breaking changes. Unreleased (would fold into the next minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)