### PR TITLE
feat(mcp): stdio Dockerfile for WebReaper.Mcp (Glama listing)

### DIFF
--- a/WebReaper.Mcp/Dockerfile
+++ b/WebReaper.Mcp/Dockerfile
@@ -1,0 +1,41 @@
+# WebReaper.Mcp: the stdio MCP server (scrape / map / crawl / extract /
+# extract_with_prompt / extract_inferred). This is the server named in
+# server.json and on the MCP registry; Glama builds this image in its sandbox
+# and runs the MCP introspection handshake (tools/list) against it.
+#
+# Introspection needs no network and no browser, so this image stays minimal:
+# the default HTTP scrape / map / crawl / extract paths work out of the box.
+# browser=true needs a Chromium on PATH; see WebReaper.Mcp.AspNetCore/Dockerfile
+# for the browser-capable (Debian + Chromium) variant.
+#
+# Build context = the REPO ROOT (the server references the library projects):
+#
+#   docker build -f WebReaper.Mcp/Dockerfile -t webreaper-mcp .
+
+# --- build (SDK tag matches global.json) ---
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+# Restore as its own layer: shared build props + the csproj graph only
+# (Mcp -> WebReaper / Cdp / AI / AI.Http), so a source-only edit skips restore.
+COPY global.json Directory.Build.props ./
+COPY WebReaper/WebReaper.csproj WebReaper/
+COPY WebReaper.Cdp/WebReaper.Cdp.csproj WebReaper.Cdp/
+COPY WebReaper.AI/WebReaper.AI.csproj WebReaper.AI/
+COPY WebReaper.AI.Http/WebReaper.AI.Http.csproj WebReaper.AI.Http/
+COPY WebReaper.Mcp/WebReaper.Mcp.csproj WebReaper.Mcp/
+RUN dotnet restore WebReaper.Mcp/WebReaper.Mcp.csproj
+# Sources, then framework-dependent publish.
+COPY WebReaper/ WebReaper/
+COPY WebReaper.Cdp/ WebReaper.Cdp/
+COPY WebReaper.AI/ WebReaper.AI/
+COPY WebReaper.AI.Http/ WebReaper.AI.Http/
+COPY WebReaper.Mcp/ WebReaper.Mcp/
+RUN dotnet publish WebReaper.Mcp/WebReaper.Mcp.csproj -c Release -o /app --no-restore /p:UseAppHost=false
+
+# --- runtime: the .NET 10 base runtime is all a stdio host needs ---
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS final
+WORKDIR /app
+COPY --from=build /app ./
+# MCP is JSON-RPC over stdio; Program.cs routes logs to stderr so stdout stays a
+# clean protocol channel.
+ENTRYPOINT ["dotnet", "WebReaper.Mcp.dll"]


### PR DESCRIPTION
## Why

Glama gates the `punkpeye/awesome-mcp-servers` listing ([PR #8883](https://github.com/punkpeye/awesome-mcp-servers/pull/8883)): it builds a server image in its sandbox and runs the MCP introspection handshake. `WebReaper.Mcp` is a NuGet stdio exe with no in-repo Dockerfile, so Glama's inferred build fails and the listing is withheld.

## What

`WebReaper.Mcp/Dockerfile`: multi-stage net10 build (SDK build to base runtime), framework-dependent publish, stdio entrypoint. Minimal by design (no Chromium): introspection needs no browser or network. The browser-capable variant stays `WebReaper.Mcp.AspNetCore/Dockerfile`.

## Verified

Local `docker build -f WebReaper.Mcp/Dockerfile .` succeeds; the container answers `initialize` + `tools/list` with all six tools (`scrape`, `map`, `crawl`, `extract`, `extract_with_prompt`, `extract_inferred`), each with an `inputSchema`. No secrets needed.

## Follow-up (owner, on Glama)

1. Submit / claim `alex-on-ai/WebReaper` at glama.ai/mcp/servers.
2. Paste this Dockerfile into the Glama admin Dockerfile page (build context = repo root).
3. Once checks are green, copy the Glama score badge and add it to PR #8883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
