### PR TITLE
Add MCP Registry listing (server.json + ownership marker)

### DIFF
--- a/WebReaper.Mcp/README.md
+++ b/WebReaper.Mcp/README.md
@@ -1,5 +1,7 @@
 # WebReaper.Mcp
 
+<!-- mcp-name: io.github.alex-on-ai/webreaper -->
+
 MCP (Model Context Protocol) server satellite for [WebReaper](https://github.com/alex-on-ai/WebReaper).
 
 The agent client (Cursor / Claude Desktop / Copilot Studio) spawns

--- a/server.json
+++ b/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.alex-on-ai/webreaper",
+  "title": "WebReaper",
+  "description": "AI-native web scraper: scrape, crawl and map any site to clean markdown over stdio. MIT-licensed.",
+  "version": "11.3.2",
+  "websiteUrl": "https://webreaper.ai",
+  "repository": {
+    "url": "https://github.com/alex-on-ai/WebReaper",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "nuget",
+      "registryBaseUrl": "https://api.nuget.org/v3/index.json",
+      "identifier": "WebReaper.Mcp",
+      "version": "11.3.2",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Lists WebReaper on the official MCP Registry (`registry.modelcontextprotocol.io`), a canonical source MCP clients and LLMs read.

**What this adds**
- `server.json` (root): `io.github.alex-on-ai/webreaper`, nuget package `WebReaper.Mcp` run via `dnx` over stdio, `websiteUrl: https://webreaper.ai`. Passes `mcp-publisher validate`.
- `<!-- mcp-name: io.github.alex-on-ai/webreaper -->` in `WebReaper.Mcp/README.md`, the registry's NuGet ownership proof.

**To publish (3 steps, after merge)**
1. Cut a new `WebReaper.Mcp` NuGet release whose README contains the marker above (the currently-published package predates it). Set `server.json` `version` + `packages[0].version` to that release (placeholder `11.3.2` here, match your actual release).
2. `mcp-publisher login github` (interactive, as alex-on-ai).
3. `mcp-publisher publish`

Namespace `io.github.alex-on-ai/*` is authorized by the GitHub login in step 2.
