### PR TITLE
chore: PackageProjectUrl → webreaper.ai + Built-by-HighCraft.io credit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
     <Company>Alex Pavlov</Company>
     <Product>WebReaper</Product>
     <Copyright>Copyright (c) Alex Pavlov</Copyright>
-    <PackageProjectUrl>https://github.com/alex-on-ai/WebReaper</PackageProjectUrl>
+    <PackageProjectUrl>https://webreaper.ai</PackageProjectUrl>
     <RepositoryUrl>https://github.com/alex-on-ai/WebReaper</RepositoryUrl>
     <!-- ADR-0017: relicensed to MIT to remove funnel-adoption friction.
          Per-csproj <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 AI-native web scraper. Single binary with a bundled Claude Code skill.
 
+Built by [HighCraft](https://highcraft.io).
+
 ## Install
 
 **macOS / Linux (Homebrew):**
@@ -525,3 +527,7 @@ WebReaper is MIT-licensed (ADR-0017). All NuGet packages plus the `WebReaper.Cli
 Prior to the 10.0.0 wave, WebReaper was GPL-3.0-or-later. The relicense is strictly more permissive: every existing user is unaffected; new users who couldn't embed under GPL now can. Historical contributors are credited in [`CONTRIBUTORS.md`](CONTRIBUTORS.md). See [`docs/adr/0017-relicense-gpl-mit.md`](docs/adr/0017-relicense-gpl-mit.md) for the analysis and contributor consent path.
 
 Contributions are welcome under the same MIT terms; sign-off via DCO ([`CONTRIBUTING.md`](CONTRIBUTING.md)).
+
+---
+
+Built by [HighCraft](https://highcraft.io) — a software and AI engineering team.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 AI-native web scraper. Single binary with a bundled Claude Code skill.
 
-Built by [HighCraft](https://highcraft.io).
+Built by [HighCraft.io](https://highcraft.io).
 
 ## Install
 
@@ -530,4 +530,4 @@ Contributions are welcome under the same MIT terms; sign-off via DCO ([`CONTRIBU
 
 ---
 
-Built by [HighCraft](https://highcraft.io) — a software and AI engineering team.
+Built by [HighCraft.io](https://highcraft.io) — a software and AI engineering team.


### PR DESCRIPTION
Re-applies the Engine-1 repo prep staged on #257's branch that didn't make it in — #257 merged at the canonicalization commit, before these two follow-ups landed.

- `Directory.Build.props`: `PackageProjectUrl` → `https://webreaper.ai` (product site is the authority target; `RepositoryUrl` stays the repo). [W0a]
- README: `Built by [HighCraft.io](https://highcraft.io)` credit under the tagline + footer. [W0c]

🤖 Generated with [Claude Code](https://claude.com/claude-code)