### PR TITLE
chore: finish pavlovtech→alex-on-ai canonicalization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -552,7 +552,7 @@ jobs:
 
   homebrew-publish:
     # ADR-0070 §1: render Formula/webreaper.rb from the template in this
-    # repo, push to pavlovtech/homebrew-webreaper using a tap-scoped
+    # repo, push to alex-on-ai/homebrew-webreaper using a tap-scoped
     # fine-grained PAT (GH_TOKEN_HOMEBREW_TAP). Runs after `checksums`
     # because it reads SHA256 values from SHA256SUMS.
     #
@@ -621,7 +621,7 @@ jobs:
           echo "--- rendered Formula/webreaper.rb ---"
           cat webreaper.rb
 
-      - name: Push to pavlovtech/homebrew-webreaper
+      - name: Push to alex-on-ai/homebrew-webreaper
         env:
           GH_TOKEN_HOMEBREW_TAP: ${{ secrets.GH_TOKEN_HOMEBREW_TAP }}
         run: |
@@ -631,7 +631,7 @@ jobs:
           VERSION="${{ needs.pack.outputs.version }}"
 
           git clone --depth 1 \
-            "https://x-access-token:${GH_TOKEN_HOMEBREW_TAP}@github.com/pavlovtech/homebrew-webreaper.git" \
+            "https://x-access-token:${GH_TOKEN_HOMEBREW_TAP}@github.com/alex-on-ai/homebrew-webreaper.git" \
             tap
           mkdir -p tap/Formula
           cp webreaper.rb tap/Formula/webreaper.rb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ don't need an ADR.
 
 ## Reporting bugs
 
-Bugs are tracked as [GitHub Issues](https://github.com/pavlovtech/WebReaper/issues).
+Bugs are tracked as [GitHub Issues](https://github.com/alex-on-ai/WebReaper/issues).
 A good bug report includes:
 
 - A clear, descriptive title.
@@ -77,7 +77,7 @@ A good bug report includes:
 
 ## Suggesting enhancements
 
-Enhancement suggestions are also [GitHub Issues](https://github.com/pavlovtech/WebReaper/issues).
+Enhancement suggestions are also [GitHub Issues](https://github.com/alex-on-ai/WebReaper/issues).
 A good enhancement suggestion includes:
 
 - A clear description of the use case.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,8 +39,8 @@
     <Company>Alex Pavlov</Company>
     <Product>WebReaper</Product>
     <Copyright>Copyright (c) Alex Pavlov</Copyright>
-    <PackageProjectUrl>https://github.com/pavlovtech/WebReaper</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/pavlovtech/WebReaper</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/alex-on-ai/WebReaper</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/alex-on-ai/WebReaper</RepositoryUrl>
     <!-- ADR-0017: relicensed to MIT to remove funnel-adoption friction.
          Per-csproj <PackageLicenseExpression>MIT</PackageLicenseExpression>
          entries (added with the original sweep) remain as a redundant,

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # WebReaper
 
 [![NuGet](https://img.shields.io/nuget/v/WebReaper)](https://www.nuget.org/packages/WebReaper)
-[![CI](https://github.com/pavlovtech/WebReaper/actions/workflows/CI.yml/badge.svg)](https://github.com/pavlovtech/WebReaper/actions/workflows/CI.yml)
+[![CI](https://github.com/alex-on-ai/WebReaper/actions/workflows/CI.yml/badge.svg)](https://github.com/alex-on-ai/WebReaper/actions/workflows/CI.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.txt)
 
 AI-native web scraper. Single binary with a bundled Claude Code skill.
@@ -13,13 +13,13 @@ AI-native web scraper. Single binary with a bundled Claude Code skill.
 **macOS / Linux (Homebrew):**
 
 ```bash
-brew install pavlovtech/webreaper/webreaper
+brew install alex-on-ai/webreaper/webreaper
 ```
 
 **Any POSIX shell (install.sh):**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/alex-on-ai/WebReaper/master/scripts/install.sh | sh
 ```
 
 **.NET library:**
@@ -28,7 +28,7 @@ curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts
 dotnet add package WebReaper
 ```
 
-Windows binaries are on the [GitHub Releases page](https://github.com/pavlovtech/WebReaper/releases/latest); `winget` and `Scoop` are on the v10.1 roadmap.
+Windows binaries are on the [GitHub Releases page](https://github.com/alex-on-ai/WebReaper/releases/latest); `winget` and `Scoop` are on the v10.1 roadmap.
 
 **Updating:** `brew upgrade webreaper` (Homebrew), or re-run the install.sh line with `--upgrade` appended (`| sh -s -- --upgrade`), or `dotnet add package WebReaper` (library). When a newer release exists, `scrape` / `crawl` / `map` print a one-line upgrade hint on stderr (interactive terminals only, never in a pipe or CI); disable that check with `WEBREAPER_NO_UPDATE_CHECK=1`.
 

--- a/WebReaper.AI/README.md
+++ b/WebReaper.AI/README.md
@@ -1,6 +1,6 @@
 # WebReaper.AI
 
-LLM extraction satellite for [WebReaper](https://github.com/pavlovtech/WebReaper). Bring your own model: OpenAI, Anthropic, Ollama, Azure OpenAI, llamafile, anything implementing `IChatClient` (Microsoft.Extensions.AI).
+LLM extraction satellite for [WebReaper](https://github.com/alex-on-ai/WebReaper). Bring your own model: OpenAI, Anthropic, Ollama, Azure OpenAI, llamafile, anything implementing `IChatClient` (Microsoft.Extensions.AI).
 
 ## Install
 
@@ -10,7 +10,7 @@ dotnet add package WebReaper.AI
 
 ## What's in this package
 
-Per [ADR-0044](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0044-llm-extractor-satellite.md), [ADR-0046](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0046-extraction-router.md), [ADR-0047](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0047-self-healing-selectors.md), [ADR-0050](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0050-semantic-page-actions.md), [ADR-0051](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0051-agent-crawl-driver.md), [ADR-0064](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0064-use-ai-policy.md), [ADR-0067](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0067-schema-inferrer-seam.md):
+Per [ADR-0044](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0044-llm-extractor-satellite.md), [ADR-0046](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0046-extraction-router.md), [ADR-0047](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0047-self-healing-selectors.md), [ADR-0050](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0050-semantic-page-actions.md), [ADR-0051](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0051-agent-crawl-driver.md), [ADR-0064](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0064-use-ai-policy.md), [ADR-0067](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0067-schema-inferrer-seam.md):
 
 | Builder call | Purpose |
 |---|---|
@@ -46,13 +46,13 @@ The deterministic fold runs first. The LLM fires only when a field returns empty
 
 ## Design
 
-`WebReaper.AI` is a satellite package per [ADR-0009](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0009-registration-seam-and-satellite-adapters.md): the LLM dependencies (`Microsoft.Extensions.AI.Abstractions`) stay quarantined off the dependency-light, Native-AOT-clean WebReaper core. The consumer's `IChatClient` makes the actual LLM call.
+`WebReaper.AI` is a satellite package per [ADR-0009](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0009-registration-seam-and-satellite-adapters.md): the LLM dependencies (`Microsoft.Extensions.AI.Abstractions`) stay quarantined off the dependency-light, Native-AOT-clean WebReaper core. The consumer's `IChatClient` makes the actual LLM call.
 
-`LlmCall<T>` (the shared mechanism, [ADR-0059](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0059-llm-call-mechanism-module.md)) handles JSON-mode parsing with bounded retry, system-prompt caching ([ADR-0065](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0065-llm-call-system-prompt-caching.md)), and cost telemetry ([ADR-0066](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0066-engine-cost-telemetry.md)).
+`LlmCall<T>` (the shared mechanism, [ADR-0059](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0059-llm-call-mechanism-module.md)) handles JSON-mode parsing with bounded retry, system-prompt caching ([ADR-0065](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0065-llm-call-system-prompt-caching.md)), and cost telemetry ([ADR-0066](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0066-engine-cost-telemetry.md)).
 
 ## See also
 
-- Main repo: [github.com/pavlovtech/WebReaper](https://github.com/pavlovtech/WebReaper)
-- All AI features showcased in [`Examples/WebReaper.AiNativeShowcase`](https://github.com/pavlovtech/WebReaper/tree/master/Examples/WebReaper.AiNativeShowcase)
-- Schema inference demos in [`Examples/WebReaper.SchemaInferenceShowcase`](https://github.com/pavlovtech/WebReaper/tree/master/Examples/WebReaper.SchemaInferenceShowcase)
-- License: [MIT](https://github.com/pavlovtech/WebReaper/blob/master/LICENSE.txt) ([ADR-0017](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0017-relicense-gpl-mit.md))
+- Main repo: [github.com/alex-on-ai/WebReaper](https://github.com/alex-on-ai/WebReaper)
+- All AI features showcased in [`Examples/WebReaper.AiNativeShowcase`](https://github.com/alex-on-ai/WebReaper/tree/master/Examples/WebReaper.AiNativeShowcase)
+- Schema inference demos in [`Examples/WebReaper.SchemaInferenceShowcase`](https://github.com/alex-on-ai/WebReaper/tree/master/Examples/WebReaper.SchemaInferenceShowcase)
+- License: [MIT](https://github.com/alex-on-ai/WebReaper/blob/master/LICENSE.txt) ([ADR-0017](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0017-relicense-gpl-mit.md))

--- a/WebReaper.AzureServiceBus/README.md
+++ b/WebReaper.AzureServiceBus/README.md
@@ -1,7 +1,7 @@
 # WebReaper.AzureServiceBus
 
 Azure Service Bus scheduler for
-[WebReaper](https://github.com/pavlovtech/WebReaper): a distributed job queue
+[WebReaper](https://github.com/alex-on-ai/WebReaper): a distributed job queue
 backed by an Azure Service Bus queue, for sharing crawl state across workers
 and serverless functions.
 

--- a/WebReaper.Cdp/README.md
+++ b/WebReaper.Cdp/README.md
@@ -1,6 +1,6 @@
 # WebReaper.Cdp
 
-Raw [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) `IPageLoadTransport` for [WebReaper](https://github.com/pavlovtech/WebReaper); the **AOT-clean** browser transport, the bedrock for stealth Chromium fork backends (see [WebReaper.Stealth.CloakBrowser](https://www.nuget.org/packages/WebReaper.Stealth.CloakBrowser)).
+Raw [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) `IPageLoadTransport` for [WebReaper](https://github.com/alex-on-ai/WebReaper); the **AOT-clean** browser transport, the bedrock for stealth Chromium fork backends (see [WebReaper.Stealth.CloakBrowser](https://www.nuget.org/packages/WebReaper.Stealth.CloakBrowser)).
 
 ## Why this satellite
 
@@ -60,4 +60,4 @@ var endpoint = await CdpLaunchHelpers.LaunchAsync(
 
 ## SemVer
 
-10.0.0 (initial release). See [ADR-0052](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0052-cdp-direct-loader-satellite.md) for the design.
+10.0.0 (initial release). See [ADR-0052](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0052-cdp-direct-loader-satellite.md) for the design.

--- a/WebReaper.Cli/UpdateNotifier.cs
+++ b/WebReaper.Cli/UpdateNotifier.cs
@@ -16,9 +16,9 @@ internal static class UpdateNotifier
 {
     private const string DisableVar = "WEBREAPER_NO_UPDATE_CHECK";
     private const string LatestUrl =
-        "https://api.github.com/repos/pavlovtech/WebReaper/releases/latest";
+        "https://api.github.com/repos/alex-on-ai/WebReaper/releases/latest";
     private const string InstallHint =
-        "curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh -s -- --upgrade";
+        "curl -fsSL https://raw.githubusercontent.com/alex-on-ai/WebReaper/master/scripts/install.sh | sh -s -- --upgrade";
     private static readonly TimeSpan Ttl = TimeSpan.FromHours(24);
     private static readonly TimeSpan FetchTimeout = TimeSpan.FromMilliseconds(1500);
 

--- a/WebReaper.Cli/skill/SKILL.md
+++ b/WebReaper.Cli/skill/SKILL.md
@@ -213,10 +213,10 @@ Exit code `0` on success, non-zero on failure. Errors print one human-readable
 line to stderr. Common cases:
 
 - **`webreaper: command not found`** → not installed. Instruct the user:
-  - **macOS / Linux**: `brew install pavlovtech/webreaper/webreaper`, or
-    `curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh`
+  - **macOS / Linux**: `brew install alex-on-ai/webreaper/webreaper`, or
+    `curl -fsSL https://raw.githubusercontent.com/alex-on-ai/WebReaper/master/scripts/install.sh | sh`
   - **Windows**: download the latest archive for `win-x64` (or `win-arm64`)
-    from <https://github.com/pavlovtech/WebReaper/releases/latest>, extract
+    from <https://github.com/alex-on-ai/WebReaper/releases/latest>, extract
     `webreaper.exe`, place on `%PATH%`.
 - **`⚠ N page(s) still blocked at the top tier …` on stderr (non-zero exit)** →
   the loader climbed to its top tier and the page was still a challenge. Add the

--- a/WebReaper.Cosmos/README.md
+++ b/WebReaper.Cosmos/README.md
@@ -1,6 +1,6 @@
 # WebReaper.Cosmos
 
-Azure Cosmos DB sink for [WebReaper](https://github.com/pavlovtech/WebReaper).
+Azure Cosmos DB sink for [WebReaper](https://github.com/alex-on-ai/WebReaper).
 
 Satellite package (ADR-0009): the Cosmos sink is kept out of the WebReaper
 core so the core stays dependency-light and Native-AOT-clean. The Cosmos SDK

--- a/WebReaper.Extraction.Attributes/README.md
+++ b/WebReaper.Extraction.Attributes/README.md
@@ -1,6 +1,6 @@
 # WebReaper.Extraction.Attributes
 
-`[ScrapeSchema]` and `[ScrapeField]` marker attributes for [WebReaper](https://github.com/pavlovtech/WebReaper)'s Roslyn source generator. Consumed by [`WebReaper.Extraction.Generators`](https://www.nuget.org/packages/WebReaper.Extraction.Generators) at compile time. Lightweight; no runtime dependencies beyond the BCL.
+`[ScrapeSchema]` and `[ScrapeField]` marker attributes for [WebReaper](https://github.com/alex-on-ai/WebReaper)'s Roslyn source generator. Consumed by [`WebReaper.Extraction.Generators`](https://www.nuget.org/packages/WebReaper.Extraction.Generators) at compile time. Lightweight; no runtime dependencies beyond the BCL.
 
 ## Install
 
@@ -57,7 +57,7 @@ No reflection at runtime; AOT-clean. Schema typos become compile errors.
 
 ## See also
 
-- Main repo: [github.com/pavlovtech/WebReaper](https://github.com/pavlovtech/WebReaper)
+- Main repo: [github.com/alex-on-ai/WebReaper](https://github.com/alex-on-ai/WebReaper)
 - The source generator: [`WebReaper.Extraction.Generators`](https://www.nuget.org/packages/WebReaper.Extraction.Generators)
-- Design: [ADR-0045](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0045-scrape-schema-source-generator.md)
-- License: [MIT](https://github.com/pavlovtech/WebReaper/blob/master/LICENSE.txt)
+- Design: [ADR-0045](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0045-scrape-schema-source-generator.md)
+- License: [MIT](https://github.com/alex-on-ai/WebReaper/blob/master/LICENSE.txt)

--- a/WebReaper.Extraction.Generators/README.md
+++ b/WebReaper.Extraction.Generators/README.md
@@ -59,7 +59,7 @@ Nested `[ScrapeSchema]` types are explicitly deferred to a future version. The a
 
 ## See also
 
-- Main repo: [github.com/pavlovtech/WebReaper](https://github.com/pavlovtech/WebReaper)
+- Main repo: [github.com/alex-on-ai/WebReaper](https://github.com/alex-on-ai/WebReaper)
 - The attributes: [`WebReaper.Extraction.Attributes`](https://www.nuget.org/packages/WebReaper.Extraction.Attributes)
-- Design: [ADR-0045](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0045-scrape-schema-source-generator.md)
-- License: [MIT](https://github.com/pavlovtech/WebReaper/blob/master/LICENSE.txt)
+- Design: [ADR-0045](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0045-scrape-schema-source-generator.md)
+- License: [MIT](https://github.com/alex-on-ai/WebReaper/blob/master/LICENSE.txt)

--- a/WebReaper.Mcp.AspNetCore/README.md
+++ b/WebReaper.Mcp.AspNetCore/README.md
@@ -1,7 +1,7 @@
 # WebReaper.Mcp.AspNetCore
 
 A **Streamable HTTP** [MCP](https://modelcontextprotocol.io) server host for
-[WebReaper](https://github.com/pavlovtech/WebReaper). It exposes WebReaper's
+[WebReaper](https://github.com/alex-on-ai/WebReaper). It exposes WebReaper's
 scraping tools over HTTP so URL-based MCP clients (n8n, hosted agents) can
 reach them. Sibling to the stdio `WebReaper.Mcp` satellite; both expose the
 same tools (`scrape`, `map`, `extract`, `extract_with_prompt`, `crawl`).
@@ -18,11 +18,11 @@ dotnet run --project WebReaper.Mcp.AspNetCore
 ```
 
 The container image (Chromium baked in) is the recommended way to self-host.
-Each release publishes it to GHCR as `ghcr.io/pavlovtech/webreaper-mcp-http`:
+Each release publishes it to GHCR as `ghcr.io/alex-on-ai/webreaper-mcp-http`:
 
 ```bash
 docker run --rm -p 8080:8080 -e WEBREAPER_MCP_TOKEN=change-me \
-  ghcr.io/pavlovtech/webreaper-mcp-http:latest
+  ghcr.io/alex-on-ai/webreaper-mcp-http:latest
 # or build it: docker build -f WebReaper.Mcp.AspNetCore/Dockerfile -t webreaper-mcp-http .
 ```
 

--- a/WebReaper.Mcp/README.md
+++ b/WebReaper.Mcp/README.md
@@ -1,6 +1,6 @@
 # WebReaper.Mcp
 
-MCP (Model Context Protocol) server satellite for [WebReaper](https://github.com/pavlovtech/WebReaper).
+MCP (Model Context Protocol) server satellite for [WebReaper](https://github.com/alex-on-ai/WebReaper).
 
 The agent client (Cursor / Claude Desktop / Copilot Studio) spawns
 this binary and communicates over stdio. Three tools:

--- a/WebReaper.Mongo/README.md
+++ b/WebReaper.Mongo/README.md
@@ -1,6 +1,6 @@
 # WebReaper.Mongo
 
-MongoDB adapters for [WebReaper](https://github.com/pavlovtech/WebReaper): a
+MongoDB adapters for [WebReaper](https://github.com/alex-on-ai/WebReaper): a
 result sink, plus MongoDB-backed scraper-config and cookie storage.
 
 Satellite package (ADR-0009): the Mongo adapters are kept out of the WebReaper

--- a/WebReaper.Playwright/README.md
+++ b/WebReaper.Playwright/README.md
@@ -1,6 +1,6 @@
 # WebReaper.Playwright
 
-[Microsoft.Playwright](https://playwright.dev/dotnet/)-backed `IPageLoadTransport` for [WebReaper](https://github.com/pavlovtech/WebReaper); the modern, multi-browser headless-scraping satellite. Replaces the deleted `WebReaper.Puppeteer` in v10.
+[Microsoft.Playwright](https://playwright.dev/dotnet/)-backed `IPageLoadTransport` for [WebReaper](https://github.com/alex-on-ai/WebReaper); the modern, multi-browser headless-scraping satellite. Replaces the deleted `WebReaper.Puppeteer` in v10.
 
 ## Why Playwright (not Puppeteer)
 
@@ -57,7 +57,7 @@ await engine.RunAsync();
 + .WithPlaywrightPageLoader()
 ```
 
-That is the full diff for the common case. See [ADR-0053](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0053-playwright-satellite-puppeteer-deletion.md) for the deletion rationale.
+That is the full diff for the common case. See [ADR-0053](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0053-playwright-satellite-puppeteer-deletion.md) for the deletion rationale.
 
 ## SemVer
 

--- a/WebReaper.Redis/README.md
+++ b/WebReaper.Redis/README.md
@@ -1,6 +1,6 @@
 # WebReaper.Redis
 
-Redis adapters for [WebReaper](https://github.com/pavlovtech/WebReaper): a
+Redis adapters for [WebReaper](https://github.com/alex-on-ai/WebReaper): a
 distributed scheduler, visited-link tracker, result sink, and Redis-backed
 scraper-config and cookie storage. Swapping the scheduler + config storage +
 link tracker to Redis lets multiple workers share crawl state.

--- a/WebReaper.Sqlite/README.md
+++ b/WebReaper.Sqlite/README.md
@@ -1,6 +1,6 @@
 # WebReaper.Sqlite
 
-SQLite embedded-store adapters for [WebReaper](https://github.com/pavlovtech/WebReaper):
+SQLite embedded-store adapters for [WebReaper](https://github.com/alex-on-ai/WebReaper):
 a **local durable scheduler** (and, from the next slice, a visited-link
 tracker) backed by SQLite via `Microsoft.Data.Sqlite`. "Resume" is a
 `SELECT … WHERE consumed = 0` over an indexed table; not a hand-rolled

--- a/WebReaper.Stealth.CloakBrowser/README.md
+++ b/WebReaper.Stealth.CloakBrowser/README.md
@@ -1,6 +1,6 @@
 # WebReaper.Stealth.CloakBrowser
 
-[CloakBrowser](https://github.com/CloakHQ/CloakBrowser) stealth Chromium fork backend for [WebReaper](https://github.com/pavlovtech/WebReaper). One-liner `.WithCloakBrowser()` that finds (or downloads from upstream) the CloakBrowser binary, launches it with the fork's recommended flags, and wires its CDP endpoint into [`WebReaper.Cdp`](https://www.nuget.org/packages/WebReaper.Cdp).
+[CloakBrowser](https://github.com/CloakHQ/CloakBrowser) stealth Chromium fork backend for [WebReaper](https://github.com/alex-on-ai/WebReaper). One-liner `.WithCloakBrowser()` that finds (or downloads from upstream) the CloakBrowser binary, launches it with the fork's recommended flags, and wires its CDP endpoint into [`WebReaper.Cdp`](https://www.nuget.org/packages/WebReaper.Cdp).
 
 The first concrete satellite of the ADR-0054 stealth-backend pattern.
 
@@ -12,7 +12,7 @@ C++ source-level fingerprint patches make the browser indistinguishable from a r
 |---|---|
 | Cloudflare Turnstile, reCAPTCHA v3, FingerprintJS, BrowserScan | **Silent pass**; challenge never appears |
 | reCAPTCHA v2 image grid, hCaptcha (interactive puzzles) | Not handled by stealth; needs a separate captcha-solving service |
-| DataDome on aggressive sites | Partial; vendor recommends headed mode + residential proxies (use [`WithProxy(...)`](https://github.com/pavlovtech/WebReaper)) |
+| DataDome on aggressive sites | Partial; vendor recommends headed mode + residential proxies (use [`WithProxy(...)`](https://github.com/alex-on-ai/WebReaper)) |
 
 ## Install
 
@@ -58,8 +58,8 @@ See [BINARY-LICENSE.md](https://github.com/CloakHQ/CloakBrowser/blob/main/BINARY
     └── builder.WithCdpPageLoader(endpoint.CdpUrl)    → connects WebReaper.Cdp to the running browser
 ```
 
-Composes naturally with [`WithProxy(...)`](https://github.com/pavlovtech/WebReaper) (residential proxies for the hardest sites) and the LLM action resolver from `WebReaper.AI` (`.WithLlmActionResolver(...)`; semantic clicks like "dismiss popup" work through stealth).
+Composes naturally with [`WithProxy(...)`](https://github.com/alex-on-ai/WebReaper) (residential proxies for the hardest sites) and the LLM action resolver from `WebReaper.AI` (`.WithLlmActionResolver(...)`; semantic clicks like "dismiss popup" work through stealth).
 
 ## SemVer
 
-10.0.0 (initial release). See [ADR-0054](https://github.com/pavlovtech/WebReaper/blob/master/docs/adr/0054-stealth-backend-pattern-cloakbrowser.md) for the design.
+10.0.0 (initial release). See [ADR-0054](https://github.com/alex-on-ai/WebReaper/blob/master/docs/adr/0054-stealth-backend-pattern-cloakbrowser.md) for the design.

--- a/WebReaper/Core/Mapping/SiteMapper.cs
+++ b/WebReaper/Core/Mapping/SiteMapper.cs
@@ -17,7 +17,7 @@ namespace WebReaper.Core.Mapping;
 public sealed class SiteMapper : ISiteMapper
 {
     private const string UserAgent =
-        "Mozilla/5.0 (compatible; WebReaperSiteMapper/1.0; +https://github.com/pavlovtech/WebReaper)";
+        "Mozilla/5.0 (compatible; WebReaperSiteMapper/1.0; +https://github.com/alex-on-ai/WebReaper)";
 
     private static readonly XNamespace Sitemap = "http://www.sitemaps.org/schemas/sitemap/0.9";
 

--- a/docs/mcp-http-quickstart.md
+++ b/docs/mcp-http-quickstart.md
@@ -18,12 +18,12 @@ stdio satellite (one shared `WebReaperTools`).
 
 The image bakes a headless Chromium, so `browser=true` works out of the box.
 Each release publishes it to GHCR as
-`ghcr.io/pavlovtech/webreaper-mcp-http:<version>` (and `:latest`):
+`ghcr.io/alex-on-ai/webreaper-mcp-http:<version>` (and `:latest`):
 
 ```bash
 docker run --rm -p 8080:8080 \
   -e WEBREAPER_MCP_TOKEN=change-me-to-a-long-random-secret \
-  ghcr.io/pavlovtech/webreaper-mcp-http:latest
+  ghcr.io/alex-on-ai/webreaper-mcp-http:latest
 ```
 
 Or build it yourself (context = repo root):

--- a/docs/testing/manual-test-plan.md
+++ b/docs/testing/manual-test-plan.md
@@ -62,7 +62,7 @@ scripts/test-install.sh
 
 ## 1. Installation matrix (manual)
 
-- [ ] **Homebrew (macOS arm64):** `brew install pavlovtech/webreaper/webreaper` → `webreaper version`
+- [ ] **Homebrew (macOS arm64):** `brew install alex-on-ai/webreaper/webreaper` → `webreaper version`
 - [ ] **Homebrew (macOS x64):** same, on Intel
 - [ ] **install.sh (Linux x64):** clean box, `curl … | sh` → installs, `webreaper version`
 - [ ] **install.sh (Linux arm64):** same

--- a/homebrew/webreaper.rb.template
+++ b/homebrew/webreaper.rb.template
@@ -1,6 +1,6 @@
 # Homebrew formula template (ADR-0070).
 #
-# Rendered into the pavlovtech/homebrew-webreaper tap repo by the
+# Rendered into the alex-on-ai/homebrew-webreaper tap repo by the
 # `homebrew-publish` job in this repo's .github/workflows/release.yml,
 # after `cli-publish` succeeds. Placeholders are sed-substituted:
 #
@@ -17,28 +17,28 @@
 
 class Webreaper < Formula
   desc "Declarative .NET web scraper / crawler: AI-native CLI"
-  homepage "https://github.com/pavlovtech/WebReaper"
+  homepage "https://github.com/alex-on-ai/WebReaper"
   version "{{VERSION}}"
   license "MIT"
 
   on_macos do
     on_arm do
-      url "https://github.com/pavlovtech/WebReaper/releases/download/{{TAG}}/webreaper-{{TAG}}-osx-arm64.zip"
+      url "https://github.com/alex-on-ai/WebReaper/releases/download/{{TAG}}/webreaper-{{TAG}}-osx-arm64.zip"
       sha256 "{{SHA256_OSX_ARM64}}"
     end
     on_intel do
-      url "https://github.com/pavlovtech/WebReaper/releases/download/{{TAG}}/webreaper-{{TAG}}-osx-x64.zip"
+      url "https://github.com/alex-on-ai/WebReaper/releases/download/{{TAG}}/webreaper-{{TAG}}-osx-x64.zip"
       sha256 "{{SHA256_OSX_X64}}"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/pavlovtech/WebReaper/releases/download/{{TAG}}/webreaper-{{TAG}}-linux-x64.tar.gz"
+      url "https://github.com/alex-on-ai/WebReaper/releases/download/{{TAG}}/webreaper-{{TAG}}-linux-x64.tar.gz"
       sha256 "{{SHA256_LINUX_X64}}"
     end
     on_arm do
-      url "https://github.com/pavlovtech/WebReaper/releases/download/{{TAG}}/webreaper-{{TAG}}-linux-arm64.tar.gz"
+      url "https://github.com/alex-on-ai/WebReaper/releases/download/{{TAG}}/webreaper-{{TAG}}-linux-arm64.tar.gz"
       sha256 "{{SHA256_LINUX_ARM64}}"
     end
   end

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,9 +2,9 @@
 # install.sh: WebReaper CLI installer (ADR-0070).
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/alex-on-ai/WebReaper/master/scripts/install.sh | sh
 #   # or with flags:
-#   curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh -s -- --force
+#   curl -fsSL https://raw.githubusercontent.com/alex-on-ai/WebReaper/master/scripts/install.sh | sh -s -- --force
 #
 # Environment variables:
 #   WEBREAPER_VERSION        : pin to a specific tag (e.g. v10.0.0). Default: latest release.
@@ -31,7 +31,7 @@
 
 set -eu
 
-REPO="pavlovtech/WebReaper"
+REPO="alex-on-ai/WebReaper"
 DEFAULT_PREFIX="/usr/local/bin"
 FALLBACK_PREFIX="${HOME}/.local/bin"
 
@@ -62,7 +62,7 @@ usage() {
 # install.sh: WebReaper CLI installer
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/alex-on-ai/WebReaper/master/scripts/install.sh | sh
 #
 # Flags: --force, --upgrade, --help.
 # See script header for env vars and exit codes.

--- a/website/app/opengraph-image.tsx
+++ b/website/app/opengraph-image.tsx
@@ -71,7 +71,7 @@ export default function OpenGraphImage() {
         </div>
 
         <div style={{ display: "flex", fontSize: 24, color: "#9aa3ad" }}>
-          github.com/pavlovtech/WebReaper
+          github.com/alex-on-ai/WebReaper
         </div>
       </div>
     ),

--- a/website/content/docs/getting-started.mdx
+++ b/website/content/docs/getting-started.mdx
@@ -13,10 +13,10 @@ embed in any .NET app. This guide gets you from zero to your first result.
 
 ```bash
 # macOS / Linux (Homebrew)
-brew install pavlovtech/webreaper/webreaper
+brew install alex-on-ai/webreaper/webreaper
 
 # Any POSIX shell
-curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/alex-on-ai/WebReaper/master/scripts/install.sh | sh
 ```
 
 ## Your first scrape

--- a/website/content/docs/installation.mdx
+++ b/website/content/docs/installation.mdx
@@ -14,7 +14,7 @@ and no database. Pick whichever fits your workflow, or use both.
 The fastest path on macOS and Linux is the Homebrew tap:
 
 ```bash
-brew install pavlovtech/webreaper/webreaper
+brew install alex-on-ai/webreaper/webreaper
 ```
 
 Upgrades come through `brew upgrade webreaper` like any other formula.
@@ -25,19 +25,19 @@ The install script detects your OS and architecture, downloads the matching
 binary from GitHub Releases, and drops it on your PATH:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/alex-on-ai/WebReaper/master/scripts/install.sh | sh
 ```
 
 To update an existing install in place, append the upgrade flag:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh -s -- --upgrade
+curl -fsSL https://raw.githubusercontent.com/alex-on-ai/WebReaper/master/scripts/install.sh | sh -s -- --upgrade
 ```
 
 ## Windows
 
 Download the zip for your architecture from the
-[GitHub Releases](https://github.com/pavlovtech/WebReaper/releases) page, unzip
+[GitHub Releases](https://github.com/alex-on-ai/WebReaper/releases) page, unzip
 it, and put `webreaper.exe` somewhere on your PATH. Both `win-x64` and
 `win-arm64` builds are published with every release.
 

--- a/website/lib/site.ts
+++ b/website/lib/site.ts
@@ -7,16 +7,16 @@ export const siteConfig = {
   ogImage: "/og/default.png",
   version: "11.0.0",
   install: {
-    brew: "brew install pavlovtech/webreaper/webreaper",
-    curl: "curl -fsSL https://raw.githubusercontent.com/pavlovtech/WebReaper/master/scripts/install.sh | sh",
+    brew: "brew install alex-on-ai/webreaper/webreaper",
+    curl: "curl -fsSL https://raw.githubusercontent.com/alex-on-ai/WebReaper/master/scripts/install.sh | sh",
     nuget: "dotnet add package WebReaper",
   },
   links: {
-    github: "https://github.com/pavlovtech/WebReaper",
+    github: "https://github.com/alex-on-ai/WebReaper",
     nuget: "https://www.nuget.org/packages/WebReaper",
-    discussions: "https://github.com/pavlovtech/WebReaper/discussions",
-    issues: "https://github.com/pavlovtech/WebReaper/issues",
-    license: "https://github.com/pavlovtech/WebReaper/blob/master/LICENSE.txt",
+    discussions: "https://github.com/alex-on-ai/WebReaper/discussions",
+    issues: "https://github.com/alex-on-ai/WebReaper/issues",
+    license: "https://github.com/alex-on-ai/WebReaper/blob/master/LICENSE.txt",
   },
   contactEmail: "business@highcraft.io",
   nav: [
@@ -47,10 +47,10 @@ export const siteConfig = {
     {
       title: "Open source",
       links: [
-        { title: "GitHub", href: "https://github.com/pavlovtech/WebReaper" },
+        { title: "GitHub", href: "https://github.com/alex-on-ai/WebReaper" },
         { title: "NuGet", href: "https://www.nuget.org/packages/WebReaper" },
-        { title: "Discussions", href: "https://github.com/pavlovtech/WebReaper/discussions" },
-        { title: "Report an issue", href: "https://github.com/pavlovtech/WebReaper/issues" },
+        { title: "Discussions", href: "https://github.com/alex-on-ai/WebReaper/discussions" },
+        { title: "Report an issue", href: "https://github.com/alex-on-ai/WebReaper/issues" },
       ],
     },
     {


### PR DESCRIPTION
Finishes the `pavlovtech` → `alex-on-ai` rename. The repo redirect already worked, but functional references throughout the tree still pointed at the old org. This canonicalizes the **functional** ones and deliberately leaves **historical** records intact.

### Canonicalized → `alex-on-ai`
- **Release pipeline** — `release.yml` Homebrew tap push target (`alex-on-ai/homebrew-webreaper`); the rendered `homebrew/webreaper.rb.template` (homepage + all release-download URLs)
- **Installers** — `scripts/install.sh` (`REPO` var + usage)
- **Shipped CLI** — `UpdateNotifier.cs` (update-check API URL + install hint); `SiteMapper.cs` (crawler User-Agent)
- **NuGet metadata** — `Directory.Build.props` (`PackageProjectUrl` / `RepositoryUrl`)
- **Docs** — `README.md` + 13 satellite package READMEs; the `website/` install docs, `site.ts` links, OG image
- **GHCR** — `ghcr.io/pavlovtech/…` → `ghcr.io/alex-on-ai/webreaper-mcp-http`, matching the pipeline's `ghcr.io/${repository_owner}/…` publish target

### Left as historical (unchanged)
- `CHANGELOG.md` PR links + release notes
- `docs/adr/*.md` point-in-time commands and references
- `CONTRIBUTORS.md` `@pavlovtech` author handle
- `CONTEXT.md` source permalink
- winget id fixture in `UpdateNotifierTests` — the published id is `io.highcraft.webreaper`, and winget ids don't change on a GitHub rename

### Verification
- `dotnet build -c Release` — clean (0 errors)
- Unit tests — **697 passed / 0 failed** (`WebReaper.Cli.Tests` 135 incl. `UpdateNotifierTests`, `WebReaper.UnitTests` 555, generators 7)
- The 12 `WebReaper.IntegrationTests` failures are pre-existing **live-network** failures (they crawl an external site that now 404s) and are independent of this diff
- Website `npm` build not run — change there is string-literals only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
