### PR TITLE
docs: repoint GHCR image to ghcr.io/alex-on-ai (account rename)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ An additive release: a new Streamable HTTP MCP server so URL-based clients (n8n,
 - **`WEBREAPER_CDP_URL` browser sidecar ([ADR-0086]).** A `browser=true` MCP call now connects to an external CDP endpoint (a shared Chromium / browserless pool) when `WEBREAPER_CDP_URL` is set, instead of launching managed Chromium; `WEBREAPER_MCP_MAX_CONCURRENT_BROWSERS` caps concurrent launches. The selection lives in the shared satellite, so the stdio server gains the sidecar option too.
 - **Per-call model on `extract_with_prompt` ([ADR-0086]).** The tool gains an optional `model` parameter overriding `WEBREAPER_LLM_MODEL` for that one call; the API key stays environment-only, never a tool argument.
 
-The container image publishes to `ghcr.io/pavlovtech/webreaper-mcp-http` (tagged with the version and `latest`) on each release.
+The container image publishes to `ghcr.io/alex-on-ai/webreaper-mcp-http` (tagged with the version and `latest`) on each release.
 
 All 15 packages ship at 11.2.0 (lockstep).
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Two MCP servers expose the same tools (`scrape`, `map`, `extract`, `extract_with
 
   ```bash
   docker run -p 8080:8080 -e WEBREAPER_MCP_TOKEN=your-secret \
-    ghcr.io/pavlovtech/webreaper-mcp-http:latest
+    ghcr.io/alex-on-ai/webreaper-mcp-http:latest
   ```
 
   See the [n8n quickstart](docs/mcp-http-quickstart.md).
@@ -308,7 +308,7 @@ The release ships fifteen packages (one core, fourteen satellites), all versione
 | **WebReaper.Extraction.Attributes** | The `[ScrapeSchema]` / `[ScrapeField]` marker types. Standalone, no runtime cost. | `[ScrapeSchema]` `[ScrapeField("selector")]` |
 | **WebReaper.Extraction.Generators** | Roslyn source generator that emits `static Schema` plus reflection-free `static Materialize(JsonObject)` (ADR-0045). `DevelopmentDependency=true`; does not propagate at runtime. | compile-time only |
 | **WebReaper.Mcp** | MCP server `Exe` exposing scrape / map / extract / extract_with_prompt / extract_inferred / crawl as MCP tools over **stdio** (ADR-0049). Interop adapter for local MCP clients (Cursor, Claude Desktop). | the package _is_ the executable |
-| **WebReaper.Mcp.AspNetCore** | MCP server over **Streamable HTTP** (ADR-0086) for URL-based clients like n8n; same tools as `WebReaper.Mcp`, plus bearer-token auth and a `WEBREAPER_CDP_URL` browser sidecar. Also ships as a Chromium-baked container image. | the package _is_ the executable; or `docker run ghcr.io/pavlovtech/webreaper-mcp-http` |
+| **WebReaper.Mcp.AspNetCore** | MCP server over **Streamable HTTP** (ADR-0086) for URL-based clients like n8n; same tools as `WebReaper.Mcp`, plus bearer-token auth and a `WEBREAPER_CDP_URL` browser sidecar. Also ships as a Chromium-baked container image. | the package _is_ the executable; or `docker run ghcr.io/alex-on-ai/webreaper-mcp-http` |
 | **WebReaper.Mongo** | MongoDB result sink and MongoDB-backed config / cookie storage. | `.WriteToMongoDb(...)` `.WithMongoDbConfigStorage(...)` `.WithMongoDbCookieStorage(...)` |
 | **WebReaper.Redis** | Redis scheduler, visited-link tracker, result sink, config / cookie storage. | `.WithRedisScheduler(...)` `.TrackVisitedLinksInRedis(...)` `.WriteToRedis(...)` `.WithRedisConfigStorage(...)` `.WithRedisCookieStorage(...)` |
 | **WebReaper.AzureServiceBus** | Distributed scheduler over an Azure Service Bus queue. | `.WithAzureServiceBusScheduler(...)` |

--- a/WebReaper.Mcp.AspNetCore/README.md
+++ b/WebReaper.Mcp.AspNetCore/README.md
@@ -18,11 +18,11 @@ dotnet run --project WebReaper.Mcp.AspNetCore
 ```
 
 The container image (Chromium baked in) is the recommended way to self-host.
-Each release publishes it to GHCR as `ghcr.io/pavlovtech/webreaper-mcp-http`:
+Each release publishes it to GHCR as `ghcr.io/alex-on-ai/webreaper-mcp-http`:
 
 ```bash
 docker run --rm -p 8080:8080 -e WEBREAPER_MCP_TOKEN=change-me \
-  ghcr.io/pavlovtech/webreaper-mcp-http:latest
+  ghcr.io/alex-on-ai/webreaper-mcp-http:latest
 # or build it: docker build -f WebReaper.Mcp.AspNetCore/Dockerfile -t webreaper-mcp-http .
 ```
 

--- a/docs/mcp-http-quickstart.md
+++ b/docs/mcp-http-quickstart.md
@@ -18,12 +18,12 @@ stdio satellite (one shared `WebReaperTools`).
 
 The image bakes a headless Chromium, so `browser=true` works out of the box.
 Each release publishes it to GHCR as
-`ghcr.io/pavlovtech/webreaper-mcp-http:<version>` (and `:latest`):
+`ghcr.io/alex-on-ai/webreaper-mcp-http:<version>` (and `:latest`):
 
 ```bash
 docker run --rm -p 8080:8080 \
   -e WEBREAPER_MCP_TOKEN=change-me-to-a-long-random-secret \
-  ghcr.io/pavlovtech/webreaper-mcp-http:latest
+  ghcr.io/alex-on-ai/webreaper-mcp-http:latest
 ```
 
 Or build it yourself (context = repo root):

--- a/website/content/blog/scrape-websites-from-n8n.mdx
+++ b/website/content/blog/scrape-websites-from-n8n.mdx
@@ -27,7 +27,7 @@ box:
 
 ```bash
 docker run -p 8080:8080 -e WEBREAPER_MCP_TOKEN=your-secret \
-  ghcr.io/pavlovtech/webreaper-mcp-http:latest
+  ghcr.io/alex-on-ai/webreaper-mcp-http:latest
 ```
 
 `WEBREAPER_MCP_TOKEN` is required: the server refuses to start on a public

--- a/website/content/docs/mcp-server.mdx
+++ b/website/content/docs/mcp-server.mdx
@@ -49,7 +49,7 @@ Run the HTTP server. The container image bakes a headless Chromium, so
 
 ```bash
 docker run -p 8080:8080 -e WEBREAPER_MCP_TOKEN=your-secret \
-  ghcr.io/pavlovtech/webreaper-mcp-http:latest
+  ghcr.io/alex-on-ai/webreaper-mcp-http:latest
 ```
 
 `WEBREAPER_MCP_TOKEN` is required here: the server binds all interfaces in the


### PR DESCRIPTION
The account rename `pavlovtech` -> `alex-on-ai` moved the GHCR package: `ghcr.io/alex-on-ai/webreaper-mcp-http` serves it (verified HTTP 200 for `:11.2.0` and `:latest`); the old `ghcr.io/pavlovtech/...` now 403s. GHCR does not follow rename redirects for pull or push, which is also why the v11.3.0 image-publish job failed (`denied: not_found: owner not found`).

Repoints all 8 `ghcr.io/pavlovtech/webreaper-mcp-http` references to `ghcr.io/alex-on-ai` across README, the package README, the website docs + blog, the quickstart, and the CHANGELOG. GitHub repo / raw / Homebrew-tap URLs keep working via the rename redirect and are left as-is.

Paired with a re-dispatch of the v11.3.0 release so the image actually publishes under `alex-on-ai` (the release job uses `${{ github.repository_owner }}`, which now resolves to the new owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)